### PR TITLE
semcode: make a bit faster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
+cargo-features = ["profile-rustflags"]
+
 [package]
 name = "semcode"
 version = "0.1.0"
@@ -65,4 +67,16 @@ name = "semcode-lsp"
 path = "src/bin/semcode-lsp.rs"
 
 [profile.release]
-debug = false
+debug = false          # no debug
+opt-level = 3          # max performance (O3)
+lto = "fat"            # full link-time optimization across crates
+codegen-units = 1      # single codegen unit for better optimization
+panic = "abort"        # remove unwinding runtime
+strip = "symbols"      # remove debug symbols
+incremental = false    # always fully optimize
+overflow-checks = false # no runtime overflow checks
+rpath = false          # omit runtime search paths
+rustflags = [
+  "-C", "target-cpu=native",             # tune for your CPU; enables all supported instructions
+]
+

--- a/src/database/search.rs
+++ b/src/database/search.rs
@@ -1390,6 +1390,9 @@ impl SearchManager {
         // Query with specific git_file_hashes using regexp_match
         let hash_values: Vec<String> = resolved_hashes.values().cloned().collect();
 
+        // Compile regex once before processing batches (performance optimization)
+        let regex = regex::Regex::new(pattern)?;
+
         let mut types = Vec::new();
         for chunk in hash_values.chunks(100) {
             let hash_conditions: Vec<String> = chunk
@@ -1459,10 +1462,6 @@ impl SearchManager {
                     }
 
                     // Apply regex matching in code since LanceDB has issues with combined conditions
-                    let regex = match regex::Regex::new(pattern) {
-                        Ok(r) => r,
-                        Err(_) => continue, // Skip invalid regex patterns
-                    };
                     if !regex.is_match(name) {
                         continue;
                     }
@@ -1635,6 +1634,9 @@ impl SearchManager {
         // Query with specific git_file_hashes using regexp_match for typedefs
         let hash_values: Vec<String> = resolved_hashes.values().cloned().collect();
 
+        // Compile regex once before processing batches (performance optimization)
+        let regex = regex::Regex::new(pattern)?;
+
         let mut typedefs = Vec::new();
         for chunk in hash_values.chunks(100) {
             let hash_conditions: Vec<String> = chunk
@@ -1694,10 +1696,6 @@ impl SearchManager {
                     }
 
                     // Apply regex matching in code since LanceDB has issues with combined conditions
-                    let regex = match regex::Regex::new(pattern) {
-                        Ok(r) => r,
-                        Err(_) => continue, // Skip invalid regex patterns
-                    };
                     if !regex.is_match(name) {
                         continue;
                     }
@@ -2009,6 +2007,9 @@ impl SearchManager {
             .try_collect::<Vec<_>>()
             .await?;
 
+        // Compile regex once before processing batches (performance optimization)
+        let regex = regex::Regex::new(pattern)?;
+
         let mut macros = Vec::new();
         for batch in &results {
             let name_array = batch
@@ -2051,10 +2052,6 @@ impl SearchManager {
                 let name = name_array.value(i);
 
                 // Apply regex matching in code
-                let regex = match regex::Regex::new(pattern) {
-                    Ok(r) => r,
-                    Err(_) => continue,
-                };
                 if !regex.is_match(name) {
                     continue;
                 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -556,14 +556,13 @@ impl PipelineBuilder {
                     let start = Instant::now();
                     let mut total_processed = 0;
 
-                    let mut batch = ProcessedBatch {
-                        functions: Vec::new(),
-                        types: Vec::new(),
-                        macros: Vec::new(),
-                        processed_files: Vec::new(),
-                    };
-
                     let mut batch_size = 2000;
+                    let mut batch = ProcessedBatch {
+                        functions: Vec::with_capacity(batch_size),
+                        types: Vec::with_capacity(batch_size),
+                        macros: Vec::with_capacity(batch_size / 5), // Fewer macros typically
+                        processed_files: Vec::with_capacity(50), // ~1 file per batch avg
+                    };
                     let mut last_batch_time = Instant::now();
 
                     loop {
@@ -629,10 +628,10 @@ impl PipelineBuilder {
                                     let batch_to_send = std::mem::replace(
                                         &mut batch,
                                         ProcessedBatch {
-                                            functions: Vec::new(),
-                                            types: Vec::new(),
-                                            macros: Vec::new(),
-                                            processed_files: Vec::new(),
+                                            functions: Vec::with_capacity(batch_size),
+                                            types: Vec::with_capacity(batch_size),
+                                            macros: Vec::with_capacity(batch_size / 5),
+                                            processed_files: Vec::with_capacity(50),
                                         },
                                     );
 


### PR DESCRIPTION
make semcode a bit faster with safe changes.

this is rough on build times, but they were not great previously and this is largely a function of the number of dependencies.

not sure this is a fantastic idea given it makes bad build times worse, but iiuc this is all about optimizing for mcp/lsp type usages where performance is everything (which this would help).

==================== size before
❯ ls -lah ../semcode/target/release/semcode-mcp
.rwxr-xr-x patso patso 195 MB Sat Oct 18 03:14:11 2025  ../semcode/target/release/semcode-mcp

==================== size after
❯ ls -lah ../worktrees/semcode-faster/target/release/semcode-mcp 
.rwxr-xr-x patso patso 87 MB Sat Oct 18 03:35:10 2025  ../worktrees/semcode-faster/target/release/semcode-mcp

==================== index before
❯ ../semcode/target/release/semcode-index -s . --clear --perf Clearing existing data...
Existing data cleared.
About to start pipeline processing with 62129 files...
[00:00:33] ########################################   91070/91070   files Processing complete                                                                                                              Pipeline processing completed successfully

=== Pipeline Processing Complete ===
Files processed: 91070
Functions indexed: 858817
Types indexed: 156968
Macros indexed: 134765

Starting database optimization...
Database optimization completed successfully

=== Embedded Data Statistics ===
Call relationships: embedded in function/macro JSON columns Function-type mappings: embedded in function JSON columns Type-type mappings: embedded in type JSON columns

To query this database, run:
  semcode --database ./.semcode.db

Printing performance statistics...

=== Performance Statistics ===
database_batch_insert          count=   109 avg=  309.99ms min=  137.23ms max= 1115.92ms total=  33789.32ms
database_optimization          count=     1 avg= 6584.81ms min= 6584.81ms max= 6584.81ms total=   6584.81ms
db_insert_combined             count=   109 avg=  309.83ms min=  137.10ms max= 1115.80ms total=  33772.00ms
db_mark_files_processed        count=   109 avg=   29.22ms min=    7.71ms max=   66.92ms total=   3185.37ms
pipeline_processing            count=     1 avg=34151.46ms min=34151.46ms max=34151.46ms total=  34151.46ms
treesitter_parse               count= 91070 avg=    9.13ms min=    0.00ms max= 3328.60ms total= 831527.27ms

Total time tracked: 943.01s

==================== index after
❯ ../worktrees/semcode-faster/target/release/semcode-index -s . --clear --perf Clearing existing data...
Existing data cleared.
About to start pipeline processing with 62129 files...
[00:00:32] ########################################   91070/91070   files Processing complete                                                                                                              Pipeline processing completed successfully

=== Pipeline Processing Complete ===
Files processed: 91070
Functions indexed: 858817
Types indexed: 156968
Macros indexed: 134765

Starting database optimization...
Database optimization completed successfully

=== Embedded Data Statistics ===
Call relationships: embedded in function/macro JSON columns Function-type mappings: embedded in function JSON columns Type-type mappings: embedded in type JSON columns

To query this database, run:
  semcode --database ./.semcode.db

Printing performance statistics...

=== Performance Statistics ===
database_batch_insert          count=   109 avg=  300.07ms min=  143.55ms max= 1366.25ms total=  32707.32ms
database_optimization          count=     1 avg= 6731.55ms min= 6731.55ms max= 6731.55ms total=   6731.55ms
db_insert_combined             count=   109 avg=  299.89ms min=  143.18ms max= 1366.03ms total=  32688.27ms
db_mark_files_processed        count=   109 avg=   25.81ms min=    6.02ms max=   72.49ms total=   2813.71ms
pipeline_processing            count=     1 avg=33024.43ms min=33024.43ms max=33024.43ms total=  33024.43ms
treesitter_parse               count= 91070 avg=    7.85ms min=    0.00ms max= 2419.10ms total= 715318.10ms

Total time tracked: 823.28s