### PR TITLE
semcode: add optional clangd integration and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ Thumbs.db
 # Temporary files
 *.tmp
 *.temp
+compile_commands_absolute.json
 
 # claude
 .claude
+tests/fixtures/test/clangd_integration/.git
+tests/fixtures/test/clangd_integration/.semcode.db

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ walkdir = "2.5"
 indicatif = "0.18.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-indicatif = "0.3"
 rustyline = "17.0"
 colored = "3.0"
 futures = "0.3.31"
@@ -47,6 +48,11 @@ gix = "0.73"
 model2vec-rs = "0.1.4"
 tower-lsp = "0.20"      # Language Server Protocol framework for LSP server
 url = "2.5"             # URL parsing for file URIs in LSP
+clang = "2.0"           # libclang bindings for semantic enrichment
+shell-words = "1.1"     # Proper shell command parsing for compile_commands.json
+sysinfo = "0.32"        # System memory detection for dynamic queue sizing
+ipc-channel = "0.18"    # Cross-platform IPC for worker processes
+bincode = "1.3"         # Fast binary serialization for IPC messages
 
 [[bin]]
 name = "semcode-index"
@@ -63,6 +69,13 @@ path = "src/bin/semcode-mcp.rs"
 [[bin]]
 name = "semcode-lsp"
 path = "src/bin/semcode-lsp.rs"
+
+[dev-dependencies]
+assert_cmd = "2.0"      # Test CLI binaries
+predicates = "3.0"      # Better test assertions
+rstest = "0.18"         # Fixtures & parametric tests
+insta = "1.34"          # Snapshot testing
+pretty_assertions = "1.4"  # Better diffs in test failures
 
 [profile.release]
 debug = false

--- a/src/bin/semcode-mcp.rs
+++ b/src/bin/semcode-mcp.rs
@@ -64,13 +64,34 @@ async fn mcp_query_function_or_macro(
                 .await
                 .unwrap_or_default();
 
+            // Add clangd enrichment info if available
+            let usr_line = func
+                .usr
+                .as_ref()
+                .map(|u| format!("USR: {}\n", u))
+                .unwrap_or_default();
+            let sig_line = func
+                .signature
+                .as_ref()
+                .map(|s| format!("Signature: {}\n", s))
+                .unwrap_or_default();
+            let canonical_line = func
+                .canonical_return_type
+                .as_ref()
+                .filter(|c| *c != &func.return_type)
+                .map(|c| format!("Canonical Return Type: {}\n", c))
+                .unwrap_or_default();
+
             result.push_str(&format!(
-                "Function: {} (git SHA: {})\nFile: {}:{}-{}\nReturn Type: {}\nParameters: ({})\nCalls: {} functions\nCalled by: {} functions\nBody:\n{}\n\n",
+                "Function: {} (git SHA: {})\nFile: {}:{}-{}\n{}{}{}Return Type: {}\nParameters: ({})\nCalls: {} functions\nCalled by: {} functions\nBody:\n{}\n\n",
                 func.name,
                 git_sha,
                 func.file_path,
                 func.line_start,
                 func.line_end,
+                usr_line,
+                sig_line,
+                canonical_line,
                 func.return_type,
                 params_str,
                 calls.len(),
@@ -123,9 +144,27 @@ async fn mcp_query_function_or_macro(
                 .await
                 .unwrap_or_default();
 
+            // Add clangd enrichment info if available
+            let func_usr_line = func
+                .usr
+                .as_ref()
+                .map(|u| format!("USR: {}\n", u))
+                .unwrap_or_default();
+            let func_sig_line = func
+                .signature
+                .as_ref()
+                .map(|s| format!("Signature: {}\n", s))
+                .unwrap_or_default();
+            let func_canonical_line = func
+                .canonical_return_type
+                .as_ref()
+                .filter(|c| *c != &func.return_type)
+                .map(|c| format!("Canonical Return Type: {}\n", c))
+                .unwrap_or_default();
+
             result.push_str(&format!(
-                "Function: {}\nFile: {}:{}-{}\nReturn Type: {}\nParameters: ({})\nCalls: {} functions\nCalled by: {} functions\nBody:\n{}\n\n",
-                func.name, func.file_path, func.line_start, func.line_end, func.return_type, func_params_str, func_calls.len(), func_callers.len(), func.body
+                "Function: {}\nFile: {}:{}-{}\n{}{}{}Return Type: {}\nParameters: ({})\nCalls: {} functions\nCalled by: {} functions\nBody:\n{}\n\n",
+                func.name, func.file_path, func.line_start, func.line_end, func_usr_line, func_sig_line, func_canonical_line, func.return_type, func_params_str, func_calls.len(), func_callers.len(), func.body
             ));
 
             // Display macro

--- a/src/clangd_analyzer.rs
+++ b/src/clangd_analyzer.rs
@@ -1,0 +1,899 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Clangd integration for enriching semantic analysis with compiler-grade precision
+//!
+//! This module uses libclang to enhance the Tree-sitter based analysis
+//! with semantic information that requires compilation context:
+//! - Unified Symbol Resolution (USR) for unique symbol identification
+//! - Canonical types for templates, auto, typedef resolution
+//! - Precise overload resolution
+//! - Cross-reference into system headers
+
+use anyhow::{anyhow, Context, Result};
+use clang::*;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// GCC-specific compiler flags that clang doesn't recognize
+///
+/// These flags will cause clang to emit warnings or errors if passed,
+/// so we filter them out when invoking libclang.
+///
+/// Note: This list only includes flags that clang genuinely doesn't support.
+/// Flags that both compilers support (like -Wenum-conversion) are NOT filtered.
+const FLAGS_TO_FILTER_FOR_LIBCLANG: &[&str] = &[
+    // Stack and memory management (GCC-only)
+    "-fconserve-stack",
+    "-fno-allow-store-data-races",
+    "-fzero-init-padding-bits=all",
+    // Function alignment (GCC-only)
+    "-fmin-function-alignment=", // Matches any value
+    // Security mitigations (GCC-only)
+    "-mindirect-branch-register",
+    "-mindirect-branch=", // Matches any variant
+    // Architecture-specific (GCC-only)
+    "-mpreferred-stack-boundary=", // Matches any value
+    "-mrecord-mcount",
+    // GCC-specific warnings
+    "-Wdefault-const-init-var-unsafe",
+    "-Wno-dangling-pointer",
+    "-Wno-stringop-overflow",
+    "-Wno-alloc-size-larger-than",
+    "-Wno-packed-not-aligned",
+    "-Wpacked-not-aligned",
+    "-Wno-stringop-truncation",
+    "-Wstringop-truncation",
+    "-Wrestrict",
+    "-Wimplicit-fallthrough=", // Matches any value like -Wimplicit-fallthrough=5
+    "-Werror=designated-init",
+    "-Wno-maybe-uninitialized",
+    // Tree optimization flags (GCC-only)
+    "-fno-var-tracking-assignments",
+    "-fno-tree-loop-im",
+    "-fno-tree-loop-ivcanon",
+    // Plugin flags (GCC-only, not portable to clang)
+    "-fplugin=",
+    "-fplugin-arg-",
+];
+
+/// Compilation command from compile_commands.json
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CompileCommand {
+    directory: String,
+    command: Option<String>,
+    arguments: Option<Vec<String>>,
+    file: String,
+}
+
+/// Clangd analyzer that uses libclang for semantic enrichment
+pub struct ClangdAnalyzer {
+    pub compile_commands_path: PathBuf,
+    source_root: PathBuf,
+    compile_commands: Arc<Mutex<HashMap<String, CompileCommand>>>,
+    index: Index<'static>,
+}
+
+/// Symbol enrichment result
+#[derive(Debug, Clone)]
+pub struct SymbolEnrichment {
+    pub usr: Option<String>,
+    pub signature: Option<String>,
+    pub canonical_type: Option<String>,
+}
+
+impl ClangdAnalyzer {
+    /// Create a new ClangdAnalyzer
+    ///
+    /// # Arguments
+    /// * `compile_commands_path` - Path to compile_commands.json or the directory containing it
+    /// * `source_root` - The root directory of the source code (for resolving relative paths)
+    pub fn new(
+        compile_commands_path: impl AsRef<Path>,
+        source_root: impl AsRef<Path>,
+    ) -> Result<Self> {
+        let path = compile_commands_path.as_ref();
+        let compile_commands_path = if path.is_dir() {
+            path.join("compile_commands.json")
+        } else {
+            path.to_path_buf()
+        };
+
+        let source_root = source_root.as_ref().to_path_buf();
+
+        // Leak Clang to get 'static reference - ClangdAnalyzer is long-lived anyway
+        let clang = Box::leak(Box::new(
+            Clang::new().map_err(|e| anyhow!("Failed to load libclang: {}", e))?,
+        ));
+
+        // Create shared index that will be reused across all parses
+        let index = Index::new(clang, false, false);
+
+        Ok(Self {
+            compile_commands_path,
+            source_root,
+            compile_commands: Arc::new(Mutex::new(HashMap::new())),
+            index,
+        })
+    }
+
+    /// Check if clangd enrichment is available
+    ///
+    /// # Arguments
+    /// * `path` - Path to compile_commands.json or directory containing it
+    ///
+    /// # Returns
+    /// True if compile_commands.json exists and libclang is available
+    pub fn is_available(path: impl AsRef<Path>) -> bool {
+        let path = path.as_ref();
+        let compile_commands_path = if path.is_dir() {
+            path.join("compile_commands.json")
+        } else {
+            path.to_path_buf()
+        };
+
+        // Check if compile_commands.json exists and libclang is available
+        compile_commands_path.exists() && Clang::new().is_ok()
+    }
+
+    /// Load compile_commands.json
+    async fn load_compile_commands(&self) -> Result<()> {
+        let content = tokio::fs::read_to_string(&self.compile_commands_path)
+            .await
+            .context("Failed to read compile_commands.json")?;
+
+        let commands: Vec<CompileCommand> =
+            serde_json::from_str(&content).context("Failed to parse compile_commands.json")?;
+
+        let mut map = self.compile_commands.lock().await;
+        map.clear();
+
+        // Get the directory containing compile_commands.json to resolve relative paths
+        let compile_commands_dir = self
+            .compile_commands_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."));
+
+        let mut loaded_count = 0;
+        let mut failed_count = 0;
+
+        for cmd in commands {
+            // Resolve directory relative to compile_commands.json location
+            let directory = if cmd.directory.starts_with('/') {
+                // Absolute path
+                PathBuf::from(&cmd.directory)
+            } else {
+                // Relative path - resolve relative to compile_commands.json
+                compile_commands_dir.join(&cmd.directory)
+            };
+
+            // Handle both relative and absolute file paths
+            let file_path = if cmd.file.starts_with('/') {
+                // File is already absolute - use as-is
+                PathBuf::from(&cmd.file)
+            } else {
+                // File is relative - join with directory
+                directory.join(&cmd.file)
+            };
+
+            // Try to canonicalize, but if it fails (file doesn't exist yet), use the path as-is
+            let canonical = file_path.canonicalize().unwrap_or_else(|_| {
+                failed_count += 1;
+                file_path.clone()
+            });
+
+            let path_str = canonical.display().to_string();
+            map.insert(path_str, cmd);
+            loaded_count += 1;
+        }
+
+        tracing::debug!(
+            "Loaded {} compile commands from {} ({} paths canonicalized, {} used as-is)",
+            map.len(),
+            self.compile_commands_path.display(),
+            loaded_count - failed_count,
+            failed_count
+        );
+
+        // Log a sample entry for debugging
+        if let Some((path, _)) = map.iter().next() {
+            tracing::debug!("Sample compile command entry key: {}", path);
+        }
+
+        Ok(())
+    }
+
+    /// Initialize the analyzer (load compile commands)
+    pub async fn initialize(&self) -> Result<()> {
+        self.load_compile_commands().await
+    }
+
+    /// Get compile arguments for a file
+    async fn get_compile_args(&self, file_path: &Path) -> Option<Vec<String>> {
+        // If the path is relative, make it absolute by joining with source_root
+        let absolute_path = if file_path.is_absolute() {
+            file_path.to_path_buf()
+        } else {
+            self.source_root.join(file_path)
+        };
+
+        // Then canonicalize to match how paths are stored in the HashMap
+        let canonical_path = absolute_path
+            .canonicalize()
+            .unwrap_or_else(|_| absolute_path);
+
+        let commands = self.compile_commands.lock().await;
+
+        let lookup_key = canonical_path.display().to_string();
+        tracing::debug!(
+            "Looking up compile args for path: {:?} -> canonical: {}",
+            file_path,
+            lookup_key
+        );
+
+        let cmd = commands.get(&lookup_key)?;
+
+        // Get the working directory for this compilation
+        let working_dir = PathBuf::from(&cmd.directory);
+
+        // Extract arguments from command or arguments field
+        let mut args = if let Some(ref args) = cmd.arguments {
+            // arguments field is already a proper array
+            args.clone()
+        } else if let Some(ref command) = cmd.command {
+            // Parse command string properly using shell-words
+            // This handles quotes, escapes, and complex arguments correctly
+            match shell_words::split(command) {
+                Ok(args) => args,
+                Err(e) => {
+                    tracing::debug!("Failed to parse compile command '{}': {}", command, e);
+                    return None;
+                }
+            }
+        } else {
+            return None;
+        };
+
+        // Remove the compiler name (first argument) if present
+        // The first arg is the compiler executable, which libclang doesn't need
+        // It could be gcc, clang, cc, or a full path like /usr/bin/gcc
+        if !args.is_empty() {
+            let first_arg = &args[0];
+            // Check if it looks like a compiler (doesn't start with -)
+            if !first_arg.starts_with('-') {
+                args.remove(0);
+            }
+        }
+
+        // Filter out flags that libclang doesn't need or that might cause issues
+        args.retain(|arg| !Self::should_filter_flag(arg));
+
+        // Remove -include and -o directives (and their arguments)
+        // -include can cause AstDeserialization errors if headers have GCC PCH versions
+        // -o is for output files which libclang doesn't need
+        let mut filtered_args = Vec::new();
+        let mut skip_next = false;
+        for arg in args.iter() {
+            if skip_next {
+                tracing::debug!("Filtering out flagged argument: {}", arg);
+                skip_next = false;
+                continue;
+            }
+            if arg == "-include" || arg == "-o" {
+                // Skip this flag and the next argument
+                tracing::debug!("Found {} flag, will skip next arg", arg);
+                skip_next = true;
+                continue;
+            }
+            filtered_args.push(arg.clone());
+        }
+        args = filtered_args;
+
+        tracing::debug!("After filtering, {} args remain", args.len());
+
+        // Convert relative include paths to absolute paths using the working directory
+        // This is critical because libclang doesn't know what directory to resolve relative paths from
+        let mut absolute_args = Vec::new();
+        let mut i = 0;
+        while i < args.len() {
+            let arg = &args[i];
+
+            if arg == "-I" && i + 1 < args.len() {
+                // -I with separate path argument
+                let path = &args[i + 1];
+                absolute_args.push(arg.clone());
+                if path.starts_with('/') {
+                    // Already absolute
+                    absolute_args.push(path.clone());
+                } else {
+                    // Relative - make absolute
+                    let abs_path = working_dir.join(path);
+                    absolute_args.push(abs_path.display().to_string());
+                }
+                i += 2;
+            } else if arg.starts_with("-I") && arg.len() > 2 {
+                // -I with path attached like -I./include
+                let path = &arg[2..];
+                if path.starts_with('/') {
+                    // Already absolute
+                    absolute_args.push(arg.clone());
+                } else {
+                    // Relative - make absolute
+                    let abs_path = working_dir.join(path);
+                    absolute_args.push(format!("-I{}", abs_path.display()));
+                }
+                i += 1;
+            } else {
+                absolute_args.push(arg.clone());
+                i += 1;
+            }
+        }
+        args = absolute_args;
+
+        // Remove the source file from arguments if present
+        // libclang's parser() takes the file separately, it should NOT be in the args
+        let original_file = &cmd.file;
+        let canonical_str = canonical_path.display().to_string();
+
+        // Extract just the filename for matching
+        let canonical_filename = canonical_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("");
+
+        args.retain(|arg| {
+            // Check if this argument is the source file in any form:
+            // 1. Exact match with original path from compile_commands.json
+            // 2. Exact match with canonical path
+            // 3. Ends with the original file path (catches relative paths)
+            // 4. Argument is just the filename (catches "8250_dma.c" style)
+            // 5. Argument ends with a path separator followed by the filename
+            let is_source_file = arg == original_file
+                || arg == &canonical_str
+                || arg.ends_with(original_file)
+                || arg == canonical_filename
+                || arg.ends_with(&format!("/{}", canonical_filename));
+
+            !is_source_file
+        });
+
+        // Add flags to help libclang parse correctly
+        // -fno-pch prevents trying to use GCC precompiled headers
+        // -x c explicitly tells clang this is C code
+        args.push("-fno-pch".to_string());
+        args.push("-x".to_string());
+        args.push("c".to_string());
+        tracing::debug!("Added -fno-pch and -x c flags for libclang");
+
+        Some(args)
+    }
+
+    /// Check if a compiler flag should be filtered out when passing to libclang
+    fn should_filter_flag(flag: &str) -> bool {
+        FLAGS_TO_FILTER_FOR_LIBCLANG.iter().any(|filter_flag| {
+            if filter_flag.ends_with('=') {
+                // For flags like "-mpreferred-stack-boundary=", match the prefix
+                flag.starts_with(filter_flag)
+            } else {
+                // Exact match
+                flag == *filter_flag
+            }
+        })
+    }
+
+    /// Enrich a function symbol with libclang data
+    ///
+    /// # Arguments
+    /// * `file_path` - Source file path
+    /// * `function_name` - Function name
+    /// * `line` - Line number where function is defined
+    ///
+    /// # Returns
+    /// Enrichment data if available
+    pub async fn enrich_function(
+        &self,
+        file_path: &Path,
+        function_name: &str,
+        line: u32,
+    ) -> Result<SymbolEnrichment> {
+        tracing::debug!(
+            "enrich_function called for {} at line {} in {:?}",
+            function_name,
+            line,
+            file_path
+        );
+
+        // Canonicalize the file path - libclang needs an absolute path
+        let canonical_path = file_path
+            .canonicalize()
+            .unwrap_or_else(|_| file_path.to_path_buf());
+
+        // Get compile arguments for this file
+        let args = match self.get_compile_args(&canonical_path).await {
+            Some(args) => args,
+            None => {
+                // No compile command = no enrichment
+                return Ok(SymbolEnrichment {
+                    usr: None,
+                    signature: None,
+                    canonical_type: None,
+                });
+            }
+        };
+
+        tracing::debug!("Parsing {:?} with args: {:?}", canonical_path, args);
+
+        // Parse the file with libclang using the canonical path and shared index
+        let tu = match self.index
+            .parser(&canonical_path)
+            .arguments(&args)
+            .detailed_preprocessing_record(true) // Required to access macro definitions in AST
+            .skip_function_bodies(false)
+            .parse()
+        {
+            Ok(tu) => {
+                // Log diagnostics even on successful parse
+                let diags = tu.get_diagnostics();
+                if !diags.is_empty() {
+                    tracing::debug!(
+                        "Parse succeeded with {} diagnostics for {:?}",
+                        diags.len(),
+                        canonical_path
+                    );
+                    for (i, diag) in diags.iter().take(3).enumerate() {
+                        tracing::debug!("  Diagnostic {}: {:?}", i, diag.get_text());
+                    }
+                }
+                tu
+            }
+            Err(e) => {
+                tracing::debug!(
+                    "Failed to parse {:?} with libclang: {:?}\nArgs were: {:?}",
+                    canonical_path,
+                    e,
+                    args
+                );
+                // Return empty enrichment instead of error
+                return Ok(SymbolEnrichment {
+                    usr: None,
+                    signature: None,
+                    canonical_type: None,
+                });
+            }
+        };
+
+        // Find the function at the specified line
+        let entity = tu.get_entity();
+        let mut enrichment = SymbolEnrichment {
+            usr: None,
+            signature: None,
+            canonical_type: None,
+        };
+
+        // Traverse AST to find the function
+        entity.visit_children(|cursor, _| {
+            if let Some(name) = cursor.get_name() {
+                if name == function_name {
+                    if let Some(loc) = cursor.get_location() {
+                        let file_loc = loc.get_file_location();
+                        if file_loc.line as u32 == line {
+                            // Found the function! Extract enrichment data
+                            if let Some(usr) = cursor.get_usr() {
+                                enrichment.usr = Some(usr.0); // Usr is a newtype wrapper
+                            }
+
+                            // Get signature from display name
+                            if let Some(display_name) = cursor.get_display_name() {
+                                enrichment.signature = Some(display_name);
+                            }
+
+                            // Get canonical return type
+                            if let Some(result_type) = cursor.get_result_type() {
+                                let canonical = result_type.get_canonical_type();
+                                enrichment.canonical_type = Some(canonical.get_display_name());
+                            }
+
+                            return EntityVisitResult::Break;
+                        }
+                    }
+                }
+            }
+            EntityVisitResult::Recurse
+        });
+
+        if enrichment.usr.is_some() {
+            tracing::debug!(
+                "Enriched function {}:{} with USR",
+                file_path.display(),
+                function_name
+            );
+        }
+
+        Ok(enrichment)
+    }
+
+    /// Enrich a type symbol with libclang data
+    pub async fn enrich_type(
+        &self,
+        file_path: &Path,
+        type_name: &str,
+        line: u32,
+    ) -> Result<SymbolEnrichment> {
+        // Canonicalize the file path - libclang needs an absolute path
+        let canonical_path = file_path
+            .canonicalize()
+            .unwrap_or_else(|_| file_path.to_path_buf());
+
+        let args = match self.get_compile_args(&canonical_path).await {
+            Some(args) => args,
+            None => {
+                return Ok(SymbolEnrichment {
+                    usr: None,
+                    signature: None,
+                    canonical_type: None,
+                });
+            }
+        };
+
+        let tu = self
+            .index
+            .parser(&canonical_path)
+            .arguments(&args)
+            .parse()
+            .context("Failed to parse file with libclang")?;
+
+        let entity = tu.get_entity();
+        let mut enrichment = SymbolEnrichment {
+            usr: None,
+            signature: None,
+            canonical_type: None,
+        };
+
+        entity.visit_children(|cursor, _| {
+            if let Some(loc) = cursor.get_location() {
+                let file_loc = loc.get_file_location();
+                if file_loc.line as u32 == line {
+                    if let Some(name) = cursor.get_name() {
+                        // Match type name (may have struct/union/enum prefix)
+                        if name == type_name
+                            || format!("struct {}", name) == type_name
+                            || format!("union {}", name) == type_name
+                            || format!("enum {}", name) == type_name
+                        {
+                            if let Some(usr) = cursor.get_usr() {
+                                enrichment.usr = Some(usr.0);
+                            }
+
+                            if let Some(cursor_type) = cursor.get_type() {
+                                let canonical = cursor_type.get_canonical_type();
+                                enrichment.canonical_type = Some(canonical.get_display_name());
+                            }
+
+                            return EntityVisitResult::Break;
+                        }
+                    }
+                }
+            }
+            EntityVisitResult::Recurse
+        });
+
+        Ok(enrichment)
+    }
+
+    /// Enrich a macro symbol with libclang data
+    pub async fn enrich_macro(
+        &self,
+        file_path: &Path,
+        macro_name: &str,
+        line: u32,
+    ) -> Result<SymbolEnrichment> {
+        // Canonicalize the file path - libclang needs an absolute path
+        let canonical_path = file_path
+            .canonicalize()
+            .unwrap_or_else(|_| file_path.to_path_buf());
+
+        let args = match self.get_compile_args(&canonical_path).await {
+            Some(args) => args,
+            None => {
+                return Ok(SymbolEnrichment {
+                    usr: None,
+                    signature: None,
+                    canonical_type: None,
+                });
+            }
+        };
+
+        let tu = self
+            .index
+            .parser(&canonical_path)
+            .arguments(&args)
+            .parse()
+            .context("Failed to parse file with libclang")?;
+
+        let entity = tu.get_entity();
+        let mut enrichment = SymbolEnrichment {
+            usr: None,
+            signature: None,
+            canonical_type: None,
+        };
+
+        entity.visit_children(|cursor, _| {
+            if cursor.get_kind() == EntityKind::MacroDefinition {
+                if let Some(loc) = cursor.get_location() {
+                    let file_loc = loc.get_file_location();
+                    if file_loc.line as u32 == line {
+                        if let Some(name) = cursor.get_name() {
+                            if name == macro_name {
+                                if let Some(usr) = cursor.get_usr() {
+                                    enrichment.usr = Some(usr.0);
+                                }
+                                return EntityVisitResult::Break;
+                            }
+                        }
+                    }
+                }
+            }
+            EntityVisitResult::Recurse
+        });
+
+        Ok(enrichment)
+    }
+
+    /// Enrich multiple symbols from a single file in one pass
+    ///
+    /// This is much more efficient than calling enrich_function/type/macro individually
+    /// because it parses the file once and extracts all symbols in a single AST traversal.
+    ///
+    /// # Arguments
+    /// * `file_path` - Source file path
+    /// * `functions` - Functions to enrich (name, line)
+    /// * `types` - Types to enrich (name, line)
+    /// * `macros` - Macros to enrich (name, line)
+    ///
+    /// # Returns
+    /// Maps from (name, line) to enrichment data for each symbol type
+    pub async fn enrich_file_batch(
+        &self,
+        file_path: &Path,
+        functions: &[(String, u32)],
+        types: &[(String, u32)],
+        macros: &[(String, u32)],
+    ) -> Result<(
+        HashMap<(String, u32), SymbolEnrichment>,
+        HashMap<(String, u32), SymbolEnrichment>,
+        HashMap<(String, u32), SymbolEnrichment>,
+    )> {
+        use std::collections::HashMap;
+
+        // Canonicalize the file path - libclang needs an absolute path
+        let canonical_path = file_path
+            .canonicalize()
+            .unwrap_or_else(|_| file_path.to_path_buf());
+
+        // Get compile arguments for this file
+        let args = match self.get_compile_args(&canonical_path).await {
+            Some(args) => args,
+            None => {
+                // No compile command = no enrichment
+                return Ok((HashMap::new(), HashMap::new(), HashMap::new()));
+            }
+        };
+
+        tracing::debug!(
+            "Batch enriching {:?}: {} functions, {} types, {} macros",
+            file_path,
+            functions.len(),
+            types.len(),
+            macros.len()
+        );
+
+        // Parse the file ONCE with libclang using shared index
+        let tu = match self
+            .index
+            .parser(&canonical_path)
+            .arguments(&args)
+            .detailed_preprocessing_record(true) // Required to access macro definitions in AST
+            .skip_function_bodies(false)
+            .parse()
+        {
+            Ok(tu) => {
+                // Log diagnostics even on successful parse
+                let diags = tu.get_diagnostics();
+                if !diags.is_empty() {
+                    tracing::debug!(
+                        "Parse succeeded with {} diagnostics for {:?}",
+                        diags.len(),
+                        canonical_path
+                    );
+                    for (i, diag) in diags.iter().take(3).enumerate() {
+                        tracing::debug!("  Diagnostic {}: {:?}", i, diag.get_text());
+                    }
+                }
+                tu
+            }
+            Err(e) => {
+                tracing::debug!(
+                    "Failed to parse {:?} with libclang: {:?}\nArgs were: {:?}",
+                    canonical_path,
+                    e,
+                    args
+                );
+                // Return empty enrichment instead of error
+                return Ok((HashMap::new(), HashMap::new(), HashMap::new()));
+            }
+        };
+
+        // Build lookup sets for fast O(1) checking
+        let function_set: HashMap<_, _> = functions
+            .iter()
+            .map(|(name, line)| ((name.as_str(), *line), ()))
+            .collect();
+        let macro_set: HashMap<_, _> = macros
+            .iter()
+            .map(|(name, line)| ((name.as_str(), *line), ()))
+            .collect();
+
+        // For types, build a line -> type_names map for efficient lookup
+        // This avoids O(n*m) nested loop when checking types
+        let mut type_line_map: HashMap<u32, Vec<&String>> = HashMap::new();
+        for (type_name, type_line) in types {
+            type_line_map
+                .entry(*type_line)
+                .or_insert_with(Vec::new)
+                .push(type_name);
+        }
+
+        // Result maps
+        let mut function_enrichments = HashMap::new();
+        let mut type_enrichments = HashMap::new();
+        let mut macro_enrichments = HashMap::new();
+
+        // Single AST traversal to extract ALL symbols
+        let entity = tu.get_entity();
+        entity.visit_children(|cursor, _| {
+            let kind = cursor.get_kind();
+
+            // Check if this is a macro definition
+            if kind == EntityKind::MacroDefinition {
+                if let (Some(name), Some(loc)) = (cursor.get_name(), cursor.get_location()) {
+                    let file_loc = loc.get_file_location();
+                    let line = file_loc.line as u32;
+
+                    if macro_set.contains_key(&(name.as_str(), line)) {
+                        tracing::debug!("Processing macro {} at line {}", name, line);
+                        tracing::debug!("  Cursor kind: {:?}", cursor.get_kind());
+                        tracing::debug!("  Cursor display name: {:?}", cursor.get_display_name());
+                        tracing::debug!("  Cursor is definition: {}", cursor.is_definition());
+
+                        let mut enrichment = SymbolEnrichment {
+                            usr: None,
+                            signature: None,
+                            canonical_type: None,
+                        };
+
+                        let usr_result = cursor.get_usr();
+                        tracing::debug!("  get_usr() returned: {:?}", usr_result);
+
+                        if let Some(usr) = usr_result {
+                            tracing::debug!("  ✓ Macro {} HAS USR: {}", name, usr.0);
+                            enrichment.usr = Some(usr.0);
+                        } else {
+                            tracing::debug!("  ✗ Macro {} has NO USR from libclang (cursor.get_usr() returned None)", name);
+                        }
+
+                        macro_enrichments.insert((name.clone(), line), enrichment);
+                    }
+                }
+                return EntityVisitResult::Recurse;
+            }
+
+            // For functions and types, we need name and location
+            if let (Some(name), Some(loc)) = (cursor.get_name(), cursor.get_location()) {
+                let file_loc = loc.get_file_location();
+                let line = file_loc.line as u32;
+
+                // Check if this is a function we're looking for (O(1) HashMap lookup)
+                if function_set.contains_key(&(name.as_str(), line)) {
+                    let mut enrichment = SymbolEnrichment {
+                        usr: None,
+                        signature: None,
+                        canonical_type: None,
+                    };
+
+                    if let Some(usr) = cursor.get_usr() {
+                        enrichment.usr = Some(usr.0);
+                    }
+
+                    if let Some(display_name) = cursor.get_display_name() {
+                        enrichment.signature = Some(display_name);
+                    }
+
+                    if let Some(result_type) = cursor.get_result_type() {
+                        let canonical = result_type.get_canonical_type();
+                        enrichment.canonical_type = Some(canonical.get_display_name());
+                    }
+
+                    function_enrichments.insert((name.clone(), line), enrichment);
+                }
+
+                // Check if this is a type we're looking for (O(1) lookup by line, then small vector check)
+                // Types can have various names with struct/union/enum prefixes
+                if let Some(type_names) = type_line_map.get(&line) {
+                    for type_name in type_names {
+                        let matches = name == **type_name
+                            || format!("struct {}", name) == **type_name
+                            || format!("union {}", name) == **type_name
+                            || format!("enum {}", name) == **type_name;
+
+                        if matches {
+                            let mut enrichment = SymbolEnrichment {
+                                usr: None,
+                                signature: None,
+                                canonical_type: None,
+                            };
+
+                            if let Some(usr) = cursor.get_usr() {
+                                enrichment.usr = Some(usr.0);
+                            }
+
+                            if let Some(cursor_type) = cursor.get_type() {
+                                let canonical = cursor_type.get_canonical_type();
+                                enrichment.canonical_type = Some(canonical.get_display_name());
+                            }
+
+                            type_enrichments.insert(((*type_name).clone(), line), enrichment);
+                            break; // Found the match, no need to check other type names
+                        }
+                    }
+                }
+            }
+
+            EntityVisitResult::Recurse
+        });
+
+        tracing::debug!(
+            "Batch enrichment complete for {:?}: {} functions, {} types, {} macros enriched",
+            file_path,
+            function_enrichments.len(),
+            type_enrichments.len(),
+            macro_enrichments.len()
+        );
+
+        Ok((function_enrichments, type_enrichments, macro_enrichments))
+    }
+
+    /// Check if a file can be enriched (has compile commands)
+    pub async fn can_enrich_file(&self, file_path: &Path) -> bool {
+        let canonical_path = file_path
+            .canonicalize()
+            .unwrap_or_else(|_| file_path.to_path_buf());
+
+        self.get_compile_args(&canonical_path).await.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_clangd_availability() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let compile_commands = temp_dir.path().join("compile_commands.json");
+
+        // Should return false when file doesn't exist
+        assert!(!ClangdAnalyzer::is_available(&compile_commands));
+
+        // Create empty compile_commands.json
+        std::fs::write(&compile_commands, "[]").unwrap();
+
+        // Should return true when file exists (if libclang is available)
+        // This may fail in CI without libclang installed
+        let available = ClangdAnalyzer::is_available(&compile_commands);
+        if available {
+            let analyzer = ClangdAnalyzer::new(&compile_commands, temp_dir.path());
+            assert!(analyzer.is_ok());
+        }
+    }
+}

--- a/src/clangd_processor.rs
+++ b/src/clangd_processor.rs
@@ -1,0 +1,483 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Clangd processor - manages worker pool and distributes enrichment work
+//!
+//! This module contains the controller that runs in the main process.
+//! It:
+//! - Spawns multiple worker processes (self-spawning same binary)
+//! - Distributes work requests to workers via IPC
+//! - Collects enrichment results
+//! - Handles worker failures and cleanup
+//!
+//! This design achieves parallelism by running multiple isolated processes,
+//! each with its own libclang instance, avoiding internal libclang locks.
+
+use anyhow::{Context, Result};
+use crossbeam_channel::{bounded, Receiver, Sender};
+use ipc_channel::ipc::{IpcOneShotServer, IpcReceiver, IpcSender};
+use std::env;
+use std::path::PathBuf;
+use std::process::{Child, Command};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+
+use crate::clangd_worker::{WorkRequest, WorkResponse};
+use crate::{FunctionInfo, MacroInfo, TypeInfo};
+
+/// Parsed file ready for enrichment
+#[derive(Debug)]
+pub struct EnrichmentRequest {
+    pub path: PathBuf,
+    pub functions: Vec<FunctionInfo>,
+    pub types: Vec<TypeInfo>,
+    pub macros: Vec<MacroInfo>,
+    pub git_file_sha: String,
+    /// Worker assignment for round-robin distribution
+    pub worker_id: usize,
+}
+
+/// Enriched file ready for database insertion
+#[derive(Debug)]
+pub struct EnrichmentResponse {
+    pub path: PathBuf,
+    pub functions: Vec<FunctionInfo>,
+    pub types: Vec<TypeInfo>,
+    pub macros: Vec<MacroInfo>,
+    pub git_file_sha: String,
+}
+
+/// Worker pool that manages multiple clangd worker processes
+pub struct ClangdProcessor {
+    workers: Arc<std::sync::Mutex<Vec<WorkerHandle>>>,
+    worker_channels: Arc<std::sync::Mutex<Vec<IpcSender<WorkRequest>>>>,
+    work_tx: Option<Sender<EnrichmentRequest>>,
+    result_rx: Receiver<EnrichmentResponse>,
+    result_tx: Sender<EnrichmentResponse>,  // Keep for spawning collectors
+    coordinator_thread: Option<thread::JoinHandle<()>>,  // Need to join on drop
+
+    // Configuration for worker processes
+    compile_commands_path: PathBuf,
+    source_root: PathBuf,
+    max_workers: usize,
+    worker_binary_path: PathBuf,  // Path to binary to spawn for workers
+
+    // Statistics
+    pub files_with_compile_commands: Arc<AtomicUsize>,
+    pub enriched_functions: Arc<AtomicUsize>,
+    pub enriched_types: Arc<AtomicUsize>,
+    pub enriched_macros: Arc<AtomicUsize>,
+    pub macros_kept_by_clangd: Arc<AtomicUsize>,
+}
+
+struct WorkerHandle {
+    id: usize,
+    process: Child,
+}
+
+impl ClangdProcessor {
+    /// Create a new processor with default worker count (num_cpus - 2)
+    ///
+    /// # Arguments
+    /// * `compile_commands_path` - Path to compile_commands.json
+    /// * `source_root` - Root directory of source code
+    pub fn new_with_defaults(
+        compile_commands_path: PathBuf,
+        source_root: PathBuf,
+    ) -> Result<Self> {
+        let num_workers = Self::default_worker_count();
+        let worker_binary = env::current_exe().context("Failed to get current executable path")?;
+        Self::new_with_binary(num_workers, compile_commands_path, source_root, worker_binary)
+    }
+
+    /// Calculate default worker count: num_cpus - 2, with minimum of 1
+    pub fn default_worker_count() -> usize {
+        let num_cpus = num_cpus::get();
+        if num_cpus <= 2 {
+            1
+        } else {
+            num_cpus - 2
+        }
+    }
+
+    /// Create a new processor with worker pool
+    ///
+    /// # Arguments
+    /// * `max_workers` - Maximum number of worker processes
+    /// * `compile_commands_path` - Path to compile_commands.json
+    /// * `source_root` - Root directory of source code
+    pub fn new(
+        max_workers: usize,
+        compile_commands_path: PathBuf,
+        source_root: PathBuf,
+    ) -> Result<Self> {
+        let worker_binary = env::current_exe().context("Failed to get current executable path")?;
+        Self::new_with_binary(max_workers, compile_commands_path, source_root, worker_binary)
+    }
+
+    /// Create a new processor with custom worker binary path (for testing)
+    ///
+    /// # Arguments
+    /// * `max_workers` - Maximum number of worker processes
+    /// * `compile_commands_path` - Path to compile_commands.json
+    /// * `source_root` - Root directory of source code
+    /// * `worker_binary_path` - Path to binary to use for worker processes
+    pub fn new_with_binary(
+        max_workers: usize,
+        compile_commands_path: PathBuf,
+        source_root: PathBuf,
+        worker_binary_path: PathBuf,
+    ) -> Result<Self> {
+        tracing::info!(
+            "Creating ClangdProcessor with capacity for {} workers",
+            max_workers
+        );
+
+        // Channels for work distribution (large buffer to avoid backpressure)
+        let (work_tx, work_rx) = bounded::<EnrichmentRequest>(100_000);
+        let (result_tx, result_rx) = bounded::<EnrichmentResponse>(100_000);
+
+        // Statistics
+        let files_with_compile_commands = Arc::new(AtomicUsize::new(0));
+        let enriched_functions = Arc::new(AtomicUsize::new(0));
+        let enriched_types = Arc::new(AtomicUsize::new(0));
+        let enriched_macros = Arc::new(AtomicUsize::new(0));
+        let macros_kept_by_clangd = Arc::new(AtomicUsize::new(0));
+
+        // Workers will be spawned by the pipeline when enrichment begins
+        // Set up shared worker channels for coordinator
+        let worker_channels = Arc::new(std::sync::Mutex::new(Vec::<IpcSender<WorkRequest>>::new()));
+        let workers = Arc::new(std::sync::Mutex::new(Vec::<WorkerHandle>::new()));
+
+        tracing::info!("Processor ready (max {} workers)", max_workers);
+
+        // Spawn coordinator thread to distribute work
+        let coordinator_work_rx = work_rx.clone();
+        let coordinator_worker_channels = worker_channels.clone();
+
+        let coordinator_thread = thread::Builder::new()
+            .name("enrichment-coordinator".to_string())
+            .spawn(move || {
+                Self::coordinate_work(coordinator_work_rx, coordinator_worker_channels)
+            })
+            .context("Failed to spawn coordinator thread")?;
+
+        Ok(Self {
+            workers,
+            worker_channels,
+            work_tx: Some(work_tx),
+            result_rx,
+            result_tx,
+            coordinator_thread: Some(coordinator_thread),
+            compile_commands_path,
+            source_root,
+            max_workers,
+            worker_binary_path,
+            files_with_compile_commands,
+            enriched_functions,
+            enriched_types,
+            enriched_macros,
+            macros_kept_by_clangd,
+        })
+    }
+
+    /// Spawn a new worker process
+    pub fn spawn_worker(&self) -> Result<()> {
+        // Get current worker count to determine worker ID
+        let current_worker_id = self.workers.lock().unwrap().len();
+
+        // Check if we've reached max workers
+        if current_worker_id >= self.max_workers {
+            anyhow::bail!("Maximum number of workers ({}) already spawned", self.max_workers);
+        }
+
+        tracing::debug!("Spawning worker {}", current_worker_id);
+
+        // Create IPC channels for this worker
+        let (work_server, work_server_name) = IpcOneShotServer::new()
+            .context("Failed to create IPC server for work channel")?;
+        let (response_server, response_server_name) = IpcOneShotServer::new()
+            .context("Failed to create IPC server for response channel")?;
+
+        // Spawn worker process using configured binary path
+        let child = Command::new(&self.worker_binary_path)
+            .arg("--clangd-worker")
+            .arg("--worker-id")
+            .arg(current_worker_id.to_string())
+            .arg("--ipc-work-server")
+            .arg(&work_server_name)
+            .arg("--ipc-response-server")
+            .arg(&response_server_name)
+            .arg("--compile-commands")
+            .arg(&self.compile_commands_path)
+            .arg("--source")
+            .arg(&self.source_root)
+            .spawn()
+            .with_context(|| format!("Failed to spawn worker {}", current_worker_id))?;
+
+        let pid = child.id();
+        tracing::info!("Worker {} spawned with PID {}", current_worker_id, pid);
+
+        // Accept connections from worker
+        let (_, work_tx): (_, IpcSender<WorkRequest>) = work_server
+            .accept()
+            .with_context(|| format!("Failed to accept work channel from worker {}", current_worker_id))?;
+
+        let (_, response_rx): (_, IpcReceiver<WorkResponse>) = response_server
+            .accept()
+            .with_context(|| format!("Failed to accept response channel from worker {}", current_worker_id))?;
+
+        // Add worker to list
+        self.workers.lock().unwrap().push(WorkerHandle {
+            id: current_worker_id,
+            process: child,
+        });
+
+        // Add worker channel to coordinator's list
+        self.worker_channels.lock().unwrap().push(work_tx);
+
+        // Spawn thread to collect results from this worker
+        let result_tx_clone = self.result_tx.clone();
+        let stats_files = self.files_with_compile_commands.clone();
+        let stats_funcs = self.enriched_functions.clone();
+        let stats_types = self.enriched_types.clone();
+        let stats_macros = self.enriched_macros.clone();
+        let stats_kept = self.macros_kept_by_clangd.clone();
+
+        thread::Builder::new()
+            .name(format!("worker-{}-collector", current_worker_id))
+            .spawn(move || {
+                Self::collect_worker_responses(
+                    current_worker_id,
+                    response_rx,
+                    result_tx_clone,
+                    stats_files,
+                    stats_funcs,
+                    stats_types,
+                    stats_macros,
+                    stats_kept,
+                );
+                tracing::debug!("Worker {} collector thread exiting", current_worker_id);
+            })
+            .with_context(|| format!("Failed to spawn collector thread for worker {}", current_worker_id))?;
+
+        tracing::info!("Worker {} fully initialized and ready", current_worker_id);
+        Ok(())
+    }
+
+    /// Submit work for enrichment
+    pub fn submit_work(&self, request: EnrichmentRequest) -> Result<()> {
+        self.work_tx
+            .as_ref()
+            .context("Work channel closed - call finish_submitting() only after all work is submitted")?
+            .send(request)
+            .context("Failed to send work request")?;
+        Ok(())
+    }
+
+    /// Signal that all work has been submitted
+    /// This closes the work channel and allows workers to exit when done
+    pub fn finish_submitting(&mut self) {
+        tracing::info!("Closing work channel - all files submitted");
+        self.work_tx = None;
+    }
+
+    /// Receive enriched result (blocking)
+    pub fn recv_result(&self) -> Result<EnrichmentResponse> {
+        self.result_rx
+            .recv()
+            .context("Failed to receive enrichment result")
+    }
+
+    /// Try to receive enriched result (non-blocking)
+    pub fn try_recv_result(&self) -> Option<EnrichmentResponse> {
+        self.result_rx.try_recv().ok()
+    }
+
+    /// Coordinator thread: distributes work to workers using round-robin assignment
+    fn coordinate_work(
+        work_rx: Receiver<EnrichmentRequest>,
+        worker_channels: Arc<std::sync::Mutex<Vec<IpcSender<WorkRequest>>>>,
+    ) {
+        tracing::info!("Coordinator thread started, waiting for work...");
+
+        let mut work_distributed = 0;
+        let mut work_received = 0;
+
+        while let Ok(request) = work_rx.recv() {
+            work_received += 1;
+            if work_received <= 5 || work_received % 100 == 0 {
+                tracing::info!("Coordinator received work item {} for {:?}", work_received, request.path);
+            }
+            // Send full symbols to worker for enrichment
+            let work_request = WorkRequest {
+                file_path: request.path.clone(),
+                functions: request.functions,
+                types: request.types,
+                macros: request.macros,
+                git_file_sha: request.git_file_sha,
+            };
+
+            // Get current worker channels
+            let channels = worker_channels.lock().unwrap();
+            let num_workers = channels.len();
+
+            if work_distributed == 0 {
+                tracing::info!("Coordinator received first work item, {} workers available", num_workers);
+            }
+
+            if num_workers == 0 {
+                tracing::warn!("No workers available - dropping request for {:?}", request.path);
+                continue;
+            }
+
+            // Round-robin assignment - remap to actually-spawned workers (may be fewer than max_workers)
+            let worker_id = request.worker_id % num_workers;
+
+            if work_distributed < 5 {
+                tracing::info!("Coordinator sending work item {} to worker {}", work_distributed, worker_id);
+            }
+
+            if let Err(e) = channels[worker_id].send(work_request) {
+                tracing::error!("Failed to send work to worker {}: {}", worker_id, e);
+            } else {
+                work_distributed += 1;
+                if work_distributed < 5 {
+                    tracing::info!("Coordinator successfully sent work item {} to worker {}", work_distributed, worker_id);
+                }
+                if work_distributed % 1000 == 0 {
+                    tracing::info!("Coordinator distributed {} work items to {} workers",
+                        work_distributed, num_workers);
+                }
+            }
+            drop(channels); // Release lock before next iteration
+        }
+
+        tracing::info!("Coordinator received {} work items, distributed {} to workers", work_received, work_distributed);
+
+        // Close all worker channels to signal them to exit
+        tracing::info!("Closing all worker channels to signal workers to exit");
+        let mut channels = worker_channels.lock().unwrap();
+        channels.clear(); // Drop all IPC senders - this closes the channels
+        drop(channels);
+    }
+
+    /// Collector thread: receives results from a worker
+    fn collect_worker_responses(
+        worker_id: usize,
+        response_rx: IpcReceiver<WorkResponse>,
+        result_tx: Sender<EnrichmentResponse>,
+        files_with_compile_commands: Arc<AtomicUsize>,
+        enriched_functions: Arc<AtomicUsize>,
+        enriched_types: Arc<AtomicUsize>,
+        enriched_macros: Arc<AtomicUsize>,
+        macros_kept_by_clangd: Arc<AtomicUsize>,
+    ) {
+        tracing::info!("Collector thread started for worker {}, waiting for results...", worker_id);
+
+        let mut responses_collected = 0;
+
+        while let Ok(worker_response) = response_rx.recv() {
+            responses_collected += 1;
+
+            if responses_collected == 1 || responses_collected % 100 == 0 {
+                tracing::info!("Worker {} collector received {} responses", worker_id, responses_collected);
+            }
+
+            // Track statistics
+            if worker_response.had_compile_commands {
+                files_with_compile_commands.fetch_add(1, Ordering::Relaxed);
+            }
+
+            // Count enriched symbols (those with USR set)
+            let func_count = worker_response.functions.iter()
+                .filter(|f| f.usr.is_some())
+                .count();
+            let type_count = worker_response.types.iter()
+                .filter(|t| t.usr.is_some())
+                .count();
+            let macro_count = worker_response.macros.iter()
+                .filter(|m| m.usr.is_some())
+                .count();
+
+            // Count non-function-like macros that were kept due to USR
+            let kept_count = worker_response.macros.iter()
+                .filter(|m| !m.is_function_like && m.usr.is_some())
+                .count();
+
+            enriched_functions.fetch_add(func_count, Ordering::Relaxed);
+            enriched_types.fetch_add(type_count, Ordering::Relaxed);
+            enriched_macros.fetch_add(macro_count, Ordering::Relaxed);
+            macros_kept_by_clangd.fetch_add(kept_count, Ordering::Relaxed);
+
+            tracing::debug!(
+                "Worker {} returned {} function, {} type, {} macro enrichments",
+                worker_id,
+                func_count,
+                type_count,
+                macro_count
+            );
+
+            // Forward enriched symbols to result channel
+            let enrichment_response = EnrichmentResponse {
+                path: worker_response.file_path,
+                functions: worker_response.functions,
+                types: worker_response.types,
+                macros: worker_response.macros,
+                git_file_sha: worker_response.git_file_sha,
+            };
+
+            if let Err(e) = result_tx.send(enrichment_response) {
+                tracing::error!("Worker {} collector failed to send result: {}", worker_id, e);
+                break;
+            }
+        }
+
+        tracing::info!(
+            "Worker {} collector finished after processing {} responses",
+            worker_id,
+            responses_collected
+        );
+    }
+}
+
+impl Drop for ClangdProcessor {
+    fn drop(&mut self) {
+        let num_workers = self.workers.lock().unwrap().len();
+        tracing::info!("Shutting down ClangdProcessor and {} workers", num_workers);
+
+        // Close work channel to signal coordinator thread to exit
+        self.work_tx = None;
+
+        // Wait for coordinator thread to exit
+        if let Some(coordinator) = self.coordinator_thread.take() {
+            tracing::debug!("Waiting for coordinator thread to exit");
+            if let Err(e) = coordinator.join() {
+                tracing::error!("Coordinator thread panicked: {:?}", e);
+            } else {
+                tracing::info!("Coordinator thread exited");
+            }
+        }
+
+        // Close all worker channels (coordinator already did this, but just in case)
+        {
+            let mut channels = self.worker_channels.lock().unwrap();
+            channels.clear(); // Drop all IPC senders
+        }
+
+        // Wait for all workers to exit
+        let mut workers = self.workers.lock().unwrap();
+        for worker in workers.iter_mut() {
+            tracing::debug!("Waiting for worker {} to exit", worker.id);
+            match worker.process.wait() {
+                Ok(status) => {
+                    tracing::info!("Worker {} exited with status: {}", worker.id, status);
+                }
+                Err(e) => {
+                    tracing::error!("Failed to wait for worker {}: {}", worker.id, e);
+                }
+            }
+        }
+
+        tracing::info!("All workers shut down");
+    }
+}

--- a/src/clangd_worker.rs
+++ b/src/clangd_worker.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Clangd worker process - performs actual enrichment in isolated process
+//!
+//! This module contains the worker-side code that runs in child processes.
+//! Each worker:
+//! - Creates its own ClangdAnalyzer instance (no shared state)
+//! - Receives work requests via IPC
+//! - Performs libclang enrichment
+//! - Sends results back via IPC
+//!
+//! This design sidesteps libclang's internal global locks by running
+//! multiple isolated processes, similar to how Python's multiprocessing
+//! sidesteps the GIL.
+
+use anyhow::{Context, Result};
+use ipc_channel::ipc::{IpcReceiver, IpcSender};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use crate::clangd_analyzer::ClangdAnalyzer;
+use crate::{FunctionInfo, MacroInfo, TypeInfo};
+
+/// Work request sent from parent to worker
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WorkRequest {
+    /// File to enrich
+    pub file_path: PathBuf,
+    /// Functions to enrich (original symbols - will be enriched and returned)
+    pub functions: Vec<FunctionInfo>,
+    /// Types to enrich (original symbols - will be enriched and returned)
+    pub types: Vec<TypeInfo>,
+    /// Macros to enrich (original symbols - will be enriched and returned)
+    pub macros: Vec<MacroInfo>,
+    /// Git file SHA (passed through)
+    pub git_file_sha: String,
+}
+
+/// Work response sent from worker to parent
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WorkResponse {
+    /// File that was enriched
+    pub file_path: PathBuf,
+    /// Enriched functions (with USR, signature, etc. applied)
+    pub functions: Vec<FunctionInfo>,
+    /// Enriched types (with USR, canonical type, etc. applied)
+    pub types: Vec<TypeInfo>,
+    /// Enriched macros (filtered and with USR applied)
+    pub macros: Vec<MacroInfo>,
+    /// Git file SHA (passed through)
+    pub git_file_sha: String,
+    /// Whether file had compile commands
+    pub had_compile_commands: bool,
+}
+
+/// Worker process entry point
+///
+/// This is called when the binary is started with --clangd-worker flag.
+/// The worker:
+/// 1. Connects to parent via IPC
+/// 2. Creates ClangdAnalyzer
+/// 3. Processes work requests in a loop
+/// 4. Exits when channel closes
+pub async fn run_worker(
+    worker_id: usize,
+    work_rx: IpcReceiver<WorkRequest>,
+    response_tx: IpcSender<WorkResponse>,
+    compile_commands_path: PathBuf,
+    source_root: PathBuf,
+) -> Result<()> {
+    tracing::debug!(
+        "Worker {} starting (PID: {})",
+        worker_id,
+        std::process::id()
+    );
+
+    // Create ClangdAnalyzer (isolated per worker, no shared state with other workers)
+    let analyzer = ClangdAnalyzer::new(&compile_commands_path, &source_root)
+        .context("Failed to create ClangdAnalyzer")?;
+
+    analyzer
+        .initialize()
+        .await
+        .context("Failed to initialize ClangdAnalyzer")?;
+
+    tracing::info!("Worker {} initialized and ready for work, waiting for requests...", worker_id);
+
+    let mut files_processed = 0;
+
+    // Process work requests until channel closes
+    while let Ok(request) = work_rx.recv() {
+        files_processed += 1;
+
+        if files_processed <= 3 || files_processed % 100 == 0 {
+            tracing::info!(
+                "Worker {} processing file {}: {:?}",
+                worker_id,
+                files_processed,
+                request.file_path
+            );
+        }
+
+        // Check if file has compile commands
+        let had_compile_commands = analyzer.can_enrich_file(&request.file_path).await;
+
+        if !had_compile_commands {
+            // No compile commands - return original symbols with no enrichment
+            // But filter macros to function-like only
+            let filtered_macros: Vec<MacroInfo> = request.macros.into_iter()
+                .filter(|m| m.is_function_like)
+                .collect();
+
+            let response = WorkResponse {
+                file_path: request.file_path,
+                functions: request.functions,
+                types: request.types,
+                macros: filtered_macros,
+                git_file_sha: request.git_file_sha,
+                had_compile_commands: false,
+            };
+
+            if let Err(e) = response_tx.send(response) {
+                tracing::error!("Worker {} failed to send response: {}", worker_id, e);
+                break;
+            }
+            if files_processed <= 3 || files_processed % 100 == 0 {
+                tracing::info!("Worker {} sent response {}", worker_id, files_processed);
+            }
+            continue;
+        }
+
+        // Extract (name, line) pairs for enrichment
+        let function_keys: Vec<_> = request.functions.iter()
+            .map(|f| (f.name.clone(), f.line_start))
+            .collect();
+        let type_keys: Vec<_> = request.types.iter()
+            .map(|t| (t.name.clone(), t.line_start))
+            .collect();
+        let macro_keys: Vec<_> = request.macros.iter()
+            .map(|m| (m.name.clone(), m.line_start))
+            .collect();
+
+        // Perform batch enrichment (single libclang parse)
+        let result = analyzer
+            .enrich_file_batch(
+                &request.file_path,
+                &function_keys,
+                &type_keys,
+                &macro_keys,
+            )
+            .await;
+
+        match result {
+            Ok((function_enrichments, type_enrichments, macro_enrichments)) => {
+                // Apply enrichments to original symbols
+                let mut enriched_functions = request.functions;
+                let mut enriched_types = request.types;
+                let mut enriched_macros = Vec::new();
+
+                // Apply function enrichments
+                for func in enriched_functions.iter_mut() {
+                    if let Some(enrichment) = function_enrichments.get(&(func.name.clone(), func.line_start)) {
+                        if let Some(ref usr) = enrichment.usr {
+                            func.usr = Some(usr.clone());
+                        }
+                        if let Some(ref sig) = enrichment.signature {
+                            func.signature = Some(sig.clone());
+                        }
+                        if let Some(ref canonical) = enrichment.canonical_type {
+                            func.canonical_return_type = Some(canonical.clone());
+                        }
+                    }
+                }
+
+                // Apply type enrichments
+                for typ in enriched_types.iter_mut() {
+                    if let Some(enrichment) = type_enrichments.get(&(typ.name.clone(), typ.line_start)) {
+                        if let Some(ref usr) = enrichment.usr {
+                            typ.usr = Some(usr.clone());
+                        }
+                        if let Some(ref canonical) = enrichment.canonical_type {
+                            typ.canonical_name = Some(canonical.clone());
+                        }
+                    }
+                }
+
+                // Apply macro enrichments and filtering
+                for mac in request.macros {
+                    // Always keep function-like macros
+                    if mac.is_function_like {
+                        let mut enriched_mac = mac;
+                        if let Some(enrichment) = macro_enrichments.get(&(enriched_mac.name.clone(), enriched_mac.line_start)) {
+                            if let Some(ref usr) = enrichment.usr {
+                                enriched_mac.usr = Some(usr.clone());
+                            }
+                        }
+                        enriched_macros.push(enriched_mac);
+                    } else {
+                        // For non-function-like macros, only keep if we got USR from clangd
+                        if let Some(enrichment) = macro_enrichments.get(&(mac.name.clone(), mac.line_start)) {
+                            if let Some(ref usr) = enrichment.usr {
+                                let mut enriched_mac = mac;
+                                enriched_mac.usr = Some(usr.clone());
+                                enriched_macros.push(enriched_mac);
+                            }
+                        }
+                    }
+                }
+
+                let response = WorkResponse {
+                    file_path: request.file_path,
+                    functions: enriched_functions,
+                    types: enriched_types,
+                    macros: enriched_macros,
+                    git_file_sha: request.git_file_sha,
+                    had_compile_commands: true,
+                };
+
+                if let Err(e) = response_tx.send(response) {
+                    tracing::error!("Worker {} failed to send response: {}", worker_id, e);
+                    break;
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Worker {} enrichment error for {:?}: {}",
+                    worker_id,
+                    request.file_path,
+                    e
+                );
+
+                // Send original symbols without enrichment on error
+                let filtered_macros: Vec<MacroInfo> = request.macros.into_iter()
+                    .filter(|m| m.is_function_like)
+                    .collect();
+
+                let response = WorkResponse {
+                    file_path: request.file_path,
+                    functions: request.functions,
+                    types: request.types,
+                    macros: filtered_macros,
+                    git_file_sha: request.git_file_sha,
+                    had_compile_commands: true,
+                };
+
+                if let Err(e) = response_tx.send(response) {
+                    tracing::error!("Worker {} failed to send error response: {}", worker_id, e);
+                    break;
+                }
+            }
+        }
+    }
+
+    tracing::info!(
+        "Worker {} exiting: processed {} files, work channel closed",
+        worker_id,
+        files_processed
+    );
+
+    Ok(())
+}

--- a/src/database/content.rs
+++ b/src/database/content.rs
@@ -69,7 +69,8 @@ impl ContentStore {
         Ok(blake3_hash)
     }
 
-    /// Insert a batch of content items using upsert - handles duplicates gracefully
+    /// Insert a batch of content items - uses merge_insert for deduplication
+    /// Multiple functions can have identical content (e.g., stub functions)
     pub async fn insert_batch(&self, content_items: Vec<ContentInfo>) -> Result<()> {
         if content_items.is_empty() {
             return Ok(());
@@ -135,6 +136,7 @@ impl ContentStore {
         let batch_iterator = RecordBatchIterator::new(batches.into_iter(), schema);
 
         // Use merge_insert for upsert functionality
+        // Multiple functions can have the same content hash (e.g., stub functions returning 0)
         let mut merge_insert = table.merge_insert(&["blake3_hash"]);
         merge_insert
             .when_matched_update_all(None)

--- a/src/database/search.rs
+++ b/src/database/search.rs
@@ -187,6 +187,11 @@ impl SearchManager {
                     body,
                     calls: None, // Not populated in search results
                     types: None, // Not populated in search results
+                    usr: None,
+                    signature: None,
+                    canonical_return_type: None,
+                    calls_precise: None,
+                    overload_index: None,
                 });
             }
         }
@@ -365,6 +370,11 @@ impl SearchManager {
                         body,
                         calls: None, // Not populated in search results
                         types: None, // Not populated in search results
+                        usr: None,
+                        signature: None,
+                        canonical_return_type: None,
+                        calls_precise: None,
+                        overload_index: None,
                     });
                 }
             }
@@ -465,6 +475,9 @@ impl SearchManager {
                     members: fields,
                     definition,
                     types: None, // Not populated in search results
+                    usr: None,
+                    canonical_name: None,
+                    template_params: None,
                 });
             }
         }
@@ -637,6 +650,9 @@ impl SearchManager {
                         members: fields,
                         definition,
                         types: None, // Not populated in search results
+                        usr: None,
+                        canonical_name: None,
+                        template_params: None,
                     });
                 }
             }
@@ -722,6 +738,9 @@ impl SearchManager {
                     members: fields,
                     definition,
                     types: None, // Not populated in search results
+                    usr: None,
+                    canonical_name: None,
+                    template_params: None,
                 });
             }
         }
@@ -917,6 +936,7 @@ impl SearchManager {
                     definition: definition_array.value(i).to_string(),
                     calls: None, // Not populated in search results
                     types: None, // Not populated in search results
+                    usr: None,
                 });
             }
         }
@@ -1236,6 +1256,7 @@ impl SearchManager {
                         definition: definition_array.value(i).to_string(),
                         calls: None, // Not populated in search results
                         types: None, // Not populated in search results
+                        usr: None,
                     });
                 }
             }
@@ -1331,6 +1352,9 @@ impl SearchManager {
                     members: fields,
                     definition,
                     types: None, // Not populated in search results
+                    usr: None,
+                    canonical_name: None,
+                    template_params: None,
                 });
             }
         }
@@ -1486,6 +1510,9 @@ impl SearchManager {
                         members: fields,
                         definition,
                         types: None,
+                        usr: None,
+                        canonical_name: None,
+                        template_params: None,
                     });
                 }
             }
@@ -1825,6 +1852,11 @@ impl SearchManager {
                     body,
                     calls: None, // Not populated in search results
                     types: None, // Not populated in search results
+                    usr: None,
+                    signature: None,
+                    canonical_return_type: None,
+                    calls_precise: None,
+                    overload_index: None,
                 });
             }
         }
@@ -1986,6 +2018,11 @@ impl SearchManager {
                         body,
                         calls: None,
                         types: None,
+                        usr: None,
+                        signature: None,
+                        canonical_return_type: None,
+                        calls_precise: None,
+                        overload_index: None,
                     });
                 }
             }
@@ -2096,6 +2133,7 @@ impl SearchManager {
                     definition,
                     calls: None,
                     types: None,
+                    usr: None,
                 });
             }
         }
@@ -2258,6 +2296,7 @@ impl SearchManager {
                         definition,
                         calls: None,
                         types: None,
+                        usr: None,
                     });
                 }
             }
@@ -2545,6 +2584,11 @@ impl VectorSearchManager {
             body,
             calls: None, // Not populated from database extraction helper
             types: None, // Not populated from database extraction helper
+            usr: None,
+            signature: None,
+            canonical_return_type: None,
+            calls_precise: None,
+            overload_index: None,
         }))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Module declarations
+pub mod clangd_analyzer;
+pub mod clangd_processor;
+pub mod clangd_worker;
 mod database;
 pub mod database_utils;
 pub mod git;
@@ -18,6 +21,9 @@ pub mod display;
 pub mod search;
 
 // Re-export the main types and structs
+pub use clangd_analyzer::{ClangdAnalyzer, SymbolEnrichment};
+pub use clangd_processor::ClangdProcessor;
+pub use clangd_worker::{run_worker, WorkRequest, WorkResponse};
 pub use database::DatabaseManager;
 pub use database_utils::process_database_path;
 pub use git::{get_git_sha, get_git_sha_for_workdir};
@@ -26,7 +32,7 @@ pub use text_utils::preprocess_code;
 pub use treesitter_analyzer::TreeSitterAnalyzer;
 pub use types::{
     FieldInfo, FunctionInfo, GitFileEntry, GitFileManifestEntry, GlobalTypeRegistry, MacroInfo,
-    ParameterInfo, TypeInfo, TypedefInfo,
+    ParameterInfo, PreciseCallInfo, TypeInfo, TypedefInfo,
 };
 pub use vectorizer::CodeVectorizer;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,6 +16,17 @@ pub struct FunctionInfo {
     pub calls: Option<Vec<String>>, // Function names called by this function
     #[serde(default)]
     pub types: Option<Vec<String>>, // Type names used by this function
+    // Clangd-enriched fields (optional, only when clangd analysis is available)
+    #[serde(default)]
+    pub usr: Option<String>, // Unified Symbol Resolution ID from clangd
+    #[serde(default)]
+    pub signature: Option<String>, // Full resolved function signature
+    #[serde(default)]
+    pub canonical_return_type: Option<String>, // Fully resolved canonical return type
+    #[serde(default)]
+    pub calls_precise: Option<Vec<PreciseCallInfo>>, // Precise call information with USRs
+    #[serde(default)]
+    pub overload_index: Option<u32>, // Index when multiple overloads exist
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -26,6 +37,21 @@ pub struct ParameterInfo {
     pub type_file_path: Option<String>, // File where type is defined
     #[serde(default)]
     pub type_git_file_hash: Option<String>, // Hash of file containing type definition
+    // Clangd-enriched fields
+    #[serde(default)]
+    pub canonical_type: Option<String>, // Fully resolved canonical type from clangd
+    #[serde(default)]
+    pub type_usr: Option<String>, // USR of the type
+}
+
+/// Precise call information with clangd USRs for exact overload resolution
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreciseCallInfo {
+    pub name: String,                // Function name
+    pub usr: Option<String>,         // USR of the called function (if available from clangd)
+    pub overload_index: Option<u32>, // Which overload is being called
+    pub is_system: bool,             // Whether this is a system library call
+    pub signature: Option<String>,   // Full signature of the called function
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -40,6 +66,13 @@ pub struct TypeInfo {
     pub definition: String, // Added to store raw type definition with comments
     #[serde(default)]
     pub types: Option<Vec<String>>, // Type names referenced by this type
+    // Clangd-enriched fields
+    #[serde(default)]
+    pub usr: Option<String>, // USR from clangd
+    #[serde(default)]
+    pub canonical_name: Option<String>, // Fully qualified canonical name
+    #[serde(default)]
+    pub template_params: Option<Vec<String>>, // Template parameters if applicable
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -47,6 +80,11 @@ pub struct FieldInfo {
     pub name: String,
     pub type_name: String,
     pub offset: Option<u64>,
+    // Clangd-enriched fields
+    #[serde(default)]
+    pub canonical_type: Option<String>, // Canonical type from clangd
+    #[serde(default)]
+    pub type_usr: Option<String>, // USR of the field's type
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -72,6 +110,9 @@ pub struct MacroInfo {
     pub calls: Option<Vec<String>>, // Function names called by this macro
     #[serde(default)]
     pub types: Option<Vec<String>>, // Type names used by this macro
+    // Clangd-enriched fields
+    #[serde(default)]
+    pub usr: Option<String>, // USR from clangd
 }
 
 /// Global type registry for cross-file type resolution

--- a/tests/clangd_integration/README.md
+++ b/tests/clangd_integration/README.md
@@ -1,0 +1,37 @@
+# Clangd Integration Tests
+
+Tests for semcode's clangd integration, which adds compiler-grade semantic enrichment (USRs, canonical types, signatures) on top of Tree-sitter-based parsing.
+
+## Running Tests
+
+```bash
+# From project root
+cargo test --test clangd_integration
+
+# With verbose output
+cargo test --test clangd_integration -- --nocapture
+```
+
+Tests run in parallel with isolated temporary databases.
+
+## Prerequisites
+
+For clangd tests to run (not be skipped):
+```bash
+# Ubuntu/Debian
+sudo apt-get install libclang-dev
+
+# Fedora
+sudo dnf install clang-devel
+```
+
+## Test Fixtures
+
+- `test_sample.c` - C code exercising functions, types, macros
+- `compile_commands*.json` - Various compilation database formats for testing
+
+## Additional Documentation
+
+- **COMPILE_FLAGS_TEST.md** - Compile flag parsing details
+- **GCC_FLAGS.md** - GCC flag filtering
+- **CLANGD_CONFIG.md** - .clangd configuration support status

--- a/tests/clangd_integration/compile_commands_array.json
+++ b/tests/clangd_integration/compile_commands_array.json
@@ -1,0 +1,22 @@
+[
+  {
+    "directory": ".",
+    "arguments": [
+      "gcc",
+      "-Wall",
+      "-Wextra",
+      "-std=c11",
+      "-O2",
+      "-DVERSION=\"1.0.0\"",
+      "-DMAX_SIZE=1024",
+      "-I/usr/include/custom path",
+      "-I.",
+      "-DSTRING=\"hello world\"",
+      "-c",
+      "test_sample.c",
+      "-o",
+      "test_sample.o"
+    ],
+    "file": "test_sample.c"
+  }
+]

--- a/tests/clangd_integration/compile_commands_complex.json
+++ b/tests/clangd_integration/compile_commands_complex.json
@@ -1,0 +1,7 @@
+[
+  {
+    "directory": ".",
+    "command": "gcc -Wall -Wextra -std=c11 -O2 -DVERSION=\"1.0.0\" -DMAX_SIZE=1024 -I\"/usr/include/custom path\" -I. -DSTRING=\"hello world\" -c test_sample.c -o test_sample.o",
+    "file": "test_sample.c"
+  }
+]

--- a/tests/clangd_integration/compile_commands_gcc.json
+++ b/tests/clangd_integration/compile_commands_gcc.json
@@ -1,0 +1,7 @@
+[
+  {
+    "directory": ".",
+    "command": "gcc -Wall -Wextra -std=c11 -fconserve-stack -mindirect-branch=thunk-extern -mpreferred-stack-boundary=3 -Wno-maybe-uninitialized -fno-var-tracking-assignments -fplugin=my_plugin.so -fplugin-arg-plugin=option -c test_sample.c -o test_sample.o",
+    "file": "test_sample.c"
+  }
+]

--- a/tests/clangd_integration/compile_commands_macro_test.json
+++ b/tests/clangd_integration/compile_commands_macro_test.json
@@ -1,0 +1,7 @@
+[
+  {
+    "directory": ".",
+    "command": "gcc -Wall -std=c11 -c test_macro_usr.c -o test_macro_usr.o",
+    "file": "test_macro_usr.c"
+  }
+]

--- a/tests/clangd_integration/test_macro_usr.c
+++ b/tests/clangd_integration/test_macro_usr.c
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Minimal test file for macro USR enrichment
+
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+
+int main() {
+    return MAX(1, 2);
+}

--- a/tests/clangd_integration/test_sample.c
+++ b/tests/clangd_integration/test_sample.c
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Test file for clangd integration testing
+// This file exercises all major features that clangd enriches
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// ============================================================================
+// MACROS - Testing intelligent filtering
+// ============================================================================
+
+// Non-function-like macros (filtered out - libclang doesn't provide USRs for macros)
+#define MAX_BUFFER_SIZE 1024
+#define VERSION "1.0.0"
+#define DEBUG_MODE 1
+#define PI 3.14159
+
+// Function-like macros (always kept, but USRs not available from libclang)
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define SQUARE(x) ((x) * (x))
+#define CLAMP(x, min, max) (MIN(MAX(x, min), max))
+
+// ============================================================================
+// TYPE DEFINITIONS - Testing canonical type resolution
+// ============================================================================
+
+// Simple struct
+typedef struct {
+    int x;
+    int y;
+} Point;
+
+// Nested struct with pointer
+typedef struct {
+    Point *points;
+    size_t count;
+    size_t capacity;
+} PointArray;
+
+// Typedef chain (clangd resolves to canonical type)
+typedef Point Point2D;
+typedef Point2D Coordinate;
+
+// Forward declaration
+typedef struct Node Node;
+
+// Self-referential struct
+struct Node {
+    int data;
+    Node *next;
+    Node *prev;
+};
+
+// Union type
+typedef union {
+    int as_int;
+    float as_float;
+    char as_bytes[4];
+} Value;
+
+// Enum type
+typedef enum {
+    STATUS_OK = 0,
+    STATUS_ERROR = 1,
+    STATUS_PENDING = 2
+} Status;
+
+// ============================================================================
+// FUNCTION DECLARATIONS - Testing USR and signature extraction
+// ============================================================================
+
+// Basic functions
+Point* create_point(int x, int y);
+void destroy_point(Point *p);
+void print_point(const Point *p);
+
+// Functions with complex types
+PointArray* create_point_array(size_t initial_capacity);
+void destroy_point_array(PointArray *arr);
+int add_point(PointArray *arr, Point *p);
+
+// Functions with typedefs
+Coordinate* create_coordinate(int x, int y);
+int distance_squared(Point2D *p1, Point2D *p2);
+
+// Linked list operations
+Node* create_node(int data);
+void append_node(Node **head, int data);
+void free_list(Node *head);
+
+// Functions with various return types
+Status validate_point(const Point *p);
+Value create_value_int(int val);
+int compute_area(Point *p1, Point *p2);
+
+// ============================================================================
+// FUNCTION IMPLEMENTATIONS
+// ============================================================================
+
+Point* create_point(int x, int y) {
+    Point *p = malloc(sizeof(Point));
+    if (p) {
+        p->x = x;
+        p->y = y;
+    }
+    return p;
+}
+
+void destroy_point(Point *p) {
+    if (p) {
+        free(p);
+    }
+}
+
+void print_point(const Point *p) {
+    if (p) {
+        printf("Point(%d, %d)\n", p->x, p->y);
+    }
+}
+
+PointArray* create_point_array(size_t initial_capacity) {
+    PointArray *arr = malloc(sizeof(PointArray));
+    if (arr) {
+        arr->points = malloc(sizeof(Point) * initial_capacity);
+        arr->count = 0;
+        arr->capacity = initial_capacity;
+    }
+    return arr;
+}
+
+void destroy_point_array(PointArray *arr) {
+    if (arr) {
+        if (arr->points) {
+            free(arr->points);
+        }
+        free(arr);
+    }
+}
+
+int add_point(PointArray *arr, Point *p) {
+    if (!arr || !p) return -1;
+    if (arr->count >= arr->capacity) return -1;
+
+    arr->points[arr->count] = *p;
+    arr->count++;
+    return 0;
+}
+
+Coordinate* create_coordinate(int x, int y) {
+    // Same as create_point - tests typedef resolution
+    return create_point(x, y);
+}
+
+int distance_squared(Point2D *p1, Point2D *p2) {
+    if (!p1 || !p2) return -1;
+
+    int dx = p2->x - p1->x;
+    int dy = p2->y - p1->y;
+
+    // Uses function-like macro
+    return SQUARE(dx) + SQUARE(dy);
+}
+
+Node* create_node(int data) {
+    Node *node = malloc(sizeof(Node));
+    if (node) {
+        node->data = data;
+        node->next = NULL;
+        node->prev = NULL;
+    }
+    return node;
+}
+
+void append_node(Node **head, int data) {
+    Node *new_node = create_node(data);
+    if (!new_node) return;
+
+    if (*head == NULL) {
+        *head = new_node;
+    } else {
+        Node *current = *head;
+        while (current->next) {
+            current = current->next;
+        }
+        current->next = new_node;
+        new_node->prev = current;
+    }
+}
+
+void free_list(Node *head) {
+    while (head) {
+        Node *next = head->next;
+        free(head);
+        head = next;
+    }
+}
+
+Status validate_point(const Point *p) {
+    if (!p) return STATUS_ERROR;
+
+    // Use macro to validate bounds
+    int max_coord = MAX(abs(p->x), abs(p->y));
+    if (max_coord > MAX_BUFFER_SIZE) {
+        return STATUS_ERROR;
+    }
+
+    return STATUS_OK;
+}
+
+Value create_value_int(int val) {
+    Value v;
+    v.as_int = val;
+    return v;
+}
+
+int compute_area(Point *p1, Point *p2) {
+    if (!p1 || !p2) return 0;
+
+    int width = abs(p2->x - p1->x);
+    int height = abs(p2->y - p1->y);
+
+    return width * height;
+}
+
+// ============================================================================
+// MAIN - Testing call graph
+// ============================================================================
+
+int main(int argc, char **argv) {
+    // Create some points
+    Point *p1 = create_point(0, 0);
+    Point *p2 = create_point(3, 4);
+
+    // Test printing
+    print_point(p1);
+    print_point(p2);
+
+    // Test distance calculation with macro
+    int dist_sq = distance_squared(p1, p2);
+    printf("Distance squared: %d\n", dist_sq);
+
+    // Test validation
+    Status s = validate_point(p1);
+    printf("Point validation: %s\n", s == STATUS_OK ? "OK" : "ERROR");
+
+    // Test array operations
+    PointArray *arr = create_point_array(10);
+    add_point(arr, p1);
+    add_point(arr, p2);
+    printf("Array has %zu points\n", arr->count);
+
+    // Test linked list
+    Node *list = NULL;
+    append_node(&list, 1);
+    append_node(&list, 2);
+    append_node(&list, 3);
+
+    // Cleanup
+    destroy_point(p1);
+    destroy_point(p2);
+    destroy_point_array(arr);
+    free_list(list);
+
+    return 0;
+}

--- a/tests/clangd_integration_basic.rs
+++ b/tests/clangd_integration_basic.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Basic integration tests for semcode indexing without clangd
+
+mod common;
+
+use common::*;
+use common::predicates::*;
+use rstest::*;
+
+#[rstest]
+fn test_index_without_clangd(test_env: TestEnv) {
+    IndexRunner::new(&test_env)
+        .assert()
+        .success()
+        .stdout(has_function_count(EXPECTED_FUNCTIONS))
+        .stdout(has_type_count(EXPECTED_TYPES))
+        .stdout(has_macro_count(EXPECTED_MACROS_WITHOUT_CLANGD));
+}
+
+#[rstest]
+fn test_index_consecutive_runs(test_env: TestEnv) {
+    IndexRunner::new(&test_env).assert().success();
+    IndexRunner::new(&test_env).assert().success();
+}
+
+#[test]
+fn test_graceful_degradation_without_compile_commands() {
+    use ::predicates::prelude::*;
+
+    IndexRunner::new(&TestEnv::with_custom_file("test.c", "int main() { return 0; }\n"))
+        .with_clangd()
+        .assert()
+        .success()
+        .stderr(::predicates::str::contains("compile_commands").or(::predicates::str::contains("clangd")));
+}

--- a/tests/clangd_integration_compile_commands.rs
+++ b/tests/clangd_integration_compile_commands.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Tests for various compile_commands.json formats
+
+mod common;
+
+use common::*;
+use common::predicates::*;
+use rstest::*;
+
+#[rstest]
+#[case("compile_commands_gcc.json")]
+#[case("compile_commands_complex.json")]
+#[case("compile_commands_array.json")]
+fn test_compile_commands_formats(#[case] cc_file: &str) {
+    skip_if_no_libclang!();
+
+    let test_env = TestEnv::with_compile_commands(cc_file);
+
+    IndexRunner::new(&test_env)
+        .with_clangd()
+        .assert()
+        .success()
+        .stdout(has_enrichment_stats())
+        .stdout(has_enriched_functions(EXPECTED_FUNCTIONS));
+}
+
+#[rstest]
+fn test_clangd_with_spaces_and_quotes(test_env: TestEnv) {
+    skip_if_no_libclang!();
+
+    std::fs::write(test_env.path().join("compile_commands.json"),
+        r#"[{"directory":".","command":"gcc -I\"/path with spaces\" -c test_sample.c","file":"test_sample.c"}]"#
+    ).unwrap();
+
+    IndexRunner::new(&test_env).with_clangd().assert().success();
+}
+
+#[rstest]
+fn test_source_file_in_command_filtered(test_env: TestEnv) {
+    skip_if_no_libclang!();
+
+    std::fs::write(test_env.path().join("compile_commands.json"),
+        r#"[{"directory":".","command":"gcc -Wall -c test_sample.c -o test.o","file":"test_sample.c"}]"#
+    ).unwrap();
+
+    IndexRunner::new(&test_env).with_clangd().assert().success();
+}

--- a/tests/clangd_integration_database.rs
+++ b/tests/clangd_integration_database.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Tests for database persistence of enrichment data
+
+mod common;
+
+use common::*;
+use pretty_assertions::assert_eq;
+
+#[tokio::test]
+async fn test_enrichment_retrieval_all_paths() {
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        skip_if_no_libclang!();
+
+        let test_env = TestEnv::new();
+        IndexRunner::new(&test_env).with_clangd().assert().success();
+
+        let db = semcode::DatabaseManager::new(
+            test_env.db_path().to_str().unwrap(),
+            test_env.path().to_str().unwrap().to_string(),
+        ).await.unwrap();
+
+        // Test function enrichment
+        let func = &db.find_all_functions("create_point").await.unwrap()[0];
+        assert!(func.usr.as_ref().unwrap().starts_with("c:@F@"));
+        assert!(func.signature.is_some() && func.canonical_return_type.is_some());
+
+        // Test type enrichment via find_type
+        let type_info = db.find_type("Point").await.unwrap().unwrap();
+        assert!(type_info.usr.as_ref().unwrap().starts_with("c:@"));
+        assert!(type_info.canonical_name.is_some());
+
+        // Test macro enrichment
+        let mac = db.find_macro("MAX").await.unwrap().unwrap();
+        if let Some(usr) = &mac.usr {
+            assert!(usr.starts_with("c:"));
+        }
+
+        // Test bulk retrieval
+        let all_types = db.get_all_types().await.unwrap();
+        let point = all_types.iter().find(|t| t.name == "Point").unwrap();
+        assert!(point.usr.is_some());
+
+        // Test get_by_names
+        let types_by_name = db.get_types_by_names(&["Point".to_string()]).await.unwrap();
+        let point_by_name = types_by_name.get("Point").unwrap();
+        assert!(point_by_name.usr.is_some() && point_by_name.canonical_name.is_some());
+
+        // Verify consistency
+        assert_eq!(type_info.usr, point.usr);
+        assert_eq!(type_info.usr, point_by_name.usr);
+    })
+    .await
+    .expect("Test timed out after 5 seconds");
+}
+
+#[tokio::test]
+async fn test_enrichment_with_custom_db_path() {
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        skip_if_no_libclang!();
+
+        let test_env = TestEnv::new();
+        let custom_db = test_env.path().join("custom.semcode.db");
+
+        assert_cmd::Command::cargo_bin("semcode-index").unwrap()
+            .current_dir(test_env.path())
+            .args(["--clear", "--source", ".", "--database"])
+            .arg(&custom_db)
+            .arg("--use-clangd")
+            .assert()
+            .success();
+
+        let db = semcode::DatabaseManager::new(
+            custom_db.to_str().unwrap(),
+            test_env.path().to_str().unwrap().to_string(),
+        ).await.unwrap();
+
+        let functions = db.find_all_functions("create_point").await.unwrap();
+        assert!(!functions.is_empty() && functions[0].usr.is_some());
+    })
+    .await
+    .expect("Test timed out after 5 seconds");
+}

--- a/tests/clangd_integration_enrichment.rs
+++ b/tests/clangd_integration_enrichment.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Integration tests for clangd enrichment functionality
+
+mod common;
+
+use common::*;
+use common::predicates::*;
+use rstest::*;
+
+#[rstest]
+fn test_index_with_clangd(test_env: TestEnv) {
+    skip_if_no_libclang!();
+
+    IndexRunner::new(&test_env)
+        .with_clangd()
+        .assert()
+        .success()
+        .stdout(has_enrichment_stats())
+        .stdout(has_function_count(EXPECTED_FUNCTIONS))
+        .stdout(has_enriched_functions(EXPECTED_FUNCTIONS))
+        .stdout(has_enriched_types(EXPECTED_TYPES));
+}
+
+#[rstest]
+fn test_clangd_with_absolute_paths(test_env: TestEnv) {
+    skip_if_no_libclang!();
+
+    let test_sample = test_env.path().join("test_sample.c");
+    let cc = test_env.path().join("compile_commands_absolute.json");
+
+    std::fs::write(&cc, format!(
+        r#"[{{"command":"gcc -c {} -o test.o","directory":"{}","file":"{}"}}]"#,
+        test_sample.display(), test_env.path().display(), test_sample.display()
+    )).unwrap();
+
+    IndexRunner::new(&test_env)
+        .with_clangd()
+        .with_compile_commands_path(cc)
+        .assert()
+        .success()
+        .stdout(has_enriched_functions(EXPECTED_FUNCTIONS))
+        .stdout(has_enriched_types(EXPECTED_TYPES));
+}
+
+#[tokio::test]
+async fn test_enrichment_persists_to_database() {
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        skip_if_no_libclang!();
+
+        let test_env = TestEnv::new();
+        IndexRunner::new(&test_env).with_clangd().assert().success();
+
+        let db = semcode::DatabaseManager::new(
+            test_env.db_path().to_str().unwrap(),
+            test_env.path().to_str().unwrap().to_string(),
+        ).await.unwrap();
+
+        // Verify function enrichment
+        let func = &db.find_all_functions("free_list").await.unwrap()[0];
+        assert!(func.usr.as_ref().unwrap().starts_with("c:@F@"));
+        assert!(func.signature.as_ref().unwrap().contains("free_list"));
+
+        // Verify type enrichment
+        let type_info = db.find_type("Point").await.unwrap().unwrap();
+        assert!(type_info.usr.as_ref().unwrap().starts_with("c:@"));
+    })
+    .await
+    .expect("Test timed out after 5 seconds");
+}
+
+#[tokio::test]
+async fn test_macro_usr_enrichment() {
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        skip_if_no_libclang!();
+
+        let test_env = tempfile::tempdir().unwrap();
+        let fixtures = fixtures_dir();
+
+        for f in ["test_macro_usr.c", "compile_commands_macro_test.json"] {
+            std::fs::copy(fixtures.join(f), test_env.path().join(
+                if f.contains("macro_test") { "compile_commands.json" } else { f }
+            )).unwrap();
+        }
+
+        // Init git
+        for args in [vec!["init", "-q"], vec!["add", "."], vec!["commit", "-qm", "test"]] {
+            assert_cmd::Command::new("git").current_dir(test_env.path()).args(&args).output().unwrap();
+        }
+
+        let db_path = test_env.path().join(".semcode.db");
+        assert_cmd::Command::cargo_bin("semcode-index").unwrap()
+            .current_dir(test_env.path())
+            .args(["--clear", "--source", ".", "--database"])
+            .arg(&db_path)
+            .arg("--use-clangd")
+            .assert()
+            .success();
+
+        let db = semcode::DatabaseManager::new(
+            db_path.to_str().unwrap(),
+            test_env.path().to_str().unwrap().to_string(),
+        ).await.unwrap();
+
+        let mac = db.find_macro("MAX").await.unwrap().unwrap();
+        assert!(mac.usr.as_ref().unwrap().starts_with("c:"));
+    })
+    .await
+    .expect("Test timed out after 5 seconds");
+}

--- a/tests/clangd_multiprocess.rs
+++ b/tests/clangd_multiprocess.rs
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Tests for multi-process clangd enrichment (worker and processor)
+
+mod common;
+
+use semcode::clangd_worker::{WorkRequest, WorkResponse};
+use semcode::ClangdProcessor;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+/// Get the path to semcode-index binary, building it if needed
+/// This prevents stale binary issues when ClangdProcessor spawns worker processes
+fn get_semcode_index_binary() -> PathBuf {
+    // Use cargo_bin! macro from assert_cmd to ensure binary is built fresh
+    // This automatically builds the binary if needed before returning the path
+    assert_cmd::cargo::cargo_bin("semcode-index")
+}
+
+/// Test that worker and processor can be created
+#[tokio::test]
+async fn test_processor_creation() {
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        let binary = get_semcode_index_binary();  // Get fresh binary path
+
+        let temp_dir = TempDir::new().unwrap();
+        let source_root = temp_dir.path().to_path_buf();
+
+        // Create minimal compile_commands.json
+        let compile_commands_path = temp_dir.path().join("compile_commands.json");
+        std::fs::write(
+            &compile_commands_path,
+            r#"[
+  {
+    "directory": ".",
+    "command": "gcc -c test.c",
+    "file": "test.c"
+  }
+]"#,
+        )
+        .unwrap();
+
+        // Create test file
+        std::fs::write(
+            temp_dir.path().join("test.c"),
+            "int main() { return 0; }",
+        )
+        .unwrap();
+
+        // Try to create processor with 2 workers
+        let result = ClangdProcessor::new_with_binary(2, compile_commands_path, source_root, binary);
+
+        // Note: This may fail if libclang is not available
+        // We're just testing the API, not full functionality
+        match result {
+            Ok(_processor) => {
+                // Success! Processor created
+                println!("Processor created successfully");
+            }
+            Err(e) => {
+                // Expected to fail if libclang not available
+                println!("Processor creation failed (expected if no libclang): {}", e);
+            }
+        }
+    })
+    .await
+    .expect("Test timed out after 5 seconds");
+}
+
+/// Test that WorkRequest and WorkResponse can be serialized
+#[test]
+fn test_work_message_serialization() {
+    use semcode::FunctionInfo;
+
+    let func = FunctionInfo {
+        name: "main".to_string(),
+        file_path: "/tmp/test.c".to_string(),
+        git_file_hash: "abc123".to_string(),
+        line_start: 1,
+        line_end: 10,
+        body: "int main() {}".to_string(),
+        return_type: "int".to_string(),
+        canonical_return_type: None,
+        parameters: vec![],
+        calls: None,
+        types: None,
+        calls_precise: None,
+        usr: None,
+        signature: None,
+        overload_index: None,
+    };
+
+    let request = WorkRequest {
+        file_path: PathBuf::from("/tmp/test.c"),
+        functions: vec![func],
+        types: vec![],
+        macros: vec![],
+        git_file_sha: "abc123".to_string(),
+    };
+
+    // Test bincode serialization
+    let encoded = bincode::serialize(&request).unwrap();
+    let decoded: WorkRequest = bincode::deserialize(&encoded).unwrap();
+
+    assert_eq!(decoded.file_path, PathBuf::from("/tmp/test.c"));
+    assert_eq!(decoded.functions.len(), 1);
+    assert_eq!(decoded.functions[0].name, "main");
+    assert_eq!(decoded.git_file_sha, "abc123");
+}
+
+/// Test that empty WorkResponse can be created and serialized
+#[test]
+fn test_empty_work_response_serialization() {
+    let response = WorkResponse {
+        file_path: PathBuf::from("/tmp/test.c"),
+        functions: vec![],
+        types: vec![],
+        macros: vec![],
+        git_file_sha: "abc123".to_string(),
+        had_compile_commands: false,
+    };
+
+    // Test bincode serialization
+    let encoded = bincode::serialize(&response).unwrap();
+    let decoded: WorkResponse = bincode::deserialize(&encoded).unwrap();
+
+    assert_eq!(decoded.file_path, PathBuf::from("/tmp/test.c"));
+    assert_eq!(decoded.functions.len(), 0);
+    assert!(!decoded.had_compile_commands);
+}
+
+/// Test processor statistics tracking
+#[tokio::test]
+async fn test_processor_statistics() {
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        let binary = get_semcode_index_binary();
+        use std::sync::atomic::Ordering;
+
+        let temp_dir = TempDir::new().unwrap();
+        let source_root = temp_dir.path().to_path_buf();
+
+        // Create minimal compile_commands.json
+        let compile_commands_path = temp_dir.path().join("compile_commands.json");
+        std::fs::write(
+            &compile_commands_path,
+            r#"[{"directory": ".", "command": "gcc -c test.c", "file": "test.c"}]"#,
+        )
+        .unwrap();
+
+        std::fs::write(temp_dir.path().join("test.c"), "int main() { return 0; }").unwrap();
+
+        match ClangdProcessor::new_with_binary(1, compile_commands_path, source_root, binary) {
+            Ok(processor) => {
+                // Check that statistics are initialized to zero
+                assert_eq!(processor.files_with_compile_commands.load(Ordering::Relaxed), 0);
+                assert_eq!(processor.enriched_functions.load(Ordering::Relaxed), 0);
+                assert_eq!(processor.enriched_types.load(Ordering::Relaxed), 0);
+                assert_eq!(processor.enriched_macros.load(Ordering::Relaxed), 0);
+                println!("Statistics tracking verified");
+            }
+            Err(e) => {
+                println!("Skipping statistics test (no libclang): {}", e);
+            }
+        }
+    })
+    .await
+    .expect("Test timed out after 5 seconds");
+}
+
+/// Test that processor can be dropped cleanly
+#[tokio::test]
+async fn test_processor_drop() {
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        let binary = get_semcode_index_binary();
+
+        let temp_dir = TempDir::new().unwrap();
+        let source_root = temp_dir.path().to_path_buf();
+
+        let compile_commands_path = temp_dir.path().join("compile_commands.json");
+        std::fs::write(
+            &compile_commands_path,
+            r#"[{"directory": ".", "command": "gcc -c test.c", "file": "test.c"}]"#,
+        )
+        .unwrap();
+
+        std::fs::write(temp_dir.path().join("test.c"), "int main() { return 0; }").unwrap();
+
+        match ClangdProcessor::new_with_binary(2, compile_commands_path, source_root, binary) {
+            Ok(processor) => {
+                // Drop processor - should cleanly shut down workers
+                drop(processor);
+                println!("Processor dropped cleanly");
+            }
+            Err(e) => {
+                println!("Skipping drop test (no libclang): {}", e);
+            }
+        }
+    })
+    .await
+    .expect("Test timed out after 5 seconds");
+}
+
+/// Integration test: Verify worker can be spawned via CLI
+#[test]
+fn test_worker_mode_via_cli() {
+    use assert_cmd::Command;
+    use predicates::prelude::*;
+
+    // Try to run with --clangd-worker flag (should fail due to missing args)
+    // assert_cmd automatically builds the binary fresh before testing
+    Command::cargo_bin("semcode-index")
+        .unwrap()
+        .arg("--clangd-worker")
+        .assert()
+        .failure()  // Expect non-zero exit code
+        .stderr(
+            predicate::str::contains("worker-id")
+                .or(predicate::str::contains("ipc"))
+                .or(predicate::str::contains("required"))
+        );
+}
+
+/// Test with fixtures (if available)
+#[tokio::test]
+async fn test_processor_with_real_code() {
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        let binary = get_semcode_index_binary();
+        use common::*;
+
+        let test_env = TestEnv::new();
+
+        match ClangdProcessor::new_with_binary(
+            2,
+            test_env.path().join("compile_commands.json"),
+            test_env.path().to_path_buf(),
+            binary,
+        ) {
+            Ok(_processor) => {
+                println!("Processor created with real compile_commands.json");
+                // TODO: Submit actual work and verify results
+            }
+            Err(e) => {
+                println!("Skipping real code test (no libclang): {}", e);
+            }
+        }
+    })
+    .await
+    .expect("Test timed out after 5 seconds");
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Common test helpers and fixtures for clangd integration tests
+
+#![allow(dead_code)]
+
+use assert_cmd::Command;
+use rstest::*;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+/// Expected counts for test_sample.c without clangd enrichment
+pub const EXPECTED_FUNCTIONS: u32 = 15;
+pub const EXPECTED_TYPES: u32 = 8;
+pub const EXPECTED_MACROS_WITHOUT_CLANGD: u32 = 4; // Function-like only
+pub const EXPECTED_MACROS_WITH_CLANGD: u32 = 8; // All macros with USRs
+
+/// Test environment wrapper that manages temporary directories and git setup
+pub struct TestEnv {
+    temp_dir: TempDir,
+}
+
+impl TestEnv {
+    /// Create a new test environment with default compile_commands.json
+    pub fn new() -> Self {
+        Self::with_compile_commands("compile_commands.json")
+    }
+
+    /// Create a test environment with a specific compile_commands.json file
+    pub fn with_compile_commands(compile_commands_file: &str) -> Self {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+        // Copy test files from fixtures
+        let fixtures = fixtures_dir();
+        std::fs::copy(
+            fixtures.join("test_sample.c"),
+            temp_dir.path().join("test_sample.c"),
+        )
+        .expect("Failed to copy test_sample.c");
+
+        std::fs::copy(
+            fixtures.join(compile_commands_file),
+            temp_dir.path().join("compile_commands.json"),
+        )
+        .unwrap_or_else(|_| panic!("Failed to copy {}", compile_commands_file));
+
+        // Initialize git (required for indexing)
+        Self::init_git(&temp_dir);
+
+        Self { temp_dir }
+    }
+
+    /// Create a minimal test environment with custom file content
+    pub fn with_custom_file(filename: &str, content: &str) -> Self {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+        std::fs::write(temp_dir.path().join(filename), content)
+            .expect("Failed to write custom file");
+
+        Self::init_git(&temp_dir);
+
+        Self { temp_dir }
+    }
+
+    /// Get the path to the temporary directory
+    pub fn path(&self) -> &std::path::Path {
+        self.temp_dir.path()
+    }
+
+    /// Get the path to the database
+    pub fn db_path(&self) -> PathBuf {
+        self.path().join(".semcode.db")
+    }
+
+    /// Initialize git repository in the temp directory
+    fn init_git(temp_dir: &TempDir) {
+        Command::new("git")
+            .current_dir(temp_dir.path())
+            .args(["init", "-q"])
+            .output()
+            .expect("Failed to init git");
+
+        Command::new("git")
+            .current_dir(temp_dir.path())
+            .args(["add", "."])
+            .output()
+            .expect("Failed to git add");
+
+        Command::new("git")
+            .current_dir(temp_dir.path())
+            .args(["commit", "-qm", "test"])
+            .output()
+            .expect("Failed to git commit");
+    }
+}
+
+/// rstest fixture that provides a clean test environment
+#[fixture]
+pub fn test_env() -> TestEnv {
+    TestEnv::new()
+}
+
+/// Builder for running semcode-index with various options
+pub struct IndexRunner<'a> {
+    env: &'a TestEnv,
+    use_clangd: bool,
+    compile_commands: Option<PathBuf>,
+}
+
+impl<'a> IndexRunner<'a> {
+    /// Create a new index runner for the given test environment
+    pub fn new(env: &'a TestEnv) -> Self {
+        Self {
+            env,
+            use_clangd: false,
+            compile_commands: None,
+        }
+    }
+
+    /// Enable clangd enrichment
+    pub fn with_clangd(mut self) -> Self {
+        self.use_clangd = true;
+        self
+    }
+
+    /// Use a custom compile_commands.json path
+    pub fn with_compile_commands_path(mut self, path: PathBuf) -> Self {
+        self.compile_commands = Some(path);
+        self
+    }
+
+    /// Run semcode-index and return the output
+    pub fn run(self) -> std::process::Output {
+        let mut cmd = Command::cargo_bin("semcode-index").expect("Failed to find semcode-index");
+
+        cmd.current_dir(self.env.path())
+            .arg("--clear")
+            .arg("--source")
+            .arg(".")
+            .arg("--database")
+            .arg(self.env.db_path());
+
+        if self.use_clangd {
+            cmd.arg("--use-clangd");
+        }
+
+        if let Some(cc_path) = self.compile_commands {
+            cmd.arg("--compile-commands").arg(cc_path);
+        }
+
+        cmd.output().expect("Failed to run semcode-index")
+    }
+
+    /// Run and return an assert_cmd::Assert for fluent assertions
+    pub fn assert(self) -> assert_cmd::assert::Assert {
+        let mut cmd = Command::cargo_bin("semcode-index").expect("Failed to find semcode-index");
+
+        cmd.current_dir(self.env.path())
+            .arg("--clear")
+            .arg("--source")
+            .arg(".")
+            .arg("--database")
+            .arg(self.env.db_path());
+
+        if self.use_clangd {
+            cmd.arg("--use-clangd");
+        }
+
+        if let Some(cc_path) = self.compile_commands {
+            cmd.arg("--compile-commands").arg(cc_path);
+        }
+
+        cmd.assert()
+    }
+}
+
+/// Helper for asserting on command output
+pub struct OutputAsserter {
+    pub stderr: String,
+    pub combined: String,
+}
+
+impl OutputAsserter {
+    /// Create a new output asserter from command output
+    pub fn new(output: &std::process::Output) -> Self {
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let combined = format!("{}{}", stdout, stderr);
+
+        Self {
+            stderr,
+            combined,
+        }
+    }
+
+    /// Assert that the command succeeded
+    pub fn assert_success(&self, output: &std::process::Output) {
+        assert!(
+            output.status.success(),
+            "Command failed:\n{}",
+            self.combined
+        );
+    }
+
+    /// Assert expected indexing counts
+    pub fn assert_counts(&self, functions: u32, types: u32, macros: u32) {
+        assert!(
+            self.combined
+                .contains(&format!("Functions indexed: {}", functions)),
+            "Expected {} functions. Output:\n{}",
+            functions,
+            self.combined
+        );
+        assert!(
+            self.combined
+                .contains(&format!("Types indexed: {}", types)),
+            "Expected {} types. Output:\n{}",
+            types,
+            self.combined
+        );
+        assert!(
+            self.combined
+                .contains(&format!("Macros indexed: {}", macros)),
+            "Expected {} macros. Output:\n{}",
+            macros,
+            self.combined
+        );
+    }
+
+    /// Assert that enrichment statistics are present
+    pub fn assert_enrichment_stats(&self) {
+        assert!(
+            self.combined.contains("Clangd Enrichment Statistics"),
+            "Should show enrichment statistics. Output:\n{}",
+            self.combined
+        );
+    }
+
+    /// Assert enrichment counts
+    pub fn assert_enrichment_counts(&self, functions: u32, types: u32) {
+        assert!(
+            self.combined
+                .contains(&format!("Functions enriched with USR: {}", functions)),
+            "Expected {} functions enriched. Output:\n{}",
+            functions,
+            self.combined
+        );
+        assert!(
+            self.combined
+                .contains(&format!("Types enriched with USR: {}", types)),
+            "Expected {} types enriched. Output:\n{}",
+            types,
+            self.combined
+        );
+    }
+
+    /// Assert that compile commands were found
+    pub fn assert_compile_commands(&self, count: u32) {
+        assert!(
+            self.combined
+                .contains(&format!("Files with compile commands: {}", count)),
+            "Expected {} files with compile commands. Output:\n{}",
+            count,
+            self.combined
+        );
+    }
+
+    /// Assert no enrichment occurred
+    pub fn assert_no_enrichment(&self) {
+        assert!(
+            !self.combined.contains("Clangd Enrichment Statistics"),
+            "Should not show enrichment without --use-clangd. Output:\n{}",
+            self.combined
+        );
+        assert!(
+            !self.combined.contains("Functions enriched with USR"),
+            "Should not show USR enrichment. Output:\n{}",
+            self.combined
+        );
+    }
+
+    /// Assert that output contains a pattern
+    pub fn assert_contains(&self, pattern: &str) {
+        assert!(
+            self.combined.contains(pattern),
+            "Output should contain '{}'. Output:\n{}",
+            pattern,
+            self.combined
+        );
+    }
+
+    /// Assert that output does NOT contain a pattern
+    pub fn assert_not_contains(&self, pattern: &str) {
+        assert!(
+            !self.combined.contains(pattern),
+            "Output should NOT contain '{}'. Output:\n{}",
+            pattern,
+            self.combined
+        );
+    }
+}
+
+/// Get the path to test fixtures directory
+pub fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("clangd_integration")
+}
+
+/// Check if libclang is available on this system (Linux only)
+pub fn is_libclang_available() -> bool {
+    use std::process::Command;
+
+    // Try to find libclang using ldconfig
+    if let Ok(output) = Command::new("ldconfig").arg("-p").output() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if stdout.contains("libclang.so") || stdout.contains("libclang-") {
+            return true;
+        }
+    }
+
+    // Fallback: check common library paths
+    std::path::Path::new("/usr/lib/libclang.so").exists()
+        || std::path::Path::new("/usr/lib/x86_64-linux-gnu/libclang.so").exists()
+        || std::path::Path::new("/usr/lib64/libclang.so").exists()
+}
+
+/// Skip test if libclang is not available
+#[macro_export]
+macro_rules! skip_if_no_libclang {
+    () => {
+        if !$crate::common::is_libclang_available() {
+            eprintln!("Skipping test: libclang not available");
+            return;
+        }
+    };
+}
+
+/// Predicates for common assertions
+pub mod predicates {
+    use predicates::str::ContainsPredicate;
+
+    /// Predicate that matches enrichment statistics output
+    pub fn has_enrichment_stats() -> ContainsPredicate {
+        predicates::str::contains("Clangd Enrichment Statistics")
+    }
+
+    /// Predicate that matches function count
+    pub fn has_function_count(count: u32) -> ContainsPredicate {
+        predicates::str::contains(format!("Functions indexed: {}", count))
+    }
+
+    /// Predicate that matches type count
+    pub fn has_type_count(count: u32) -> ContainsPredicate {
+        predicates::str::contains(format!("Types indexed: {}", count))
+    }
+
+    /// Predicate that matches macro count
+    pub fn has_macro_count(count: u32) -> ContainsPredicate {
+        predicates::str::contains(format!("Macros indexed: {}", count))
+    }
+
+    /// Predicate that matches enriched function count
+    pub fn has_enriched_functions(count: u32) -> ContainsPredicate {
+        predicates::str::contains(format!("Functions enriched with USR: {}", count))
+    }
+
+    /// Predicate that matches enriched type count
+    pub fn has_enriched_types(count: u32) -> ContainsPredicate {
+        predicates::str::contains(format!("Types enriched with USR: {}", count))
+    }
+}


### PR DESCRIPTION
Add a clangd integration to enrich semcode data. Enrichment of individual capabilities and ci setup to run tests will be in subsequent commits.

This increases indexing time by ~1 minute but enables the retention of macros which would otherwise have to be pruned due to snr. Additionally, for mcp in particular, we should be able to get lightning fast query/response loops with the highest quality data (i.e. clangd, when it works) with this. This commit starts exposing clangd information via semcode mcp to confirm that ingest and retrieval flows work.

This commit also starts adding tests/sets up the manner in which tests can be added such that we can avoid regressions as we go along with somewhat wild expansions like this.

I'm not sure this is the direction we want to go in so posting this pretty early (i.e. it works but i need to go over it again, in depth), but, i think a way we can take this is to add more and more means of exposing data about code (such as clangd data) and alternate representations of code (i.e. summaries, or ast's) that are more token efficient rapidly via mcp (i.e. give the bots ways to ask information dense, accurate, brief questions about code with responses with similar qualities and make that fast).

===== indexing output:
Pipeline processing completed successfully

=== Pipeline Processing Complete ===
Files processed: 91070
Functions indexed: 858818
Types indexed: 156968
Macros indexed: 142326

=== Clangd Enrichment Statistics ===
Files with compile commands: 2860
Functions enriched with USR: 73953
Types enriched with USR: 2421
Macros enriched with USR: 10086
Non-function-like macros kept due to clangd USR: 7573

Compacting database to optimize performance...
Database compaction completed in 14.5s

Starting database optimization...
Database optimization completed successfully

=== Embedded Data Statistics ===
Call relationships: embedded in function/macro JSON columns
Function-type mappings: embedded in function JSON columns
Type-type mappings: embedded in type JSON columns

To query this database, run:
  semcode --database ./.semcode.db

Printing performance statistics...

=== Performance Statistics ===
database_batch_insert          count=   116 avg=  902.88ms min=   28.76ms max= 4168.65ms total= 104734.04ms
database_optimization          count=     1 avg=23906.43ms min=23906.43ms max=23906.43ms total=  23906.43ms
db_insert_combined             count=   116 avg=  902.40ms min=   28.18ms max= 4168.16ms total= 104678.25ms
db_mark_files_processed        count=   116 avg=   50.26ms min=   15.99ms max=  592.69ms total=   5830.36ms
pipeline_processing            count=     1 avg=128164.25ms min=128164.25ms max=128164.25ms total= 128164.25ms
treesitter_parse               count= 91070 avg=    7.41ms min=    0.00ms max= 2757.80ms total= 674701.98ms

Total time tracked: 1042.02s


===== example of lsp data being surfaced:
semcode> func pick_next_task
Searching for function or macro: pick_next_task (git SHA: 4ab715af46d9f2f72ad0c0e6cf55b9702335ed0a)

=== Function Information ===
Name: pick_next_task
File: kernel/sched/core.c
Hash: 198d2dd45f59cbcc0e6e7689eb7a9811969241d0
Lines: 6042 - 6269
USR: c:core.c@F@pick_next_task

Declaration: pick_next_task(struct rq *, struct task_struct *, struct rq_flags *)
Canonical Return Type: struct task_struct *

Function Definition:
────────────────────────────────────────────────────────────────────────────────
static struct task_struct *
pick_next_task(struct rq *rq, struct task_struct *prev, struct rq_flags *rf)