### PR TITLE
fix: deps: update arrow dependencies to v56.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 lancedb = "0.22"
-arrow = "55.2"
-arrow-array = "55.2"
-arrow-schema = "55.2"
+arrow = "56.2"
+arrow-array = "56.2"
+arrow-schema = "56.2"
 tokio = { version = "1.47.1", features = ["full"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
When building, I was getting the following error:
```
| error[E0308]: mismatched types
|    --> src/database/vectors.rs:201:17
|     |
| 201 |                 arrow::datatypes::DataType::FixedSizeList(_, size) => {
|     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `lancedb::arrow::arrow_schema::DataType`, found `arrow::datatypes::DataType`
|     |
| note: two different versions of crate `arrow_schema` are being used;
| two types coming from two different versions of the same crate are
| different types even if they look the same
```

Update `arrow`, `arrow-array`, and `arrow-schema` from `v55.2` to `v56.2` to resolve version conflicts with `lancedb` `v0.22`.