### PR TITLE
semcode: performance improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,7 +373,7 @@ Honors standard proxy environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) 
 ### Implementation Details
 
 The search leverages Semcode's content deduplication system:
-- Function bodies are stored in a separate `content` table with Blake3 hashes
+- Function bodies are stored in a separate `content` table with gxhash128 hashes
 - Regex search first finds matching content entries
 - Content hashes are then used to locate corresponding functions
 - Path filtering is applied as a post-processing step for refined results

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ tower-lsp = "0.20"      # Language Server Protocol framework for LSP server
 url = "2.5"             # URL parsing for file URIs in LSP
 similar = { version = "2.7", features = ["text"] }  # Proper diff algorithm for commit diffs
 shlex = "1.3"           # Shell-like parsing for quoted strings in CLI
+gxhash = {version = "3.4", features =["deterministic"]}          # Fast HashMap/HashSet with SIMD acceleration
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
@@ -86,6 +87,11 @@ path = "src/bin/semcode-mcp.rs"
 [[bin]]
 name = "semcode-lsp"
 path = "src/bin/semcode-lsp.rs"
+
+[profile.dev]
+rustflags = [
+  "-C", "target-cpu=native",             # tune for your CPU; enables all supported instructions (required for gxhash)
+]
 
 [profile.release]
 debug = false          # no debug

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ url = "2.5"             # URL parsing for file URIs in LSP
 similar = { version = "2.7", features = ["text"] }  # Proper diff algorithm for commit diffs
 shlex = "1.3"           # Shell-like parsing for quoted strings in CLI
 gxhash = {version = "3.4", features =["deterministic"]}          # Fast HashMap/HashSet with SIMD acceleration
+mimalloc = "0.1"        # Fast allocator (10-20% faster than system malloc, works on Linux and macOS)
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ similar = { version = "2.7", features = ["text"] }  # Proper diff algorithm for 
 shlex = "1.3"           # Shell-like parsing for quoted strings in CLI
 gxhash = {version = "3.4", features =["deterministic"]}          # Fast HashMap/HashSet with SIMD acceleration
 mimalloc = "0.1"        # Fast allocator (10-20% faster than system malloc, works on Linux and macOS)
+smallvec = { version = "1.13", features = ["serde", "union"] }  # Stack-allocated vectors for small collections (avoids heap allocation)
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ streaming-iterator = "0.1"
 once_cell = "1.20"
 crossbeam-channel = "0.5"
 sha1 = "0.10"
-blake3 = "1.8.2"
 hex = "0.4"
 dashmap = "6.1"
 tempfile = "3.14"
@@ -51,7 +50,7 @@ tower-lsp = "0.20"      # Language Server Protocol framework for LSP server
 url = "2.5"             # URL parsing for file URIs in LSP
 similar = { version = "2.7", features = ["text"] }  # Proper diff algorithm for commit diffs
 shlex = "1.3"           # Shell-like parsing for quoted strings in CLI
-gxhash = {version = "3.4", features =["deterministic"]}          # Fast HashMap/HashSet with SIMD acceleration
+gxhash = { version = "3.4", features = ["deterministic"] }  # Fast HashMap/HashSet with SIMD acceleration (deterministic for reproducible hashing)
 mimalloc = "0.1"        # Fast allocator (10-20% faster than system malloc, works on Linux and macOS)
 smallvec = { version = "1.13", features = ["serde", "union"] }  # Stack-allocated vectors for small collections (avoids heap allocation)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,10 @@ harness = false
 name = "io_operations"
 harness = false
 
+[[bench]]
+name = "collection_operations"
+harness = false
+
 [[bin]]
 name = "semcode-index"
 path = "src/bin/index.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,25 @@ url = "2.5"             # URL parsing for file URIs in LSP
 similar = { version = "2.7", features = ["text"] }  # Proper diff algorithm for commit diffs
 shlex = "1.3"           # Shell-like parsing for quoted strings in CLI
 
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
+
+[[bench]]
+name = "core_operations"
+harness = false
+
+[[bench]]
+name = "treesitter_parsing"
+harness = false
+
+[[bench]]
+name = "database_operations"
+harness = false
+
+[[bench]]
+name = "io_operations"
+harness = false
+
 [[bin]]
 name = "semcode-index"
 path = "src/bin/index.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
+cargo-features = ["profile-rustflags"]  # Not needed past Rust 1.80 stable, kept for compatibility
+
 [package]
 name = "semcode"
 version = "0.1.0"
@@ -86,4 +88,20 @@ name = "semcode-lsp"
 path = "src/bin/semcode-lsp.rs"
 
 [profile.release]
-debug = false
+debug = false          # no debug
+opt-level = 3          # max performance (O3)
+# painfully slow, but better.
+# lto = "fat"            # full link-time optimization across crates
+# codegen-units = 1      # single codegen unit for better optimization
+# incremental = false    # always fully optimize
+# not as good, but tolerable build times.
+lto = "thin"
+incremental = true     # implicitly set codegen units to 256
+#
+panic = "abort"        # remove unwinding runtime
+strip = "symbols"      # remove debug symbols
+overflow-checks = false # no runtime overflow checks
+rpath = false          # omit runtime search paths
+rustflags = [
+  "-C", "target-cpu=native",             # tune for your CPU; enables all supported instructions
+]

--- a/benches/collection_operations.rs
+++ b/benches/collection_operations.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Collection operation performance benchmarks
+//
+// Run with: cargo bench --bench collection_operations
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use semcode::collection_utils::collect_paths;
+
+#[derive(Clone)]
+struct TestItem {
+    path: String,
+}
+
+// Benchmark path collection from various sizes
+fn bench_collect_paths(c: &mut Criterion) {
+    let mut group = c.benchmark_group("collect_paths");
+
+    // Small collection (10 items)
+    let small_items: Vec<TestItem> = (0..10)
+        .map(|i| TestItem {
+            path: format!("src/file_{}.rs", i),
+        })
+        .collect();
+    group.throughput(Throughput::Elements(10));
+    group.bench_function("collect_10_paths", |b| {
+        b.iter(|| collect_paths(black_box(&small_items), |item| item.path.clone()))
+    });
+
+    // Medium collection (100 items)
+    let medium_items: Vec<TestItem> = (0..100)
+        .map(|i| TestItem {
+            path: format!("src/file_{}.rs", i),
+        })
+        .collect();
+    group.throughput(Throughput::Elements(100));
+    group.bench_function("collect_100_paths", |b| {
+        b.iter(|| collect_paths(black_box(&medium_items), |item| item.path.clone()))
+    });
+
+    // Large collection (1000 items) - typical threshold
+    let large_items: Vec<TestItem> = (0..1000)
+        .map(|i| TestItem {
+            path: format!("src/file_{}.rs", i),
+        })
+        .collect();
+    group.throughput(Throughput::Elements(1000));
+    group.bench_function("collect_1000_paths", |b| {
+        b.iter(|| collect_paths(black_box(&large_items), |item| item.path.clone()))
+    });
+
+    // Very large collection (5000 items)
+    let very_large_items: Vec<TestItem> = (0..5000)
+        .map(|i| TestItem {
+            path: format!("src/file_{}.rs", i),
+        })
+        .collect();
+    group.throughput(Throughput::Elements(5000));
+    group.bench_function("collect_5000_paths", |b| {
+        b.iter(|| collect_paths(black_box(&very_large_items), |item| item.path.clone()))
+    });
+
+    // Collection with duplicates (1000 items, 500 unique)
+    let items_with_dups: Vec<TestItem> = (0..1000)
+        .map(|i| TestItem {
+            path: format!("src/file_{}.rs", i % 500),
+        })
+        .collect();
+    group.throughput(Throughput::Elements(1000));
+    group.bench_function("collect_1000_paths_with_duplicates", |b| {
+        b.iter(|| collect_paths(black_box(&items_with_dups), |item| item.path.clone()))
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_collect_paths);
+criterion_main!(benches);

--- a/benches/core_operations.rs
+++ b/benches/core_operations.rs
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Core performance benchmarks for semcode operations
+//
+// Run with: cargo bench --bench core_operations
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use semcode::text_utils::preprocess_code;
+
+// Sample C code snippets of various sizes
+const SMALL_CODE: &str = r#"
+int add(int a, int b) {
+    return a + b;
+}
+"#;
+
+const MEDIUM_CODE: &str = r#"
+struct data_structure {
+    int value;
+    char *name;
+    struct data_structure *next;
+};
+
+int process_data(struct data_structure *ds) {
+    int result = 0;
+    while (ds != NULL) {
+        result += ds->value;
+        ds = ds->next;
+    }
+    return result;
+}
+
+void init_data(struct data_structure *ds, int val) {
+    ds->value = val;
+    ds->name = NULL;
+    ds->next = NULL;
+}
+"#;
+
+const LARGE_CODE: &str = r#"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct node {
+    int data;
+    struct node *left;
+    struct node *right;
+} node_t;
+
+node_t* create_node(int data) {
+    node_t *new_node = (node_t*)malloc(sizeof(node_t));
+    if (new_node == NULL) {
+        return NULL;
+    }
+    new_node->data = data;
+    new_node->left = NULL;
+    new_node->right = NULL;
+    return new_node;
+}
+
+void insert_node(node_t **root, int data) {
+    if (*root == NULL) {
+        *root = create_node(data);
+        return;
+    }
+    if (data < (*root)->data) {
+        insert_node(&(*root)->left, data);
+    } else {
+        insert_node(&(*root)->right, data);
+    }
+}
+
+int search_tree(node_t *root, int target) {
+    if (root == NULL) {
+        return 0;
+    }
+    if (root->data == target) {
+        return 1;
+    }
+    if (target < root->data) {
+        return search_tree(root->left, target);
+    }
+    return search_tree(root->right, target);
+}
+
+void free_tree(node_t *root) {
+    if (root == NULL) {
+        return;
+    }
+    free_tree(root->left);
+    free_tree(root->right);
+    free(root);
+}
+"#;
+
+// Benchmark text preprocessing (called before vectorization)
+fn bench_text_preprocessing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("text_preprocessing");
+
+    for (name, code) in [
+        ("small", SMALL_CODE),
+        ("medium", MEDIUM_CODE),
+        ("large", LARGE_CODE),
+    ] {
+        group.throughput(Throughput::Bytes(code.len() as u64));
+
+        group.bench_with_input(BenchmarkId::new("preprocess", name), code, |b, code| {
+            b.iter(|| preprocess_code(black_box(code)))
+        });
+    }
+
+    group.finish();
+}
+
+// Benchmark JSON operations (used for embedded relationships in database)
+fn bench_json_operations(c: &mut Criterion) {
+    use semcode::types::ParameterInfo;
+
+    let mut group = c.benchmark_group("json_operations");
+
+    // Use actual ParameterInfo structure from semcode (used in function deserialization)
+    let params = vec![
+        ParameterInfo {
+            name: "param1".to_string(),
+            type_name: "int".to_string(),
+            type_file_path: None,
+            type_git_file_hash: None,
+        },
+        ParameterInfo {
+            name: "param2".to_string(),
+            type_name: "char*".to_string(),
+            type_file_path: None,
+            type_git_file_hash: None,
+        },
+        ParameterInfo {
+            name: "param3".to_string(),
+            type_name: "struct data*".to_string(),
+            type_file_path: Some("/usr/include/data.h".to_string()),
+            type_git_file_hash: Some("abc123".to_string()),
+        },
+    ];
+    let params_str = serde_json::to_string(&params).unwrap();
+
+    group.bench_function("serialize_parameters", |b| {
+        b.iter(|| serde_json::to_string(black_box(&params)))
+    });
+
+    group.bench_function("deserialize_parameters", |b| {
+        b.iter(|| {
+            let _: Vec<ParameterInfo> = serde_json::from_str(black_box(&params_str)).unwrap();
+        })
+    });
+
+    group.finish();
+}
+
+// Benchmark regex search operations (grep_function_bodies uses LanceDB regexp_match)
+fn bench_regex_search(c: &mut Criterion) {
+    use semcode::types::FunctionInfo;
+    use semcode::DatabaseManager;
+    use tempfile::TempDir;
+    use tokio::runtime::Runtime;
+
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("regex_search");
+
+    // Setup: create a database with test functions
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("bench.db");
+
+    rt.block_on(async {
+        let db: DatabaseManager = DatabaseManager::new(
+            db_path.to_str().unwrap(),
+            temp_dir.path().to_string_lossy().to_string(),
+        )
+        .await
+        .unwrap();
+        db.create_tables().await.unwrap();
+
+        // Insert test functions with different body patterns
+        let functions = vec![
+            FunctionInfo {
+                name: "process_user_data".to_string(),
+                file_path: "/test/users.c".to_string(),
+                git_file_hash: "hash1".to_string(),
+                line_start: 10,
+                line_end: 20,
+                return_type: "int".to_string(),
+                parameters: vec![],
+                body: "int process_user_data(struct user *u) { return validate_user(u); }"
+                    .to_string(),
+                calls: None,
+                types: None,
+            },
+            FunctionInfo {
+                name: "process_system_data".to_string(),
+                file_path: "/test/system.c".to_string(),
+                git_file_hash: "hash2".to_string(),
+                line_start: 30,
+                line_end: 40,
+                return_type: "void".to_string(),
+                parameters: vec![],
+                body: "void process_system_data(int flags) { handle_flags(flags); }".to_string(),
+                calls: None,
+                types: None,
+            },
+            FunctionInfo {
+                name: "handle_request".to_string(),
+                file_path: "/test/network.c".to_string(),
+                git_file_hash: "hash3".to_string(),
+                line_start: 50,
+                line_end: 60,
+                return_type: "void".to_string(),
+                parameters: vec![],
+                body: "void handle_request(void) { parse_request(); }".to_string(),
+                calls: None,
+                types: None,
+            },
+        ];
+
+        db.insert_batch_combined(functions, vec![], vec![])
+            .await
+            .unwrap();
+    });
+
+    // Benchmark regex search (uses LanceDB's regexp_match)
+    group.bench_function("grep_function_bodies", |b| {
+        b.to_async(&rt).iter(|| async {
+            let db: DatabaseManager = DatabaseManager::new(
+                db_path.to_str().unwrap(),
+                temp_dir.path().to_string_lossy().to_string(),
+            )
+            .await
+            .unwrap();
+
+            db.grep_function_bodies(black_box(r"process_\w+_data"), None, 100)
+                .await
+                .unwrap()
+        });
+    });
+
+    group.finish();
+}
+
+// Benchmark std HashMap/HashSet operations (baseline before GxHashMap optimization)
+fn bench_hashmap_operations(c: &mut Criterion) {
+    use std::collections::{HashMap, HashSet};
+
+    let mut group = c.benchmark_group("hashmap_operations");
+
+    // Benchmark hash insertion patterns from connection.rs
+    group.throughput(Throughput::Elements(1000));
+    group.bench_function("hashmap_insert_1000", |b| {
+        b.iter(|| {
+            let mut map: HashMap<String, usize> = HashMap::new();
+            for i in 0..1000 {
+                map.insert(format!("key_{}", i), i);
+            }
+            black_box(map)
+        })
+    });
+
+    // Benchmark lookup patterns (common in symbol resolution)
+    group.bench_function("hashmap_lookup_1000", |b| {
+        let mut map: HashMap<String, usize> = HashMap::new();
+        for i in 0..1000 {
+            map.insert(format!("key_{}", i), i);
+        }
+
+        b.iter(|| {
+            for i in 0..1000 {
+                black_box(map.get(&format!("key_{}", i)));
+            }
+        })
+    });
+
+    // Benchmark HashSet patterns from git manifest filtering
+    group.throughput(Throughput::Elements(10000));
+    group.bench_function("hashset_contains_10000", |b| {
+        let set: HashSet<String> = (0..10000).map(|i| format!("hash{}", i)).collect();
+
+        b.iter(|| {
+            for i in 0..10000 {
+                black_box(set.contains(&format!("hash{}", i)));
+            }
+        })
+    });
+
+    // Benchmark HashSet building from iterator (used in get_function_callers_git_aware)
+    group.bench_function("hashset_from_iter_10000", |b| {
+        let values: Vec<String> = (0..10000).map(|i| format!("hash{}", i)).collect();
+
+        b.iter(|| {
+            let set: HashSet<String> = black_box(&values).iter().cloned().collect();
+            black_box(set)
+        })
+    });
+
+    group.finish();
+}
+
+// Benchmark Vec allocation patterns (baseline before SmallVec optimization)
+fn bench_vec_operations(c: &mut Criterion) {
+    use semcode::types::ParameterInfo;
+
+    let mut group = c.benchmark_group("vec_operations");
+
+    // Benchmark Vec allocation (common case: <=10 params, 99.9% of functions)
+    group.bench_function("vec_params_small", |b| {
+        b.iter(|| {
+            let mut params: Vec<ParameterInfo> = Vec::new();
+            for i in 0..5 {
+                params.push(ParameterInfo {
+                    name: format!("param{}", i),
+                    type_name: "int".to_string(),
+                    type_file_path: None,
+                    type_git_file_hash: None,
+                });
+            }
+            black_box(params)
+        })
+    });
+
+    // Benchmark Vec allocation at typical capacity (10 params)
+    group.bench_function("vec_params_medium", |b| {
+        b.iter(|| {
+            let mut params: Vec<ParameterInfo> = Vec::new();
+            for i in 0..10 {
+                params.push(ParameterInfo {
+                    name: format!("param{}", i),
+                    type_name: "int".to_string(),
+                    type_file_path: None,
+                    type_git_file_hash: None,
+                });
+            }
+            black_box(params)
+        })
+    });
+
+    // Benchmark Vec allocation for larger case (>10 params, 0.1% of functions)
+    group.bench_function("vec_params_large", |b| {
+        b.iter(|| {
+            let mut params: Vec<ParameterInfo> = Vec::new();
+            for i in 0..15 {
+                params.push(ParameterInfo {
+                    name: format!("param{}", i),
+                    type_name: "int".to_string(),
+                    type_file_path: None,
+                    type_git_file_hash: None,
+                });
+            }
+            black_box(params)
+        })
+    });
+
+    // Benchmark Vec for struct fields (typical: 15 fields)
+    group.bench_function("vec_fields_medium", |b| {
+        b.iter(|| {
+            let mut fields: Vec<String> = Vec::new();
+            for i in 0..15 {
+                fields.push(format!("field_{}", i));
+            }
+            black_box(fields)
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_text_preprocessing,
+    bench_json_operations,
+    bench_regex_search,
+    bench_hashmap_operations,
+    bench_vec_operations,
+);
+criterion_main!(benches);

--- a/benches/database_operations.rs
+++ b/benches/database_operations.rs
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Database operation performance benchmarks
+//
+// Run with: cargo bench --bench database_operations
+// Note: These benchmarks require a temporary database and are heavier
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use semcode::types::{FunctionInfo, MacroInfo, TypeInfo};
+use semcode::DatabaseManager;
+use tempfile::TempDir;
+use tokio::runtime::Runtime;
+
+// Helper to create test data matching real-world function patterns
+// Parameters: Most functions have 0-5 params
+// Bodies: Realistic length for C functions (~50-200 chars)
+fn create_test_functions(count: usize) -> Vec<FunctionInfo> {
+    (0..count)
+        .map(|i| FunctionInfo {
+            name: format!("test_function_{}", i),
+            file_path: format!("/test/file_{}.c", i % 100),
+            git_file_hash: format!("hash{}", i % 50),
+            line_start: i as u32,
+            line_end: (i + 10) as u32,
+            return_type: "int".to_string(),
+            parameters: vec![],
+            body: format!("void test_function_{}() {{ return {}; }}", i, i),
+            calls: None,
+            types: None,
+        })
+        .collect()
+}
+
+fn create_test_types(count: usize) -> Vec<TypeInfo> {
+    (0..count)
+        .map(|i| TypeInfo {
+            name: format!("test_type_{}", i),
+            file_path: format!("/test/file_{}.c", i % 100),
+            git_file_hash: format!("hash{}", i % 50),
+            line_start: i as u32,
+            kind: "struct".to_string(),
+            size: None,
+            members: vec![],
+            definition: format!("struct test_type_{} {{ int field; }};", i),
+            types: None,
+        })
+        .collect()
+}
+
+fn create_test_macros(count: usize) -> Vec<MacroInfo> {
+    (0..count)
+        .map(|i| MacroInfo {
+            name: format!("TEST_MACRO_{}", i),
+            file_path: format!("/test/file_{}.c", i % 100),
+            git_file_hash: format!("hash{}", i % 50),
+            line_start: i as u32,
+            is_function_like: false,
+            parameters: None,
+            definition: format!("#define TEST_MACRO_{} {}", i, i),
+            calls: None,
+            types: None,
+        })
+        .collect()
+}
+
+// Benchmark batch insertion performance
+fn bench_batch_insertion(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("batch_insertion");
+
+    for batch_size in [100, 1000, 5000] {
+        group.throughput(Throughput::Elements(batch_size as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("combined_insert", batch_size),
+            &batch_size,
+            |b, &size| {
+                b.to_async(&rt).iter(|| async move {
+                    let temp_dir = TempDir::new().unwrap();
+                    let db_path = temp_dir.path().join("bench.db");
+                    let db: DatabaseManager = DatabaseManager::new(
+                        db_path.to_str().unwrap(),
+                        temp_dir.path().to_string_lossy().to_string(),
+                    )
+                    .await
+                    .unwrap();
+                    db.create_tables().await.unwrap();
+
+                    let functions = create_test_functions(size);
+                    let types = create_test_types(size / 2);
+                    let macros = create_test_macros(size / 4);
+
+                    db.insert_batch_combined(
+                        black_box(functions),
+                        black_box(types),
+                        black_box(macros),
+                    )
+                    .await
+                    .unwrap();
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// Benchmark search operations
+fn bench_search_operations(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("search_operations");
+
+    // Setup: create a database with test data
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("bench.db");
+
+    rt.block_on(async {
+        let db: DatabaseManager = DatabaseManager::new(
+            db_path.to_str().unwrap(),
+            temp_dir.path().to_string_lossy().to_string(),
+        )
+        .await
+        .unwrap();
+        db.create_tables().await.unwrap();
+
+        // Insert 10,000 test functions
+        let functions = create_test_functions(10000);
+        let types = create_test_types(5000);
+        let macros = create_test_macros(2500);
+
+        db.insert_batch_combined(functions, types, macros)
+            .await
+            .unwrap();
+    });
+
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("search_functions_exact", |b| {
+        b.to_async(&rt).iter(|| async {
+            let db: DatabaseManager = DatabaseManager::new(
+                db_path.to_str().unwrap(),
+                temp_dir.path().to_string_lossy().to_string(),
+            )
+            .await
+            .unwrap();
+
+            db.search_functions_fuzzy(black_box("test_function_5000"))
+                .await
+                .unwrap()
+        });
+    });
+
+    group.bench_function("search_functions_fuzzy", |b| {
+        b.to_async(&rt).iter(|| async {
+            let db: DatabaseManager = DatabaseManager::new(
+                db_path.to_str().unwrap(),
+                temp_dir.path().to_string_lossy().to_string(),
+            )
+            .await
+            .unwrap();
+
+            db.search_functions_fuzzy(black_box("test_function"))
+                .await
+                .unwrap()
+        });
+    });
+
+    group.bench_function("find_function_git_aware", |b| {
+        b.to_async(&rt).iter(|| async {
+            let db: DatabaseManager = DatabaseManager::new(
+                db_path.to_str().unwrap(),
+                temp_dir.path().to_string_lossy().to_string(),
+            )
+            .await
+            .unwrap();
+
+            db.find_function_git_aware(black_box("test_function_5000"), black_box("test_commit"))
+                .await
+                .unwrap()
+        });
+    });
+
+    group.finish();
+}
+
+// Benchmark content deduplication overhead
+fn bench_content_deduplication(c: &mut Criterion) {
+    use semcode::hash::compute_blake3_hash;
+
+    let mut group = c.benchmark_group("content_deduplication");
+
+    let bodies: Vec<String> = (0..1000)
+        .map(|i| format!("void func_{}() {{ return {}; }}", i, i))
+        .collect();
+
+    group.throughput(Throughput::Elements(bodies.len() as u64));
+
+    group.bench_function("hash_all_bodies", |b| {
+        b.iter(|| {
+            bodies
+                .iter()
+                .map(|body| compute_blake3_hash(black_box(body)))
+                .collect::<Vec<_>>()
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_batch_insertion,
+    bench_search_operations,
+    bench_content_deduplication,
+);
+criterion_main!(benches);

--- a/benches/database_operations.rs
+++ b/benches/database_operations.rs
@@ -185,7 +185,7 @@ fn bench_search_operations(c: &mut Criterion) {
 
 // Benchmark content deduplication overhead
 fn bench_content_deduplication(c: &mut Criterion) {
-    use semcode::hash::compute_blake3_hash;
+    use semcode::hash::compute_gxhash;
 
     let mut group = c.benchmark_group("content_deduplication");
 
@@ -199,7 +199,7 @@ fn bench_content_deduplication(c: &mut Criterion) {
         b.iter(|| {
             bodies
                 .iter()
-                .map(|body| compute_blake3_hash(black_box(body)))
+                .map(|body| compute_gxhash(black_box(body)))
                 .collect::<Vec<_>>()
         })
     });

--- a/benches/database_operations.rs
+++ b/benches/database_operations.rs
@@ -8,11 +8,12 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use semcode::types::{FunctionInfo, MacroInfo, TypeInfo};
 use semcode::DatabaseManager;
+use smallvec::SmallVec;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
 
 // Helper to create test data matching real-world function patterns
-// Parameters: Most functions have 0-5 params
+// Parameters: Most functions have 0-5 params (SmallVec stays on stack)
 // Bodies: Realistic length for C functions (~50-200 chars)
 fn create_test_functions(count: usize) -> Vec<FunctionInfo> {
     (0..count)
@@ -23,7 +24,7 @@ fn create_test_functions(count: usize) -> Vec<FunctionInfo> {
             line_start: i as u32,
             line_end: (i + 10) as u32,
             return_type: "int".to_string(),
-            parameters: vec![],
+            parameters: SmallVec::new(),
             body: format!("void test_function_{}() {{ return {}; }}", i, i),
             calls: None,
             types: None,
@@ -40,7 +41,7 @@ fn create_test_types(count: usize) -> Vec<TypeInfo> {
             line_start: i as u32,
             kind: "struct".to_string(),
             size: None,
-            members: vec![],
+            members: SmallVec::new(),
             definition: format!("struct test_type_{} {{ int field; }};", i),
             types: None,
         })

--- a/benches/io_operations.rs
+++ b/benches/io_operations.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// I/O operation performance benchmarks
+//
+// Run with: cargo bench --bench io_operations
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use semcode::search::{dump_functions, dump_macros, dump_types};
+use semcode::types::{FunctionInfo, MacroInfo, TypeInfo};
+use semcode::DatabaseManager;
+use tempfile::TempDir;
+use tokio::runtime::Runtime;
+
+// Helper to create test data matching real-world function patterns
+// Parameters: Most functions have 0-5 params
+// Bodies: Realistic length for C functions (~50-200 chars)
+fn create_test_functions(count: usize) -> Vec<FunctionInfo> {
+    (0..count)
+        .map(|i| FunctionInfo {
+            name: format!("test_function_{}", i),
+            file_path: format!("/test/file_{}.c", i % 100),
+            git_file_hash: format!("hash{}", i % 50),
+            line_start: i as u32,
+            line_end: (i + 10) as u32,
+            return_type: "int".to_string(),
+            parameters: vec![],
+            body: format!("void test_function_{}() {{ return {}; }}", i, i),
+            calls: None,
+            types: None,
+        })
+        .collect()
+}
+
+fn create_test_types(count: usize) -> Vec<TypeInfo> {
+    (0..count)
+        .map(|i| TypeInfo {
+            name: format!("test_type_{}", i),
+            file_path: format!("/test/file_{}.c", i % 100),
+            git_file_hash: format!("hash{}", i % 50),
+            line_start: i as u32,
+            kind: "struct".to_string(),
+            size: None,
+            members: vec![],
+            definition: format!("struct test_type_{} {{ int field; }};", i),
+            types: None,
+        })
+        .collect()
+}
+
+fn create_test_macros(count: usize) -> Vec<MacroInfo> {
+    (0..count)
+        .map(|i| MacroInfo {
+            name: format!("TEST_MACRO_{}", i),
+            file_path: format!("/test/file_{}.c", i % 100),
+            git_file_hash: format!("hash{}", i % 50),
+            line_start: i as u32,
+            is_function_like: false,
+            parameters: None,
+            definition: format!("#define TEST_MACRO_{} {}", i, i),
+            calls: None,
+            types: None,
+        })
+        .collect()
+}
+
+// Benchmark dump operations with BufWriter
+fn bench_dump_operations(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("dump_operations");
+
+    for count in [100, 1000, 5000] {
+        group.throughput(Throughput::Elements(count as u64));
+
+        // Setup database with test data
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("bench.db");
+
+        rt.block_on(async {
+            let db: DatabaseManager = DatabaseManager::new(
+                db_path.to_str().unwrap(),
+                temp_dir.path().to_string_lossy().to_string(),
+            )
+            .await
+            .unwrap();
+            db.create_tables().await.unwrap();
+
+            // Insert test data
+            let functions = create_test_functions(count);
+            let types = create_test_types(count / 2);
+            let macros = create_test_macros(count / 4);
+
+            db.insert_batch_combined(functions, types, macros)
+                .await
+                .unwrap();
+        });
+
+        // Benchmark dump_functions with BufWriter
+        group.bench_with_input(BenchmarkId::new("dump_functions", count), &count, |b, _| {
+            b.to_async(&rt).iter(|| async {
+                let db: DatabaseManager = DatabaseManager::new(
+                    db_path.to_str().unwrap(),
+                    temp_dir.path().to_string_lossy().to_string(),
+                )
+                .await
+                .unwrap();
+
+                let output_file = temp_dir.path().join("dump_functions.json");
+                dump_functions(&db, output_file.to_str().unwrap())
+                    .await
+                    .unwrap();
+            });
+        });
+
+        // Benchmark dump_types with BufWriter
+        group.bench_with_input(BenchmarkId::new("dump_types", count), &count, |b, _| {
+            b.to_async(&rt).iter(|| async {
+                let db: DatabaseManager = DatabaseManager::new(
+                    db_path.to_str().unwrap(),
+                    temp_dir.path().to_string_lossy().to_string(),
+                )
+                .await
+                .unwrap();
+
+                let output_file = temp_dir.path().join("dump_types.json");
+                dump_types(&db, output_file.to_str().unwrap())
+                    .await
+                    .unwrap();
+            });
+        });
+
+        // Benchmark dump_macros with BufWriter
+        group.bench_with_input(BenchmarkId::new("dump_macros", count), &count, |b, _| {
+            b.to_async(&rt).iter(|| async {
+                let db: DatabaseManager = DatabaseManager::new(
+                    db_path.to_str().unwrap(),
+                    temp_dir.path().to_string_lossy().to_string(),
+                )
+                .await
+                .unwrap();
+
+                let output_file = temp_dir.path().join("dump_macros.json");
+                dump_macros(&db, output_file.to_str().unwrap())
+                    .await
+                    .unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_dump_operations);
+criterion_main!(benches);

--- a/benches/io_operations.rs
+++ b/benches/io_operations.rs
@@ -8,11 +8,12 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 use semcode::search::{dump_functions, dump_macros, dump_types};
 use semcode::types::{FunctionInfo, MacroInfo, TypeInfo};
 use semcode::DatabaseManager;
+use smallvec::SmallVec;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
 
 // Helper to create test data matching real-world function patterns
-// Parameters: Most functions have 0-5 params
+// Parameters: Most functions have 0-5 params (SmallVec stays on stack)
 // Bodies: Realistic length for C functions (~50-200 chars)
 fn create_test_functions(count: usize) -> Vec<FunctionInfo> {
     (0..count)
@@ -23,7 +24,7 @@ fn create_test_functions(count: usize) -> Vec<FunctionInfo> {
             line_start: i as u32,
             line_end: (i + 10) as u32,
             return_type: "int".to_string(),
-            parameters: vec![],
+            parameters: SmallVec::new(),
             body: format!("void test_function_{}() {{ return {}; }}", i, i),
             calls: None,
             types: None,
@@ -40,7 +41,7 @@ fn create_test_types(count: usize) -> Vec<TypeInfo> {
             line_start: i as u32,
             kind: "struct".to_string(),
             size: None,
-            members: vec![],
+            members: SmallVec::new(),
             definition: format!("struct test_type_{} {{ int field; }};", i),
             types: None,
         })

--- a/benches/treesitter_parsing.rs
+++ b/benches/treesitter_parsing.rs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// TreeSitter parsing performance benchmarks
+//
+// Run with: cargo bench --bench treesitter_parsing
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use semcode::treesitter_analyzer::TreeSitterAnalyzer;
+
+// Real-world C code samples
+const SIMPLE_FUNCTION: &str = r#"
+int add(int a, int b) {
+    return a + b;
+}
+"#;
+
+const COMPLEX_FUNCTION: &str = r#"
+struct buffer {
+    char *data;
+    size_t size;
+    size_t capacity;
+};
+
+int buffer_append(struct buffer *buf, const char *str, size_t len) {
+    if (buf == NULL || str == NULL) {
+        return -1;
+    }
+
+    // Check if we need to resize
+    if (buf->size + len > buf->capacity) {
+        size_t new_capacity = (buf->capacity * 2) > (buf->size + len)
+            ? (buf->capacity * 2)
+            : (buf->size + len);
+
+        char *new_data = realloc(buf->data, new_capacity);
+        if (new_data == NULL) {
+            return -1;
+        }
+
+        buf->data = new_data;
+        buf->capacity = new_capacity;
+    }
+
+    memcpy(buf->data + buf->size, str, len);
+    buf->size += len;
+
+    return 0;
+}
+"#;
+
+const STRUCT_WITH_FUNCTIONS: &str = r#"
+typedef struct node {
+    int data;
+    struct node *next;
+} node_t;
+
+node_t* node_create(int data) {
+    node_t *n = malloc(sizeof(node_t));
+    if (n) {
+        n->data = data;
+        n->next = NULL;
+    }
+    return n;
+}
+
+void node_free(node_t *n) {
+    if (n) {
+        free(n);
+    }
+}
+
+int node_count(node_t *head) {
+    int count = 0;
+    while (head) {
+        count++;
+        head = head->next;
+    }
+    return count;
+}
+"#;
+
+const COMPLEX_FILE: &str = r#"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_BUFFER 1024
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
+typedef struct {
+    char *name;
+    int age;
+    double salary;
+} employee_t;
+
+enum status {
+    STATUS_OK = 0,
+    STATUS_ERROR = -1,
+    STATUS_PENDING = 1
+};
+
+struct database {
+    employee_t *employees;
+    size_t count;
+    size_t capacity;
+};
+
+static int compare_employees(const void *a, const void *b) {
+    const employee_t *e1 = (const employee_t *)a;
+    const employee_t *e2 = (const employee_t *)b;
+    return strcmp(e1->name, e2->name);
+}
+
+int db_init(struct database *db, size_t initial_capacity) {
+    if (db == NULL || initial_capacity == 0) {
+        return STATUS_ERROR;
+    }
+
+    db->employees = calloc(initial_capacity, sizeof(employee_t));
+    if (db->employees == NULL) {
+        return STATUS_ERROR;
+    }
+
+    db->count = 0;
+    db->capacity = initial_capacity;
+    return STATUS_OK;
+}
+
+int db_add_employee(struct database *db, const char *name, int age, double salary) {
+    if (db == NULL || name == NULL) {
+        return STATUS_ERROR;
+    }
+
+    if (db->count >= db->capacity) {
+        size_t new_capacity = db->capacity * 2;
+        employee_t *new_employees = realloc(db->employees,
+            new_capacity * sizeof(employee_t));
+        if (new_employees == NULL) {
+            return STATUS_ERROR;
+        }
+        db->employees = new_employees;
+        db->capacity = new_capacity;
+    }
+
+    employee_t *emp = &db->employees[db->count];
+    emp->name = strdup(name);
+    if (emp->name == NULL) {
+        return STATUS_ERROR;
+    }
+    emp->age = age;
+    emp->salary = salary;
+    db->count++;
+
+    return STATUS_OK;
+}
+
+void db_sort(struct database *db) {
+    if (db != NULL && db->count > 0) {
+        qsort(db->employees, db->count, sizeof(employee_t), compare_employees);
+    }
+}
+
+employee_t* db_find(struct database *db, const char *name) {
+    if (db == NULL || name == NULL) {
+        return NULL;
+    }
+
+    for (size_t i = 0; i < db->count; i++) {
+        if (strcmp(db->employees[i].name, name) == 0) {
+            return &db->employees[i];
+        }
+    }
+
+    return NULL;
+}
+
+void db_destroy(struct database *db) {
+    if (db != NULL) {
+        for (size_t i = 0; i < db->count; i++) {
+            free(db->employees[i].name);
+        }
+        free(db->employees);
+        db->employees = NULL;
+        db->count = 0;
+        db->capacity = 0;
+    }
+}
+"#;
+
+// Benchmark full file analysis
+fn bench_analyze_file(c: &mut Criterion) {
+    let mut group = c.benchmark_group("treesitter_analyze");
+
+    for (name, code) in [
+        ("simple_function", SIMPLE_FUNCTION),
+        ("complex_function", COMPLEX_FUNCTION),
+        ("struct_with_functions", STRUCT_WITH_FUNCTIONS),
+        ("complex_file", COMPLEX_FILE),
+    ] {
+        group.throughput(Throughput::Bytes(code.len() as u64));
+
+        group.bench_with_input(BenchmarkId::new("full_analysis", name), code, |b, code| {
+            use std::fs;
+            use std::path::Path;
+            use tempfile::TempDir;
+
+            let temp_dir = TempDir::new().unwrap();
+            let test_file = temp_dir.path().join("test.c");
+            fs::write(&test_file, code).unwrap();
+
+            b.iter(|| {
+                let mut analyzer = TreeSitterAnalyzer::new().unwrap();
+                analyzer.analyze_file(black_box(Path::new(&test_file)))
+            })
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_analyze_file);
+criterion_main!(benches);

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-types = [
+    { path = "std::collections::HashMap", reason = "use gxhash::HashMap instead for better performance" },
+    { path = "std::collections::HashSet", reason = "use gxhash::HashSet instead for better performance" },
+]

--- a/src/bin/index.rs
+++ b/src/bin/index.rs
@@ -253,16 +253,21 @@ async fn run_commits_only(args: Args) -> Result<()> {
     // Process database path
     let database_path = process_database_path(args.database.as_deref(), Some(&args.source));
 
+    // Handle --clear flag by removing entire database directory
+    if args.clear {
+        if std::path::Path::new(&database_path).exists() {
+            println!("Removing existing database at {}...", database_path);
+            std::fs::remove_dir_all(&database_path)?;
+            println!("Existing database removed.");
+        } else {
+            println!("No existing database found at {}", database_path);
+        }
+    }
+
     // Create database manager and tables
     let db_manager =
         DatabaseManager::new(&database_path, args.source.to_string_lossy().to_string()).await?;
     db_manager.create_tables().await?;
-
-    if args.clear {
-        println!("Clearing existing data...");
-        db_manager.clear_all_data().await?;
-        println!("Existing data cleared.");
-    }
 
     // Open repository and get list of commits in range
     let repo = gix::discover(&args.source)
@@ -564,16 +569,21 @@ async fn run_pipeline(args: Args) -> Result<()> {
     // Process database path with search order: 1) -d flag, 2) source directory, 3) current directory
     let database_path = process_database_path(args.database.as_deref(), Some(&args.source));
 
+    // Handle --clear flag by removing entire database directory
+    if args.clear {
+        if std::path::Path::new(&database_path).exists() {
+            println!("Removing existing database at {}...", database_path);
+            std::fs::remove_dir_all(&database_path)?;
+            println!("Existing database removed.");
+        } else {
+            println!("No existing database found at {}", database_path);
+        }
+    }
+
     // Create database manager and tables
     let db_manager =
         DatabaseManager::new(&database_path, args.source.to_string_lossy().to_string()).await?;
     db_manager.create_tables().await?;
-
-    if args.clear {
-        println!("Clearing existing data...");
-        db_manager.clear_all_data().await?;
-        println!("Existing data cleared.");
-    }
 
     // Wrap database manager in Arc for sharing across pipeline stages
     let db_manager = Arc::new(db_manager);

--- a/src/bin/index.rs
+++ b/src/bin/index.rs
@@ -13,8 +13,8 @@ use semcode::{FunctionInfo, MacroInfo, TypeInfo};
 // Temporary call relationships are now embedded in function JSON columns
 use dashmap::DashSet;
 use gix::revision::walk::Sorting;
+use gxhash::{HashMap, HashMapExt, HashSet};
 use semcode::perf_monitor::PERF_STATS;
-use std::collections::HashSet;
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -582,7 +582,7 @@ async fn run_pipeline(args: Args) -> Result<()> {
     if !args.vectors {
         // Determine which files to process based on incremental mode
         let mut files_to_process = Vec::new();
-        let git_files_map: Option<std::collections::HashMap<PathBuf, GitFileEntry>> = None;
+        let git_files_map: Option<HashMap<PathBuf, GitFileEntry>> = None;
         let extensions: Vec<String> = args
             .extensions
             .iter()
@@ -1532,9 +1532,7 @@ async fn process_git_tuples_streaming(
 }
 
 /// Parse tags from commit message (e.g., Signed-off-by:, Reported-by:, etc.)
-fn parse_commit_message_tags(message: &str) -> std::collections::HashMap<String, Vec<String>> {
-    use std::collections::HashMap;
-
+fn parse_commit_message_tags(message: &str) -> HashMap<String, Vec<String>> {
     let mut tags: HashMap<String, Vec<String>> = HashMap::new();
 
     for line in message.lines() {

--- a/src/bin/query_impl/commands.rs
+++ b/src/bin/query_impl/commands.rs
@@ -151,7 +151,12 @@ async fn show_callchain_with_limits(
         };
 
         for (i, caller) in limited_callers.iter().enumerate() {
-            writeln!(handle, "{}. {}", (i + 1).to_string().yellow(), caller.cyan())?;
+            writeln!(
+                handle,
+                "{}. {}",
+                (i + 1).to_string().yellow(),
+                caller.cyan()
+            )?;
 
             // Show caller details if available
             if let Ok(Some(caller_func)) = db.find_function_git_aware(caller, git_sha).await {
@@ -219,7 +224,12 @@ async fn show_callchain_with_limits(
         };
 
         for (i, callee) in limited_callees.iter().enumerate() {
-            writeln!(handle, "{}. {}", (i + 1).to_string().yellow(), callee.cyan())?;
+            writeln!(
+                handle,
+                "{}. {}",
+                (i + 1).to_string().yellow(),
+                callee.cyan()
+            )?;
 
             // Show callee details if available
             if let Ok(Some(callee_func)) = db.find_function_git_aware(callee, git_sha).await {

--- a/src/bin/query_impl/commands.rs
+++ b/src/bin/query_impl/commands.rs
@@ -2,8 +2,8 @@
 use anstream::stdout;
 use anyhow::Result;
 use colored::*;
-use regex;
 use gxhash::{HashMap, HashMapExt, HashSet, HashSetExt};
+use regex;
 use semcode::{git, DatabaseManager};
 
 use owo_colors::OwoColorize as _;
@@ -2439,9 +2439,9 @@ async fn show_commit_metadata(
                         git_commit.subject,
                         git_commit.message,
                         git_commit.parent_sha,
-                        git_commit.symbols,   // Symbols extracted from diff
-                        git_commit.files,     // Files changed in commit
-                        HashMap::new(), // No tags extracted from git
+                        git_commit.symbols, // Symbols extracted from diff
+                        git_commit.files,   // Files changed in commit
+                        HashMap::new(),     // No tags extracted from git
                         git_commit.diff,
                         false,
                     )

--- a/src/bin/query_impl/commands.rs
+++ b/src/bin/query_impl/commands.rs
@@ -3,6 +3,7 @@ use anstream::stdout;
 use anyhow::Result;
 use colored::*;
 use regex;
+use gxhash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use semcode::{git, DatabaseManager};
 
 use owo_colors::OwoColorize as _;
@@ -1559,7 +1560,7 @@ async fn vcommit_similar_commits(
                 };
 
                 // Get all commits in the range using gitoxide
-                let mut range_commits = std::collections::HashSet::new();
+                let mut range_commits = HashSet::new();
 
                 // Walk from to_commit back to from_commit
                 let to_id = to_commit.id().detach();
@@ -2438,9 +2439,9 @@ async fn show_commit_metadata(
                         git_commit.subject,
                         git_commit.message,
                         git_commit.parent_sha,
-                        git_commit.symbols, // Symbols extracted from diff
-                        git_commit.files,   // Files changed in commit
-                        std::collections::HashMap::new(), // No tags extracted from git
+                        git_commit.symbols,   // Symbols extracted from diff
+                        git_commit.files,     // Files changed in commit
+                        HashMap::new(), // No tags extracted from git
                         git_commit.diff,
                         false,
                     )

--- a/src/bin/query_impl/commands.rs
+++ b/src/bin/query_impl/commands.rs
@@ -133,11 +133,16 @@ async fn show_callchain_with_limits(
 
     // Show callers with depth and limit control
     if !callers.is_empty() && up_levels > 0 {
-        println!(
+        use std::io::Write;
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+
+        writeln!(
+            handle,
             "\n{} ({} levels)",
             "=== Reverse Chain (Callers) ===".bold().magenta(),
             up_levels
-        );
+        )?;
 
         let limited_callers: Vec<_> = if calls_limit == 0 {
             callers.clone()
@@ -146,16 +151,17 @@ async fn show_callchain_with_limits(
         };
 
         for (i, caller) in limited_callers.iter().enumerate() {
-            println!("{}. {}", (i + 1).to_string().yellow(), caller.cyan());
+            writeln!(handle, "{}. {}", (i + 1).to_string().yellow(), caller.cyan())?;
 
             // Show caller details if available
             if let Ok(Some(caller_func)) = db.find_function_git_aware(caller, git_sha).await {
-                println!(
+                writeln!(
+                    handle,
                     "   └─ {} ({}:{})",
                     caller_func.return_type.bright_black(),
                     caller_func.file_path.bright_black(),
                     caller_func.line_start.to_string().bright_black()
-                );
+                )?;
             }
 
             // For multi-level depth, show second-level callers
@@ -174,31 +180,37 @@ async fn show_callchain_with_limits(
                     };
 
                     for second_caller in limited_second.iter().take(3) {
-                        println!("      └─ {}", second_caller.bright_black());
+                        writeln!(handle, "      └─ {}", second_caller.bright_black())?;
                     }
                     if limited_second.len() > 3 {
-                        println!("      └─ ... and {} more", limited_second.len() - 3);
+                        writeln!(handle, "      └─ ... and {} more", limited_second.len() - 3)?;
                     }
                 }
             }
         }
 
         if calls_limit > 0 && callers.len() > calls_limit {
-            println!(
+            writeln!(
+                handle,
                 "... and {} more callers (limited by calls_limit={})",
                 callers.len() - calls_limit,
                 calls_limit
-            );
+            )?;
         }
     }
 
     // Show callees with depth and limit control
     if !callees.is_empty() && down_levels > 0 {
-        println!(
+        use std::io::Write;
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+
+        writeln!(
+            handle,
             "\n{} ({} levels)",
             "=== Forward Chain (Callees) ===".bold().blue(),
             down_levels
-        );
+        )?;
 
         let limited_callees: Vec<_> = if calls_limit == 0 {
             callees.clone()
@@ -207,16 +219,17 @@ async fn show_callchain_with_limits(
         };
 
         for (i, callee) in limited_callees.iter().enumerate() {
-            println!("{}. {}", (i + 1).to_string().yellow(), callee.cyan());
+            writeln!(handle, "{}. {}", (i + 1).to_string().yellow(), callee.cyan())?;
 
             // Show callee details if available
             if let Ok(Some(callee_func)) = db.find_function_git_aware(callee, git_sha).await {
-                println!(
+                writeln!(
+                    handle,
                     "   └─ {} ({}:{})",
                     callee_func.return_type.bright_black(),
                     callee_func.file_path.bright_black(),
                     callee_func.line_start.to_string().bright_black()
-                );
+                )?;
             }
 
             // For multi-level depth, show second-level callees
@@ -235,21 +248,22 @@ async fn show_callchain_with_limits(
                     };
 
                     for second_callee in limited_second.iter().take(3) {
-                        println!("      └─ {}", second_callee.bright_black());
+                        writeln!(handle, "      └─ {}", second_callee.bright_black())?;
                     }
                     if limited_second.len() > 3 {
-                        println!("      └─ ... and {} more", limited_second.len() - 3);
+                        writeln!(handle, "      └─ ... and {} more", limited_second.len() - 3)?;
                     }
                 }
             }
         }
 
         if calls_limit > 0 && callees.len() > calls_limit {
-            println!(
+            writeln!(
+                handle,
                 "... and {} more callees (limited by calls_limit={})",
                 callees.len() - calls_limit,
                 calls_limit
-            );
+            )?;
         }
     }
 

--- a/src/bin/semcode-mcp.rs
+++ b/src/bin/semcode-mcp.rs
@@ -586,9 +586,9 @@ async fn mcp_show_commit_metadata(
                         git_commit.subject,
                         git_commit.message,
                         git_commit.parent_sha,
-                        git_commit.symbols,   // Symbols extracted from diff
-                        git_commit.files,     // Files changed in commit
-                        HashMap::new(), // No tags extracted from git
+                        git_commit.symbols, // Symbols extracted from diff
+                        git_commit.files,   // Files changed in commit
+                        HashMap::new(),     // No tags extracted from git
                         git_commit.diff,
                         false,
                     )

--- a/src/bin/semcode-mcp.rs
+++ b/src/bin/semcode-mcp.rs
@@ -2,6 +2,7 @@
 use anstream::stdout;
 use anyhow::Result;
 use clap::Parser;
+use gxhash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use semcode::{git, pages::PageCache, process_database_path, DatabaseManager};
 use serde_json::{json, Value};
 use std::io::{self, BufRead, Write};
@@ -585,9 +586,9 @@ async fn mcp_show_commit_metadata(
                         git_commit.subject,
                         git_commit.message,
                         git_commit.parent_sha,
-                        git_commit.symbols, // Symbols extracted from diff
-                        git_commit.files,   // Files changed in commit
-                        std::collections::HashMap::new(), // No tags extracted from git
+                        git_commit.symbols,   // Symbols extracted from diff
+                        git_commit.files,     // Files changed in commit
+                        HashMap::new(), // No tags extracted from git
                         git_commit.diff,
                         false,
                     )
@@ -3004,7 +3005,7 @@ async fn mcp_vcommit_similar_commits(
                 };
 
                 // Get all commits in the range using gitoxide
-                let mut range_commits = std::collections::HashSet::new();
+                let mut range_commits = HashSet::new();
 
                 // Walk from to_commit back to from_commit
                 let to_id = to_commit.id().detach();

--- a/src/callchain.rs
+++ b/src/callchain.rs
@@ -3,7 +3,8 @@ use crate::{DatabaseManager, FunctionInfo, MacroInfo};
 use anstream::stdout;
 use anyhow::Result;
 use owo_colors::OwoColorize as _;
-use std::collections::{HashMap, HashSet, VecDeque};
+use gxhash::{HashMap, HashMapExt, HashSet, HashSetExt};
+use std::collections::VecDeque;
 use std::io::Write;
 
 #[derive(Debug)]
@@ -972,7 +973,7 @@ pub async fn find_all_paths_to_writer(
 
     // Load only the functions we need for path analysis
     let all_path_functions = {
-        let mut functions_needed = std::collections::HashSet::new();
+        let mut functions_needed = HashSet::new();
         // Add entry points
         for entry in &entry_points {
             functions_needed.insert(entry.clone());

--- a/src/callchain.rs
+++ b/src/callchain.rs
@@ -2,8 +2,8 @@
 use crate::{DatabaseManager, FunctionInfo, MacroInfo};
 use anstream::stdout;
 use anyhow::Result;
-use owo_colors::OwoColorize as _;
 use gxhash::{HashMap, HashMapExt, HashSet, HashSetExt};
+use owo_colors::OwoColorize as _;
 use std::collections::VecDeque;
 use std::io::Write;
 

--- a/src/collection_utils.rs
+++ b/src/collection_utils.rs
@@ -14,7 +14,7 @@ use crate::consts::{COLLECTION_PARALLEL_THRESHOLD, FILTER_PARALLEL_THRESHOLD};
 ///
 /// Takes a collection of items that can provide String paths via a closure,
 /// and collects them into a HashSet. This is a generic utility for path
-/// collection operations. Automatically uses parallel processing for 
+/// collection operations. Automatically uses parallel processing for
 /// collections over COLLECTION_PARALLEL_THRESHOLD.
 ///
 /// # Arguments

--- a/src/collection_utils.rs
+++ b/src/collection_utils.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Collection transformation utilities
+//
+// This module provides utilities for transforming and collecting data
+// from collections efficiently.
+
+use gxhash::HashSet;
+
+/// Extract paths from collection and collect into a HashSet
+///
+/// Takes a collection of items that can provide String paths via a closure,
+/// and collects them into a HashSet. This is a generic utility for path
+/// collection operations.
+///
+/// # Arguments
+/// * `items` - Slice of items to extract paths from
+/// * `extractor` - Function that extracts a String from each item
+///
+/// # Returns
+/// HashSet of extracted paths
+///
+/// # Examples
+/// ```
+/// use gxhash::HashSet;
+/// use semcode::collection_utils::collect_paths;
+///
+/// struct Item { path: String }
+/// let items = vec![
+///     Item { path: "a".to_string() },
+///     Item { path: "b".to_string() },
+/// ];
+/// let paths = collect_paths(&items, |item| item.path.clone());
+/// assert_eq!(paths.len(), 2);
+/// ```
+pub fn collect_paths<T, F>(items: &[T], extractor: F) -> HashSet<String>
+where
+    F: Fn(&T) -> String,
+{
+    items.iter().map(extractor).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone)]
+    struct TestItem {
+        path: String,
+    }
+
+    #[test]
+    fn test_collect_paths_empty() {
+        let items: Vec<TestItem> = vec![];
+        let result = collect_paths(&items, |item| item.path.clone());
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_collect_paths_single() {
+        let items = vec![TestItem {
+            path: "test/file.rs".to_string(),
+        }];
+        let result = collect_paths(&items, |item| item.path.clone());
+        assert_eq!(result.len(), 1);
+        assert!(result.contains("test/file.rs"));
+    }
+
+    #[test]
+    fn test_collect_paths_multiple() {
+        let items = vec![
+            TestItem {
+                path: "src/main.rs".to_string(),
+            },
+            TestItem {
+                path: "src/lib.rs".to_string(),
+            },
+            TestItem {
+                path: "tests/test.rs".to_string(),
+            },
+        ];
+        let result = collect_paths(&items, |item| item.path.clone());
+        assert_eq!(result.len(), 3);
+        assert!(result.contains("src/main.rs"));
+        assert!(result.contains("src/lib.rs"));
+        assert!(result.contains("tests/test.rs"));
+    }
+
+    #[test]
+    fn test_collect_paths_duplicates() {
+        let items = vec![
+            TestItem {
+                path: "src/main.rs".to_string(),
+            },
+            TestItem {
+                path: "src/lib.rs".to_string(),
+            },
+            TestItem {
+                path: "src/main.rs".to_string(),
+            },
+        ];
+        let result = collect_paths(&items, |item| item.path.clone());
+        // HashSet deduplicates
+        assert_eq!(result.len(), 2);
+        assert!(result.contains("src/main.rs"));
+        assert!(result.contains("src/lib.rs"));
+    }
+
+    #[test]
+    fn test_collect_paths_large_collection() {
+        // Test with 1000 items
+        let items: Vec<TestItem> = (0..1000)
+            .map(|i| TestItem {
+                path: format!("file_{}.rs", i),
+            })
+            .collect();
+        let result = collect_paths(&items, |item| item.path.clone());
+        assert_eq!(result.len(), 1000);
+        assert!(result.contains("file_0.rs"));
+        assert!(result.contains("file_999.rs"));
+    }
+
+    #[test]
+    fn test_collect_paths_very_large_collection() {
+        // Test with 5000 items to verify scalability
+        let items: Vec<TestItem> = (0..5000)
+            .map(|i| TestItem {
+                path: format!("file_{}.rs", i),
+            })
+            .collect();
+        let result = collect_paths(&items, |item| item.path.clone());
+        assert_eq!(result.len(), 5000);
+        assert!(result.contains("file_0.rs"));
+        assert!(result.contains("file_2500.rs"));
+        assert!(result.contains("file_4999.rs"));
+    }
+
+    #[test]
+    fn test_collect_paths_with_special_chars() {
+        let items = vec![
+            TestItem {
+                path: "src/mod-name.rs".to_string(),
+            },
+            TestItem {
+                path: "tests/test_file.rs".to_string(),
+            },
+            TestItem {
+                path: "examples/ex.1.rs".to_string(),
+            },
+        ];
+        let result = collect_paths(&items, |item| item.path.clone());
+        assert_eq!(result.len(), 3);
+        assert!(result.contains("src/mod-name.rs"));
+        assert!(result.contains("tests/test_file.rs"));
+        assert!(result.contains("examples/ex.1.rs"));
+    }
+
+    #[test]
+    fn test_collect_paths_unicode() {
+        let items = vec![
+            TestItem {
+                path: "测试/文件.rs".to_string(),
+            },
+            TestItem {
+                path: "тест/файл.rs".to_string(),
+            },
+        ];
+        let result = collect_paths(&items, |item| item.path.clone());
+        assert_eq!(result.len(), 2);
+        assert!(result.contains("测试/文件.rs"));
+        assert!(result.contains("тест/файл.rs"));
+    }
+
+    #[test]
+    fn test_collect_paths_empty_strings() {
+        let items = vec![
+            TestItem {
+                path: "".to_string(),
+            },
+            TestItem {
+                path: "file.rs".to_string(),
+            },
+        ];
+        let result = collect_paths(&items, |item| item.path.clone());
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(""));
+        assert!(result.contains("file.rs"));
+    }
+
+    #[test]
+    fn test_collect_paths_custom_extractor() {
+        // Test with a different extractor function
+        struct CustomItem {
+            id: usize,
+        }
+        let items = vec![CustomItem { id: 1 }, CustomItem { id: 2 }];
+        let result = collect_paths(&items, |item| format!("id_{}", item.id));
+        assert_eq!(result.len(), 2);
+        assert!(result.contains("id_1"));
+        assert!(result.contains("id_2"));
+    }
+}

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -12,3 +12,7 @@ pub const SMALLVEC_PARAM_SIZE: usize = 10;
 /// SmallVec size for struct/union/enum fields.
 /// Based on kernel analysis: 94.92% of types have 20 or fewer fields.
 pub const SMALLVEC_FIELD_SIZE: usize = 22;
+
+/// Threshold for switching to parallel processing in batch operations.
+/// Below this threshold, sequential processing provides better cache locality.
+pub const BATCH_PARALLEL_THRESHOLD: usize = 1000;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -24,3 +24,7 @@ pub const SQL_FORMAT_PARALLEL_THRESHOLD: usize = 100;
 /// Threshold for switching to parallel processing in collection transformations.
 /// Below this threshold, sequential processing provides better cache locality.
 pub const COLLECTION_PARALLEL_THRESHOLD: usize = 1000;
+
+/// Threshold for switching to parallel processing in filter operations.
+/// Below this threshold, sequential processing provides better cache locality.
+pub const FILTER_PARALLEL_THRESHOLD: usize = 500;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -20,3 +20,7 @@ pub const BATCH_PARALLEL_THRESHOLD: usize = 1000;
 /// Threshold for switching to parallel processing in SQL string formatting.
 /// Below this threshold, sequential processing provides better cache locality.
 pub const SQL_FORMAT_PARALLEL_THRESHOLD: usize = 100;
+
+/// Threshold for switching to parallel processing in collection transformations.
+/// Below this threshold, sequential processing provides better cache locality.
+pub const COLLECTION_PARALLEL_THRESHOLD: usize = 1000;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -6,12 +6,58 @@
 //! for the vast majority of cases.
 
 /// SmallVec size for function parameters.
-/// Based on kernel analysis: 99.90% of functions have 10 or fewer parameters.
-pub const SMALLVEC_PARAM_SIZE: usize = 10;
+/// Based on kernel analysis: 94.66% of functions have 4 or fewer parameters (90th percentile: 4).
+/// Using 4 provides excellent stack allocation coverage while keeping struct size reasonable.
+pub const SMALLVEC_PARAM_SIZE: usize = 4;
 
 /// SmallVec size for struct/union/enum fields.
-/// Based on kernel analysis: 94.92% of types have 20 or fewer fields.
-pub const SMALLVEC_FIELD_SIZE: usize = 22;
+/// Based on kernel analysis: 90th percentile is 15 fields, 95th percentile is 30 fields.
+/// Using 15 balances stack usage with heap allocation frequency.
+pub const SMALLVEC_FIELD_SIZE: usize = 15;
+
+/// Default capacity for function call vectors.
+/// Based on kernel analysis: 75th percentile is 2 calls, 90th percentile is 6 calls.
+/// Most functions make 0-2 calls (76.43% combined).
+pub const VEC_CALLS_CAPACITY: usize = 2;
+
+/// Default capacity for top comment vectors.
+/// Based on kernel analysis: 75th percentile is 1 comment, 90th percentile is 1 comment.
+/// 93.05% of functions have 0-1 comments.
+pub const VEC_COMMENTS_CAPACITY: usize = 1;
+
+/// Default capacity for macro parameter vectors.
+/// Based on kernel analysis: 90th percentile is 2 parameters.
+/// 90.58% of macros have 1-2 parameters.
+pub const VEC_MACRO_PARAMS_CAPACITY: usize = 2;
+
+/// Average bytes per function definition.
+/// Based on kernel analysis: mean function size is 327 bytes.
+/// Used for Vec pre-allocation: estimated_functions = file_size / BYTES_PER_FUNCTION
+pub const BYTES_PER_FUNCTION: usize = 327;
+
+/// Average bytes per type definition (struct/union/enum).
+/// Based on kernel analysis: mean type size is 123 bytes.
+/// Used for Vec pre-allocation: estimated_types = file_size / BYTES_PER_TYPE
+pub const BYTES_PER_TYPE: usize = 123;
+
+/// Average bytes per macro definition.
+/// Based on kernel analysis: mean macro size is 105 bytes.
+/// Used for Vec pre-allocation: estimated_macros = file_size / BYTES_PER_MACRO
+pub const BYTES_PER_MACRO: usize = 105;
+
+/// Default capacity for temporary parameter parsing (95th percentile from analysis).
+/// Used when parsing parameter lists before converting to SmallVec.
+pub const TEMP_PARAM_PARSE_CAPACITY: usize = 5;
+
+/// Comment to function ratio for estimating total comments in a file.
+/// Analysis shows 0.43 comments per function, but extract_comments gets ALL comments.
+/// Using 1:2 ratio (half as many comments as functions) as conservative estimate.
+pub const COMMENTS_PER_FUNCTION_DIVISOR: usize = 2;
+
+/// Call to function ratio multiplier for estimating total calls.
+/// Analysis shows mean 2.65 calls per function across 5407 samples.
+/// Using 3 (ceil of mean) as a reasonable safety margin.
+pub const CALLS_PER_FUNCTION_MULTIPLIER: usize = 3;
 
 /// Threshold for switching to parallel processing in batch operations.
 /// Below this threshold, sequential processing provides better cache locality.
@@ -28,3 +74,10 @@ pub const COLLECTION_PARALLEL_THRESHOLD: usize = 1000;
 /// Threshold for switching to parallel processing in filter operations.
 /// Below this threshold, sequential processing provides better cache locality.
 pub const FILTER_PARALLEL_THRESHOLD: usize = 500;
+
+/// Number of distinct capture names in the Tree-sitter function query.
+/// Based on the function_query definition in treesitter_analyzer.rs (lines 38-86):
+/// @return_type, @function_name, @parameters, @body, @function, @function_ptr,
+/// @function_ptr2, @declaration (8 total).
+/// Used for HashSet capacity when tracking which capture patterns were matched.
+pub const FUNCTION_QUERY_CAPTURE_NAMES: usize = 8;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -16,3 +16,7 @@ pub const SMALLVEC_FIELD_SIZE: usize = 22;
 /// Threshold for switching to parallel processing in batch operations.
 /// Below this threshold, sequential processing provides better cache locality.
 pub const BATCH_PARALLEL_THRESHOLD: usize = 1000;
+
+/// Threshold for switching to parallel processing in SQL string formatting.
+/// Below this threshold, sequential processing provides better cache locality.
+pub const SQL_FORMAT_PARALLEL_THRESHOLD: usize = 100;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Constants used throughout the codebase for SmallVec sizing and other configurations.
+//!
+//! SmallVec sizes are derived from statistical analysis of the Linux kernel codebase
+//! using tools/analyze_kernel_stats.py. These sizes provide optimal stack allocation
+//! for the vast majority of cases.
+
+/// SmallVec size for function parameters.
+/// Based on kernel analysis: 99.90% of functions have 10 or fewer parameters.
+pub const SMALLVEC_PARAM_SIZE: usize = 10;
+
+/// SmallVec size for struct/union/enum fields.
+/// Based on kernel analysis: 94.92% of types have 20 or fewer fields.
+pub const SMALLVEC_FIELD_SIZE: usize = 22;

--- a/src/database/batch_processing.rs
+++ b/src/database/batch_processing.rs
@@ -1,0 +1,394 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Batch processing utilities for database result extraction
+//
+// This module provides sequential batch processing functions that can later
+// be optimized with parallel processing. The functions are designed to be
+// pure and testable.
+
+use arrow_array::RecordBatch;
+
+/// Process batches by applying an extractor function to each row
+///
+/// This function iterates through all batches and applies the extractor function
+/// to each row, collecting successful extractions into a Vec.
+///
+/// # Arguments
+/// * `batches` - Slice of RecordBatch to process
+/// * `extractor` - Function that extracts T from (batch, row_index)
+///
+/// # Returns
+/// Vec of successfully extracted items
+pub fn process_batches<T, F>(batches: &[RecordBatch], extractor: F) -> Vec<T>
+where
+    F: Fn(&RecordBatch, usize) -> Option<T>,
+{
+    let mut results = Vec::new();
+
+    for batch in batches {
+        for i in 0..batch.num_rows() {
+            if let Some(item) = extractor(batch, i) {
+                results.push(item);
+            }
+        }
+    }
+
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{Int32Array, RecordBatch, StringArray};
+    use arrow_schema::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_process_batches_empty() {
+        let batches: Vec<RecordBatch> = vec![];
+        let extractor = |_batch: &RecordBatch, _i: usize| Some(42);
+
+        let result = process_batches(&batches, extractor);
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_process_batches_single_batch() {
+        // Create a simple RecordBatch with Int32 data
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["a", "b", "c"])),
+            ],
+        )
+        .unwrap();
+
+        let batches = vec![batch];
+
+        // Extract the ID from each row
+        let extractor = |batch: &RecordBatch, i: usize| {
+            let id_array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            Some(id_array.value(i))
+        };
+
+        let result = process_batches(&batches, extractor);
+        assert_eq!(result, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_process_batches_multiple_batches() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int32,
+            false,
+        )]));
+
+        let batch1 = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![10, 20]))],
+        )
+        .unwrap();
+
+        let batch2 = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![30, 40, 50]))],
+        )
+        .unwrap();
+
+        let batches = vec![batch1, batch2];
+
+        let extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            Some(array.value(i))
+        };
+
+        let result = process_batches(&batches, extractor);
+        assert_eq!(result, vec![10, 20, 30, 40, 50]);
+    }
+
+    #[test]
+    fn test_process_batches_with_filtering() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int32,
+            false,
+        )]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]))],
+        )
+        .unwrap();
+
+        let batches = vec![batch];
+
+        // Only extract even numbers
+        let extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let value = array.value(i);
+            if value % 2 == 0 {
+                Some(value)
+            } else {
+                None
+            }
+        };
+
+        let result = process_batches(&batches, extractor);
+        assert_eq!(result, vec![2, 4]);
+    }
+
+    #[test]
+    fn test_process_batches_string_extraction() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["foo", "bar", "baz"])),
+            ],
+        )
+        .unwrap();
+
+        let batches = vec![batch];
+
+        // Extract names as Strings
+        let extractor = |batch: &RecordBatch, i: usize| {
+            let name_array = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            Some(name_array.value(i).to_string())
+        };
+
+        let result = process_batches(&batches, extractor);
+        assert_eq!(
+            result,
+            vec!["foo".to_string(), "bar".to_string(), "baz".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_process_batches_empty_batch_in_sequence() {
+        // Test handling of empty batches mixed with non-empty ones
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int32,
+            false,
+        )]));
+
+        let batch1 =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1, 2]))])
+                .unwrap();
+
+        let batch2 = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(Vec::<i32>::new()))],
+        )
+        .unwrap();
+
+        let batch3 =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![3, 4]))])
+                .unwrap();
+
+        let batches = vec![batch1, batch2, batch3];
+
+        let extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            Some(array.value(i))
+        };
+
+        let result = process_batches(&batches, extractor);
+        assert_eq!(result, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_process_batches_all_filtered_out() {
+        // Test when all items are filtered (all None)
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int32,
+            false,
+        )]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Int32Array::from(vec![1, 3, 5, 7, 9]))],
+        )
+        .unwrap();
+
+        let batches = vec![batch];
+
+        // Filter to only even numbers (none exist)
+        let extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let value = array.value(i);
+            if value % 2 == 0 {
+                Some(value)
+            } else {
+                None
+            }
+        };
+
+        let result = process_batches(&batches, extractor);
+        assert_eq!(result, Vec::<i32>::new());
+    }
+
+    #[test]
+    fn test_process_batches_large_batch() {
+        // Test with a larger batch to ensure no performance issues
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int32,
+            false,
+        )]));
+
+        let large_data: Vec<i32> = (0..10000).collect();
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(large_data.clone()))])
+                .unwrap();
+
+        let batches = vec![batch];
+
+        let extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            Some(array.value(i))
+        };
+
+        let result = process_batches(&batches, extractor);
+        assert_eq!(result, large_data);
+    }
+
+    #[test]
+    fn test_process_batches_complex_extraction() {
+        // Test extracting a struct/tuple from multiple columns
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("score", DataType::Int32, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["alice", "bob", "charlie"])),
+                Arc::new(Int32Array::from(vec![100, 200, 300])),
+            ],
+        )
+        .unwrap();
+
+        let batches = vec![batch];
+
+        // Extract as tuples
+        let extractor = |batch: &RecordBatch, i: usize| {
+            let id_array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let name_array = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            let score_array = batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+
+            Some((
+                id_array.value(i),
+                name_array.value(i).to_string(),
+                score_array.value(i),
+            ))
+        };
+
+        let result = process_batches(&batches, extractor);
+        assert_eq!(
+            result,
+            vec![
+                (1, "alice".to_string(), 100),
+                (2, "bob".to_string(), 200),
+                (3, "charlie".to_string(), 300),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_process_batches_mixed_filtering() {
+        // Test filtering that keeps some items from each batch
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int32,
+            false,
+        )]));
+
+        let batch1 = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]))],
+        )
+        .unwrap();
+
+        let batch2 = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![6, 7, 8, 9, 10]))],
+        )
+        .unwrap();
+
+        let batches = vec![batch1, batch2];
+
+        // Only keep values > 3 and < 9
+        let extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let value = array.value(i);
+            if value > 3 && value < 9 {
+                Some(value)
+            } else {
+                None
+            }
+        };
+
+        let result = process_batches(&batches, extractor);
+        assert_eq!(result, vec![4, 5, 6, 7, 8]);
+    }
+}

--- a/src/database/batch_processing.rs
+++ b/src/database/batch_processing.rs
@@ -7,8 +7,8 @@
 // rayon for parallelism with adaptive thresholds.
 
 use arrow_array::RecordBatch;
-use rayon::prelude::*;
 use gxhash::{HashMap, HashMapExt};
+use rayon::prelude::*;
 
 use crate::consts::BATCH_PARALLEL_THRESHOLD;
 

--- a/src/database/batch_processing.rs
+++ b/src/database/batch_processing.rs
@@ -8,6 +8,7 @@
 
 use arrow_array::RecordBatch;
 use rayon::prelude::*;
+use gxhash::{HashMap, HashMapExt};
 
 use crate::consts::BATCH_PARALLEL_THRESHOLD;
 
@@ -47,6 +48,42 @@ where
             })
             .collect()
     }
+}
+
+/// Build a HashMap from two columns in batches
+///
+/// This function processes all batches and extracts key-value pairs from two columns,
+/// collecting them into a HashMap. The key and value are extracted using provided
+/// closures.
+///
+/// # Arguments
+/// * `batches` - Slice of RecordBatch to process
+/// * `key_extractor` - Function that extracts the key (K) from (batch, row_index)
+/// * `value_extractor` - Function that extracts the value (V) from (batch, row_index)
+///
+/// # Returns
+/// HashMap of extracted key-value pairs
+pub fn build_map_from_batches<K, V, FK, FV>(
+    batches: &[RecordBatch],
+    key_extractor: FK,
+    value_extractor: FV,
+) -> HashMap<K, V>
+where
+    FK: Fn(&RecordBatch, usize) -> Option<K>,
+    FV: Fn(&RecordBatch, usize) -> Option<V>,
+    K: std::hash::Hash + Eq,
+{
+    let mut map = HashMap::new();
+
+    for batch in batches {
+        for i in 0..batch.num_rows() {
+            if let (Some(key), Some(value)) = (key_extractor(batch, i), value_extractor(batch, i)) {
+                map.insert(key, value);
+            }
+        }
+    }
+
+    map
 }
 
 #[cfg(test)]
@@ -403,5 +440,352 @@ mod tests {
 
         let result = process_batches(&batches, extractor);
         assert_eq!(result, vec![4, 5, 6, 7, 8]);
+    }
+
+    // Tests for build_map_from_batches
+
+    #[test]
+    fn test_build_map_empty() {
+        let batches: Vec<RecordBatch> = vec![];
+        let key_extractor = |_: &RecordBatch, _: usize| Some(42);
+        let value_extractor = |_: &RecordBatch, _: usize| Some("test".to_string());
+
+        let result: HashMap<i32, String> =
+            build_map_from_batches(&batches, key_extractor, value_extractor);
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_build_map_single_batch() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["a", "b", "c"])),
+            ],
+        )
+        .unwrap();
+
+        let batches = vec![batch];
+
+        let key_extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            Some(array.value(i))
+        };
+        let value_extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            Some(array.value(i).to_string())
+        };
+
+        let result = build_map_from_batches(&batches, key_extractor, value_extractor);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result.get(&1), Some(&"a".to_string()));
+        assert_eq!(result.get(&2), Some(&"b".to_string()));
+        assert_eq!(result.get(&3), Some(&"c".to_string()));
+    }
+
+    #[test]
+    fn test_build_map_multiple_batches() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Int32, false),
+        ]));
+
+        let batch1 = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b"])),
+                Arc::new(Int32Array::from(vec![10, 20])),
+            ],
+        )
+        .unwrap();
+
+        let batch2 = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["c", "d"])),
+                Arc::new(Int32Array::from(vec![30, 40])),
+            ],
+        )
+        .unwrap();
+
+        let batches = vec![batch1, batch2];
+
+        let key_extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            Some(array.value(i).to_string())
+        };
+        let value_extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            Some(array.value(i))
+        };
+
+        let result = build_map_from_batches(&batches, key_extractor, value_extractor);
+        assert_eq!(result.len(), 4);
+        assert_eq!(result.get("a"), Some(&10));
+        assert_eq!(result.get("b"), Some(&20));
+        assert_eq!(result.get("c"), Some(&30));
+        assert_eq!(result.get("d"), Some(&40));
+    }
+
+    #[test]
+    fn test_build_map_with_duplicates() {
+        // Later values should overwrite earlier ones
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Int32, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "a"])),
+                Arc::new(Int32Array::from(vec![10, 20, 30])),
+            ],
+        )
+        .unwrap();
+
+        let batches = vec![batch];
+
+        let key_extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            Some(array.value(i).to_string())
+        };
+        let value_extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            Some(array.value(i))
+        };
+
+        let result = build_map_from_batches(&batches, key_extractor, value_extractor);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result.get("a"), Some(&30)); // Last value wins
+        assert_eq!(result.get("b"), Some(&20));
+    }
+
+    #[test]
+    fn test_build_map_with_none_values() {
+        // Test handling of None from extractors
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Int32, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+                Arc::new(Int32Array::from(vec![10, 20, 30, 40, 50])),
+            ],
+        )
+        .unwrap();
+
+        let batches = vec![batch];
+
+        // Only include even keys
+        let key_extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let key = array.value(i);
+            if key % 2 == 0 {
+                Some(key)
+            } else {
+                None
+            }
+        };
+        let value_extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            Some(array.value(i))
+        };
+
+        let result = build_map_from_batches(&batches, key_extractor, value_extractor);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result.get(&2), Some(&20));
+        assert_eq!(result.get(&4), Some(&40));
+    }
+
+    #[test]
+    fn test_build_map_large_batch() {
+        // Test with 1000 items
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("key", DataType::Int32, false),
+            Field::new("value", DataType::Int32, false),
+        ]));
+
+        let keys: Vec<i32> = (0..1000).collect();
+        let values: Vec<i32> = (0..1000).map(|i| i * 2).collect();
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(keys.clone())),
+                Arc::new(Int32Array::from(values.clone())),
+            ],
+        )
+        .unwrap();
+
+        let batches = vec![batch];
+
+        let key_extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            Some(array.value(i))
+        };
+        let value_extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            Some(array.value(i))
+        };
+
+        let result = build_map_from_batches(&batches, key_extractor, value_extractor);
+        assert_eq!(result.len(), 1000);
+        assert_eq!(result.get(&0), Some(&0));
+        assert_eq!(result.get(&500), Some(&1000));
+        assert_eq!(result.get(&999), Some(&1998));
+    }
+
+    #[test]
+    fn test_build_map_string_to_string() {
+        // Test typical content hash -> content pattern
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("hash", DataType::Utf8, false),
+            Field::new("content", DataType::Utf8, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec!["hash1", "hash2", "hash3"])),
+                Arc::new(StringArray::from(vec!["content1", "content2", "content3"])),
+            ],
+        )
+        .unwrap();
+
+        let batches = vec![batch];
+
+        let key_extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            Some(array.value(i).to_string())
+        };
+        let value_extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            Some(array.value(i).to_string())
+        };
+
+        let result = build_map_from_batches(&batches, key_extractor, value_extractor);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result.get("hash1"), Some(&"content1".to_string()));
+        assert_eq!(result.get("hash2"), Some(&"content2".to_string()));
+        assert_eq!(result.get("hash3"), Some(&"content3".to_string()));
+    }
+
+    #[test]
+    fn test_build_map_empty_batch_in_sequence() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("key", DataType::Int32, false),
+            Field::new("value", DataType::Int32, false),
+        ]));
+
+        let batch1 = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(Int32Array::from(vec![10, 20])),
+            ],
+        )
+        .unwrap();
+
+        let batch2 = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(Vec::<i32>::new())),
+                Arc::new(Int32Array::from(Vec::<i32>::new())),
+            ],
+        )
+        .unwrap();
+
+        let batch3 = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![3, 4])),
+                Arc::new(Int32Array::from(vec![30, 40])),
+            ],
+        )
+        .unwrap();
+
+        let batches = vec![batch1, batch2, batch3];
+
+        let key_extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            Some(array.value(i))
+        };
+        let value_extractor = |batch: &RecordBatch, i: usize| {
+            let array = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            Some(array.value(i))
+        };
+
+        let result = build_map_from_batches(&batches, key_extractor, value_extractor);
+        assert_eq!(result.len(), 4);
+        assert_eq!(result.get(&1), Some(&10));
+        assert_eq!(result.get(&2), Some(&20));
+        assert_eq!(result.get(&3), Some(&30));
+        assert_eq!(result.get(&4), Some(&40));
     }
 }

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -65,7 +65,8 @@ impl DatabaseManager {
 
     pub async fn create_tables(&self) -> Result<()> {
         self.schema_manager.create_all_tables().await?;
-        self.schema_manager.create_scalar_indices().await?;
+        // NOTE: Indexes are NOT created here! They should be built AFTER bulk inserts
+        // for optimal performance. Call rebuild_indices() after all inserts are complete.
         Ok(())
     }
 

--- a/src/database/functions.rs
+++ b/src/database/functions.rs
@@ -7,8 +7,10 @@ use futures::TryStreamExt;
 use lancedb::connection::Connection;
 use lancedb::query::{ExecutableQuery, QueryBase};
 use gxhash::{HashMap, HashMapExt, HashSet, HashSetExt};
+use smallvec::SmallVec;
 use std::sync::Arc;
 
+use crate::consts::SMALLVEC_PARAM_SIZE;
 use crate::database::connection::OPTIMAL_BATCH_SIZE;
 use crate::database::content::ContentStore;
 use crate::types::{FunctionInfo, ParameterInfo};
@@ -21,7 +23,7 @@ struct FunctionMetadata {
     pub line_start: u32,
     pub line_end: u32,
     pub return_type: String,
-    pub parameters: Vec<ParameterInfo>,
+    pub parameters: SmallVec<[ParameterInfo; SMALLVEC_PARAM_SIZE]>,
     pub body_hash: Option<String>,
     pub calls: Option<Vec<String>>,
     pub types: Option<Vec<String>>,
@@ -620,8 +622,8 @@ impl FunctionStore {
             .downcast_ref::<StringArray>()
             .unwrap();
 
-        let parameters: Vec<ParameterInfo> =
-            serde_json::from_str::<Vec<ParameterInfo>>(parameters_array.value(row))?;
+        let parameters: SmallVec<[ParameterInfo; SMALLVEC_PARAM_SIZE]> =
+            serde_json::from_str(parameters_array.value(row))?;
 
         // Get body hash if not null
         let body_hash = if body_hash_array.is_null(row) {
@@ -795,8 +797,8 @@ impl FunctionStore {
             .downcast_ref::<StringArray>()
             .unwrap();
 
-        let parameters: Vec<ParameterInfo> =
-            serde_json::from_str::<Vec<ParameterInfo>>(parameters_array.value(row))?;
+        let parameters: SmallVec<[ParameterInfo; SMALLVEC_PARAM_SIZE]> =
+            serde_json::from_str(parameters_array.value(row))?;
 
         // Get function body from content table using hash (if not null)
         let body = if body_hash_array.is_null(row) {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -7,6 +7,7 @@ mod functions;
 pub mod processed_files;
 mod schema;
 pub mod search;
+pub mod sql_utils;
 mod symbol_filename;
 mod types;
 mod vectors;

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
+pub mod batch_processing;
 pub mod calls;
 mod connection;
 pub mod content;

--- a/src/database/processed_files.rs
+++ b/src/database/processed_files.rs
@@ -4,9 +4,9 @@ use arrow::array::{Array, ArrayRef, RecordBatch, StringArray, StringBuilder};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatchIterator;
 use futures::TryStreamExt;
+use gxhash::{HashSet, HashSetExt};
 use lancedb::connection::Connection;
 use lancedb::query::{ExecutableQuery, QueryBase};
-use gxhash::{HashSet, HashSetExt};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]

--- a/src/database/processed_files.rs
+++ b/src/database/processed_files.rs
@@ -6,6 +6,7 @@ use arrow::record_batch::RecordBatchIterator;
 use futures::TryStreamExt;
 use lancedb::connection::Connection;
 use lancedb::query::{ExecutableQuery, QueryBase};
+use gxhash::{HashSet, HashSetExt};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -276,7 +277,7 @@ impl ProcessedFileStore {
     }
 
     /// Get only git file SHAs for efficient deduplication (much faster than loading full records)
-    pub async fn get_all_git_file_shas(&self) -> Result<std::collections::HashSet<String>> {
+    pub async fn get_all_git_file_shas(&self) -> Result<HashSet<String>> {
         use futures::TryStreamExt;
 
         let table = self
@@ -302,7 +303,7 @@ impl ProcessedFileStore {
             .try_collect::<Vec<_>>()
             .await?;
 
-        let mut sha_set = std::collections::HashSet::new();
+        let mut sha_set = HashSet::new();
         let mut processed_count = 0;
 
         for batch in &results {
@@ -340,9 +341,7 @@ impl ProcessedFileStore {
     }
 
     /// Get file/git_file_sha pairs for pipeline deduplication (optimized for large datasets)
-    pub async fn get_all_file_git_sha_pairs(
-        &self,
-    ) -> Result<std::collections::HashSet<(String, String)>> {
+    pub async fn get_all_file_git_sha_pairs(&self) -> Result<HashSet<(String, String)>> {
         use futures::TryStreamExt;
 
         let table = self
@@ -369,7 +368,7 @@ impl ProcessedFileStore {
             .try_collect::<Vec<_>>()
             .await?;
 
-        let mut pair_set = std::collections::HashSet::new();
+        let mut pair_set = HashSet::new();
         let mut processed_count = 0;
 
         for batch in &results {

--- a/src/database/search.rs
+++ b/src/database/search.rs
@@ -10,7 +10,7 @@ use lancedb::DistanceType;
 use crate::database::content::ContentStore;
 use crate::types::{FieldInfo, FunctionInfo, MacroInfo, ParameterInfo, TypeInfo, TypedefInfo};
 use crate::vectorizer::CodeVectorizer;
-use std::collections::HashMap;
+use gxhash::{HashMap, HashMapExt, HashSet, HashSetExt};
 
 #[derive(Debug)]
 pub struct FunctionMatch {
@@ -232,7 +232,7 @@ impl SearchManager {
         };
 
         // Extract unique file paths
-        let mut file_paths = std::collections::HashSet::new();
+        let mut file_paths = HashSet::new();
         for batch in &initial_results {
             let file_path_array = batch
                 .column(1)
@@ -507,7 +507,7 @@ impl SearchManager {
         };
 
         // Extract unique file paths
-        let mut file_paths = std::collections::HashSet::new();
+        let mut file_paths = HashSet::new();
         for batch in &initial_results {
             let file_path_array = batch
                 .column(1)
@@ -961,7 +961,7 @@ impl SearchManager {
         };
 
         // Extract unique file paths
-        let mut file_paths = std::collections::HashSet::new();
+        let mut file_paths = HashSet::new();
         for batch in &initial_results {
             let file_path_array = batch
                 .column(1)
@@ -1028,7 +1028,7 @@ impl SearchManager {
         };
 
         // Extract unique file paths
-        let mut file_paths = std::collections::HashSet::new();
+        let mut file_paths = HashSet::new();
         for batch in &initial_results {
             let file_path_array = batch
                 .column(1)
@@ -1361,7 +1361,7 @@ impl SearchManager {
         }
 
         // Extract unique file paths
-        let mut file_paths = std::collections::HashSet::new();
+        let mut file_paths = HashSet::new();
         for batch in &initial_results {
             let file_path_array = batch
                 .column(1)
@@ -1605,7 +1605,7 @@ impl SearchManager {
         }
 
         // Extract unique file paths
-        let mut file_paths = std::collections::HashSet::new();
+        let mut file_paths = HashSet::new();
         for batch in &initial_results {
             let file_path_array = batch
                 .column(1)
@@ -1853,7 +1853,7 @@ impl SearchManager {
         }
 
         // Extract unique file paths
-        let mut file_paths = std::collections::HashSet::new();
+        let mut file_paths = HashSet::new();
         for batch in &initial_results {
             let file_path_array = batch
                 .column(1)
@@ -2123,7 +2123,7 @@ impl SearchManager {
         }
 
         // Extract unique file paths
-        let mut file_paths = std::collections::HashSet::new();
+        let mut file_paths = HashSet::new();
         for batch in &initial_results {
             let file_path_array = batch
                 .column(1)
@@ -2795,7 +2795,7 @@ impl VectorSearchManager {
             .try_collect::<Vec<_>>()
             .await?;
 
-        let mut existing_commit_shas = std::collections::HashSet::new();
+        let mut existing_commit_shas = HashSet::new();
         for batch in &existing_vector_results {
             let sha_array = batch
                 .column(0)
@@ -3101,7 +3101,7 @@ impl VectorSearchManager {
                     let similarity_score = score_map.get(&git_sha).copied().unwrap_or(0.0);
 
                     let parent_sha: Vec<String> = serde_json::from_str(parent_sha_array.value(i))?;
-                    let tags: std::collections::HashMap<String, Vec<String>> =
+                    let tags: HashMap<String, Vec<String>> =
                         serde_json::from_str(tags_array.value(i))?;
                     let symbols: Vec<String> = serde_json::from_str(symbols_array.value(i))?;
                     let files: Vec<String> = serde_json::from_str(files_array.value(i))?;

--- a/src/database/search.rs
+++ b/src/database/search.rs
@@ -2653,7 +2653,7 @@ impl VectorSearchManager {
                         // Extract content from database results
                         let mut chunk_content = Vec::new();
                         for batch in &results {
-                            let blake3_hash_array = batch
+                            let gxhash_array = batch
                                 .column(0)
                                 .as_any()
                                 .downcast_ref::<arrow::array::StringArray>()
@@ -2665,7 +2665,7 @@ impl VectorSearchManager {
                                 .unwrap();
 
                             for i in 0..batch.num_rows() {
-                                let content_hash = blake3_hash_array.value(i).to_string();
+                                let content_hash = gxhash_array.value(i).to_string();
                                 let content = content_array.value(i).to_string();
 
                                 if !content.trim().is_empty() {

--- a/src/database/search.rs
+++ b/src/database/search.rs
@@ -3034,9 +3034,11 @@ impl VectorSearchManager {
             return Ok(Vec::new());
         }
 
-        // Create a map from git_sha to similarity score
-        let score_map: HashMap<String, f32> = sha_scores.iter().cloned().collect();
-        let shas: Vec<String> = sha_scores.into_iter().map(|(sha, _)| sha).collect();
+        // Create a map from git_sha to similarity score and collect SHAs in one pass
+        let (shas, score_map): (Vec<String>, HashMap<String, f32>) = sha_scores
+            .into_iter()
+            .map(|(sha, score)| (sha.clone(), (sha, score)))
+            .unzip();
 
         // Query git_commits table for these commit SHAs
         let commits_table = self.connection.open_table("git_commits").execute().await?;

--- a/src/database/search.rs
+++ b/src/database/search.rs
@@ -6,7 +6,9 @@ use lancedb::connection::Connection;
 use lancedb::index::{vector::IvfPqIndexBuilder, Index as LanceIndex};
 use lancedb::query::{ExecutableQuery, QueryBase};
 use lancedb::DistanceType;
+use smallvec::SmallVec;
 
+use crate::consts::{SMALLVEC_FIELD_SIZE, SMALLVEC_PARAM_SIZE};
 use crate::database::content::ContentStore;
 use crate::types::{FieldInfo, FunctionInfo, MacroInfo, ParameterInfo, TypeInfo, TypedefInfo};
 use crate::vectorizer::CodeVectorizer;
@@ -159,7 +161,7 @@ impl SearchManager {
                 .unwrap();
 
             for i in 0..batch.num_rows() {
-                let parameters: Vec<ParameterInfo> =
+                let parameters: SmallVec<[ParameterInfo; SMALLVEC_PARAM_SIZE]> =
                     serde_json::from_str(parameters_array.value(i))?;
 
                 // Get function body from content table using hash (if not null)
@@ -337,7 +339,7 @@ impl SearchManager {
                     .unwrap();
 
                 for i in 0..batch.num_rows() {
-                    let parameters: Vec<ParameterInfo> =
+                    let parameters: SmallVec<[ParameterInfo; SMALLVEC_PARAM_SIZE]> =
                         serde_json::from_str(parameters_array.value(i))?;
 
                     // Get function body from content table using hash (if not null)
@@ -445,7 +447,8 @@ impl SearchManager {
                 .unwrap();
 
             for i in 0..batch.num_rows() {
-                let fields: Vec<FieldInfo> = serde_json::from_str(fields_array.value(i))?;
+                let fields: SmallVec<[FieldInfo; SMALLVEC_FIELD_SIZE]> =
+                    serde_json::from_str(fields_array.value(i))?;
                 let size = if size_array.is_null(i) {
                     None
                 } else {
@@ -617,7 +620,8 @@ impl SearchManager {
                     .unwrap();
 
                 for i in 0..batch.num_rows() {
-                    let fields: Vec<FieldInfo> = serde_json::from_str(fields_array.value(i))?;
+                    let fields: SmallVec<[FieldInfo; SMALLVEC_FIELD_SIZE]> =
+                        serde_json::from_str(fields_array.value(i))?;
                     let size = if size_array.is_null(i) {
                         None
                     } else {
@@ -702,7 +706,8 @@ impl SearchManager {
                 .unwrap();
 
             for i in 0..batch.num_rows() {
-                let fields: Vec<FieldInfo> = serde_json::from_str(fields_array.value(i))?;
+                let fields: SmallVec<[FieldInfo; SMALLVEC_FIELD_SIZE]> =
+                    serde_json::from_str(fields_array.value(i))?;
                 let size = if size_array.is_null(i) {
                     None
                 } else {
@@ -1311,7 +1316,8 @@ impl SearchManager {
                     continue;
                 }
 
-                let fields: Vec<FieldInfo> = serde_json::from_str(fields_array.value(i))?;
+                let fields: SmallVec<[FieldInfo; SMALLVEC_FIELD_SIZE]> =
+                    serde_json::from_str(fields_array.value(i))?;
                 let size = if size_array.is_null(i) {
                     None
                 } else {
@@ -1466,7 +1472,8 @@ impl SearchManager {
                         continue;
                     }
 
-                    let fields: Vec<FieldInfo> = serde_json::from_str(fields_array.value(i))?;
+                    let fields: SmallVec<[FieldInfo; SMALLVEC_FIELD_SIZE]> =
+                        serde_json::from_str(fields_array.value(i))?;
                     let size = if size_array.is_null(i) {
                         None
                     } else {
@@ -1792,7 +1799,7 @@ impl SearchManager {
                     continue;
                 }
 
-                let parameters: Vec<ParameterInfo> =
+                let parameters: SmallVec<[ParameterInfo; SMALLVEC_PARAM_SIZE]> =
                     serde_json::from_str(parameters_array.value(i))?;
 
                 // Get function body from content table using hash (if not null)
@@ -1953,7 +1960,7 @@ impl SearchManager {
                         continue;
                     }
 
-                    let parameters: Vec<ParameterInfo> =
+                    let parameters: SmallVec<[ParameterInfo; SMALLVEC_PARAM_SIZE]> =
                         serde_json::from_str(parameters_array.value(i))?;
 
                     // Get function body from content table using hash (if not null)
@@ -2514,7 +2521,8 @@ impl VectorSearchManager {
             .downcast_ref::<StringArray>()
             .unwrap();
 
-        let parameters: Vec<ParameterInfo> = serde_json::from_str(parameters_array.value(row))?;
+        let parameters: SmallVec<[ParameterInfo; SMALLVEC_PARAM_SIZE]> =
+            serde_json::from_str(parameters_array.value(row))?;
 
         // Get function body from content table using hash (if not null)
         let body = if body_hash_array.is_null(row) {

--- a/src/database/search.rs
+++ b/src/database/search.rs
@@ -1390,6 +1390,9 @@ impl SearchManager {
         // Query with specific git_file_hashes using regexp_match
         let hash_values: Vec<String> = resolved_hashes.values().cloned().collect();
 
+        // Compile regex once before processing batches (performance optimization)
+        let regex = regex::Regex::new(pattern)?;
+
         let mut types = Vec::new();
         for chunk in hash_values.chunks(100) {
             let hash_conditions: Vec<String> = chunk
@@ -1459,10 +1462,6 @@ impl SearchManager {
                     }
 
                     // Apply regex matching in code since LanceDB has issues with combined conditions
-                    let regex = match regex::Regex::new(pattern) {
-                        Ok(r) => r,
-                        Err(_) => continue, // Skip invalid regex patterns
-                    };
                     if !regex.is_match(name) {
                         continue;
                     }
@@ -1635,6 +1634,9 @@ impl SearchManager {
         // Query with specific git_file_hashes using regexp_match for typedefs
         let hash_values: Vec<String> = resolved_hashes.values().cloned().collect();
 
+        // Compile regex once before processing batches (performance optimization)
+        let regex = regex::Regex::new(pattern)?;
+
         let mut typedefs = Vec::new();
         for chunk in hash_values.chunks(100) {
             let hash_conditions: Vec<String> = chunk
@@ -1694,10 +1696,6 @@ impl SearchManager {
                     }
 
                     // Apply regex matching in code since LanceDB has issues with combined conditions
-                    let regex = match regex::Regex::new(pattern) {
-                        Ok(r) => r,
-                        Err(_) => continue, // Skip invalid regex patterns
-                    };
                     if !regex.is_match(name) {
                         continue;
                     }
@@ -2009,6 +2007,9 @@ impl SearchManager {
             .try_collect::<Vec<_>>()
             .await?;
 
+        // Compile regex once before processing batches (performance optimization)
+        let regex = regex::Regex::new(pattern)?;
+
         let mut macros = Vec::new();
         for batch in &results {
             let name_array = batch
@@ -2051,10 +2052,6 @@ impl SearchManager {
                 let name = name_array.value(i);
 
                 // Apply regex matching in code
-                let regex = match regex::Regex::new(pattern) {
-                    Ok(r) => r,
-                    Err(_) => continue,
-                };
                 if !regex.is_match(name) {
                     continue;
                 }
@@ -2155,6 +2152,9 @@ impl SearchManager {
         // Query with specific git_file_hashes using regex filtering in code
         let hash_values: Vec<String> = resolved_hashes.values().cloned().collect();
 
+        // Compile regex once before processing batches (performance optimization)
+        let regex = regex::Regex::new(pattern)?;
+
         let mut macros = Vec::new();
         for chunk in hash_values.chunks(100) {
             let hash_conditions: Vec<String> = chunk
@@ -2212,10 +2212,6 @@ impl SearchManager {
                     let name = name_array.value(i);
 
                     // Apply regex matching in code
-                    let regex = match regex::Regex::new(pattern) {
-                        Ok(r) => r,
-                        Err(_) => continue,
-                    };
                     if !regex.is_match(name) {
                         continue;
                     }

--- a/src/database/sql_utils.rs
+++ b/src/database/sql_utils.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// SQL utility functions for database operations
+//
+// This module provides utilities for building SQL queries, particularly
+// for formatting large IN clauses efficiently.
+
+/// Format strings for use in SQL IN clauses
+///
+/// Takes a slice of strings and formats them as SQL-escaped strings
+/// wrapped in single quotes. This is commonly used for building WHERE IN clauses.
+///
+/// # Arguments
+/// * `items` - Slice of strings to format
+///
+/// # Returns
+/// Vec of formatted strings with SQL escaping and single quotes
+///
+/// # Examples
+/// ```
+/// use semcode::database::sql_utils::format_sql_strings;
+///
+/// let hashes = vec!["abc123", "def456"];
+/// let formatted = format_sql_strings(&hashes);
+/// assert_eq!(formatted, vec!["'abc123'", "'def456'"]);
+/// ```
+pub fn format_sql_strings(items: &[impl AsRef<str>]) -> Vec<String> {
+    items
+        .iter()
+        .map(|item| format!("'{}'", item.as_ref().replace("'", "''")))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_sql_strings_empty() {
+        let items: Vec<String> = vec![];
+        let result = format_sql_strings(&items);
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_format_sql_strings_single() {
+        let items = vec!["test"];
+        let result = format_sql_strings(&items);
+        assert_eq!(result, vec!["'test'"]);
+    }
+
+    #[test]
+    fn test_format_sql_strings_multiple() {
+        let items = vec!["abc", "def", "ghi"];
+        let result = format_sql_strings(&items);
+        assert_eq!(result, vec!["'abc'", "'def'", "'ghi'"]);
+    }
+
+    #[test]
+    fn test_format_sql_strings_with_quotes() {
+        let items = vec!["test's", "a'b'c"];
+        let result = format_sql_strings(&items);
+        assert_eq!(result, vec!["'test''s'", "'a''b''c'"]);
+    }
+
+    #[test]
+    fn test_format_sql_strings_hashes() {
+        // Test typical hash values
+        let items = vec!["abc123def456", "1234567890abcdef", "fedcba0987654321"];
+        let result = format_sql_strings(&items);
+        assert_eq!(
+            result,
+            vec!["'abc123def456'", "'1234567890abcdef'", "'fedcba0987654321'"]
+        );
+    }
+
+    #[test]
+    fn test_format_sql_strings_large_batch() {
+        // Test with larger batch (100 items)
+        let items: Vec<String> = (0..100).map(|i| format!("hash_{}", i)).collect();
+        let result = format_sql_strings(&items);
+        assert_eq!(result.len(), 100);
+        assert_eq!(result[0], "'hash_0'");
+        assert_eq!(result[99], "'hash_99'");
+    }
+
+    #[test]
+    fn test_format_sql_strings_special_chars() {
+        let items = vec!["test\nline", "test\ttab", "test\\slash"];
+        let result = format_sql_strings(&items);
+        assert_eq!(result, vec!["'test\nline'", "'test\ttab'", "'test\\slash'"]);
+    }
+
+    #[test]
+    fn test_format_sql_strings_empty_string() {
+        let items = vec![""];
+        let result = format_sql_strings(&items);
+        assert_eq!(result, vec!["''"]);
+    }
+
+    #[test]
+    fn test_format_sql_strings_unicode() {
+        let items = vec!["测试", "тест", "🦀"];
+        let result = format_sql_strings(&items);
+        assert_eq!(result, vec!["'测试'", "'тест'", "'🦀'"]);
+    }
+
+    #[test]
+    fn test_format_sql_strings_very_large_batch() {
+        // Test with 1000 items to verify performance characteristics
+        let items: Vec<String> = (0..1000).map(|i| format!("item_{}", i)).collect();
+        let result = format_sql_strings(&items);
+        assert_eq!(result.len(), 1000);
+        assert_eq!(result[0], "'item_0'");
+        assert_eq!(result[500], "'item_500'");
+        assert_eq!(result[999], "'item_999'");
+    }
+}

--- a/src/database/symbol_filename.rs
+++ b/src/database/symbol_filename.rs
@@ -4,9 +4,9 @@ use arrow::array::{ArrayRef, RecordBatch, StringBuilder};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatchIterator;
 use futures::TryStreamExt;
+use gxhash::{HashSet, HashSetExt};
 use lancedb::connection::Connection;
 use lancedb::query::{ExecutableQuery, QueryBase};
-use gxhash::{HashSet, HashSetExt};
 use std::sync::Arc;
 
 use crate::database::connection::OPTIMAL_BATCH_SIZE;

--- a/src/database/symbol_filename.rs
+++ b/src/database/symbol_filename.rs
@@ -6,6 +6,7 @@ use arrow::record_batch::RecordBatchIterator;
 use futures::TryStreamExt;
 use lancedb::connection::Connection;
 use lancedb::query::{ExecutableQuery, QueryBase};
+use gxhash::{HashSet, HashSetExt};
 use std::sync::Arc;
 
 use crate::database::connection::OPTIMAL_BATCH_SIZE;
@@ -47,8 +48,6 @@ impl SymbolFilenameStore {
     ) -> Result<()> {
         // Deduplicate pairs in memory before sending to database
         // This significantly reduces the workload on LanceDB's merge_insert
-        use std::collections::HashSet;
-
         let mut seen_keys = HashSet::new();
         let mut unique_pairs = Vec::new();
 
@@ -138,7 +137,7 @@ impl SymbolFilenameStore {
         // Deduplicate filenames (same symbol may appear multiple times if indexed at different git commits)
         let unique_filenames: Vec<String> = filenames
             .into_iter()
-            .collect::<std::collections::HashSet<_>>()
+            .collect::<HashSet<_>>()
             .into_iter()
             .collect();
 

--- a/src/database/types.rs
+++ b/src/database/types.rs
@@ -9,8 +9,10 @@ use futures::TryStreamExt;
 use lancedb::connection::Connection;
 use lancedb::query::{ExecutableQuery, QueryBase};
 use gxhash::{HashMap, HashMapExt, HashSet, HashSetExt};
+use smallvec::SmallVec;
 use std::sync::Arc;
 
+use crate::consts::SMALLVEC_FIELD_SIZE;
 use crate::database::connection::OPTIMAL_BATCH_SIZE;
 use crate::database::content::ContentStore;
 use crate::types::{FieldInfo, MacroInfo, TypeInfo, TypedefInfo};
@@ -23,7 +25,7 @@ struct TypeMetadata {
     pub line_start: u32,
     pub kind: String,
     pub size: Option<u64>,
-    pub members: Vec<FieldInfo>,
+    pub members: SmallVec<[FieldInfo; SMALLVEC_FIELD_SIZE]>,
     pub definition_hash: Option<String>,
     pub types: Option<Vec<String>>,
 }
@@ -514,7 +516,8 @@ impl TypeStore {
             .downcast_ref::<StringArray>()
             .unwrap();
 
-        let fields: Vec<FieldInfo> = serde_json::from_str(fields_array.value(row))?;
+        let fields: SmallVec<[FieldInfo; SMALLVEC_FIELD_SIZE]> =
+            serde_json::from_str(fields_array.value(row))?;
         let size = if size_array.is_null(row) {
             None
         } else {
@@ -725,7 +728,8 @@ impl TypeStore {
             .downcast_ref::<StringArray>()
             .unwrap();
 
-        let fields: Vec<FieldInfo> = serde_json::from_str(fields_array.value(row))?;
+        let fields: SmallVec<[FieldInfo; SMALLVEC_FIELD_SIZE]> =
+            serde_json::from_str(fields_array.value(row))?;
         let size = if size_array.is_null(row) {
             None
         } else {
@@ -814,7 +818,7 @@ impl TypedefStore {
                     line_start: typedef.line_start,
                     kind: "typedef".to_string(),
                     size: None,
-                    members: Vec::new(),
+                    members: SmallVec::new(),
                     definition: full_definition,
                     types: None, // Typedefs don't reference other types directly
                 }

--- a/src/database/vectors.rs
+++ b/src/database/vectors.rs
@@ -4,16 +4,16 @@ use arrow::array::{Array, ArrayRef, FixedSizeListArray, RecordBatch, StringArray
 use arrow::datatypes::{DataType, Field, Float32Type, Schema};
 use arrow::record_batch::RecordBatchIterator;
 use futures::TryStreamExt;
+use gxhash::{HashMap, HashMapExt};
 use lancedb::connection::Connection;
 use lancedb::query::{ExecutableQuery, QueryBase};
-use gxhash::{HashMap, HashMapExt};
 use std::sync::Arc;
 
 use crate::database::connection::OPTIMAL_BATCH_SIZE;
 
 #[derive(Debug, Clone)]
 pub struct VectorEntry {
-    pub content_hash: String, // Blake3 hash of the content
+    pub content_hash: String, // gxhash128 hash of the content
     pub vector: Vec<f32>,     // Variable-dimensional vector
 }
 
@@ -176,7 +176,7 @@ impl VectorStore {
 
     fn get_schema(&self, vector_dim: usize) -> Arc<Schema> {
         Arc::new(Schema::new(vec![
-            Field::new("content_hash", DataType::Utf8, false), // Blake3 content hash as hex string
+            Field::new("content_hash", DataType::Utf8, false), // gxhash128 content hash as hex string
             Field::new(
                 "vector",
                 DataType::FixedSizeList(

--- a/src/database/vectors.rs
+++ b/src/database/vectors.rs
@@ -6,7 +6,7 @@ use arrow::record_batch::RecordBatchIterator;
 use futures::TryStreamExt;
 use lancedb::connection::Connection;
 use lancedb::query::{ExecutableQuery, QueryBase};
-use std::collections::HashMap;
+use gxhash::{HashMap, HashMapExt};
 use std::sync::Arc;
 
 use crate::database::connection::OPTIMAL_BATCH_SIZE;

--- a/src/diffdump.rs
+++ b/src/diffdump.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use anyhow::Result;
 use colored::*;
-use std::collections::HashSet;
+use gxhash::{HashSet, HashSetExt};
 use std::io::Read;
 use std::path::Path;
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -34,8 +34,8 @@ pub fn resolve_to_commit<'a>(repo: &'a gix::Repository, revspec: &str) -> Result
         .try_into_commit()
         .map_err(|_| anyhow::anyhow!("'{}' does not resolve to a commit", revspec))
 }
-use once_cell::sync::Lazy;
 use gxhash::{HashSet, HashSetExt};
+use once_cell::sync::Lazy;
 use std::path::{Path, PathBuf};
 
 // Global cache for git file hashes - lock-free concurrent access

--- a/src/git.rs
+++ b/src/git.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use dashmap::DashMap;
 use gix;
 use gix::bstr::ByteSlice;
+use gxhash::{HashMap, HashMapExt};
 
 /// Helper function to resolve a revspec (SHA, tag, etc.) to a commit object
 /// Ensures that tags are properly dereferenced to their target commits
@@ -34,7 +35,7 @@ pub fn resolve_to_commit<'a>(repo: &'a gix::Repository, revspec: &str) -> Result
         .map_err(|_| anyhow::anyhow!("'{}' does not resolve to a commit", revspec))
 }
 use once_cell::sync::Lazy;
-use std::collections::HashSet;
+use gxhash::{HashSet, HashSetExt};
 use std::path::{Path, PathBuf};
 
 // Global cache for git file hashes - lock-free concurrent access
@@ -552,9 +553,9 @@ pub fn resolve_files_at_commit<P: AsRef<Path>>(
     repo_path: P,
     commit_sha: &str,
     file_paths: &[String],
-) -> Result<std::collections::HashMap<String, String>> {
+) -> Result<HashMap<String, String>> {
     let repo_path = repo_path.as_ref();
-    let mut resolved_hashes = std::collections::HashMap::new();
+    let mut resolved_hashes = HashMap::new();
 
     tracing::debug!(
         "Resolving {} file paths at commit {}",
@@ -936,7 +937,6 @@ pub fn write_diff_and_extract_symbols(
     file_path: &str,
 ) -> (std::fmt::Result, Vec<String>) {
     use similar::{ChangeTag, TextDiff};
-    use std::collections::HashSet;
     use std::fmt::Write;
 
     // Generate a proper diff using the Myers algorithm

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -3,12 +3,14 @@ use anyhow::Result;
 use std::path::Path;
 
 /// Compute git hash of file as hex string
+#[inline]
 pub fn compute_file_hash(file_path: &Path) -> Result<Option<String>> {
     crate::git::get_git_file_hash(file_path)
 }
 
 /// Compute git hash of string content as hex string
 /// For content that's not in a file, we use SHA-1 which is git's hash algorithm
+#[inline]
 pub fn compute_content_hash(content: &str) -> String {
     use sha1::{Digest, Sha1};
     let mut hasher = Sha1::new();
@@ -18,6 +20,7 @@ pub fn compute_content_hash(content: &str) -> String {
 
 /// Compute gxhash128 hash of content for deduplication
 /// gxhash is a fast non-cryptographic hash function with SIMD acceleration
+#[inline]
 pub fn compute_gxhash(content: &str) -> String {
     let hash = gxhash::gxhash128(content.as_bytes(), 0);
     format!("{:032x}", hash)

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -16,10 +16,11 @@ pub fn compute_content_hash(content: &str) -> String {
     hex::encode(hasher.finalize())
 }
 
-/// Compute blake3 hash of content for deduplication
-/// Blake3 is faster than SHA-1 and provides better collision resistance for content deduplication
-pub fn compute_blake3_hash(content: &str) -> String {
-    hex::encode(blake3::hash(content.as_bytes()).as_bytes())
+/// Compute gxhash128 hash of content for deduplication
+/// gxhash is a fast non-cryptographic hash function with SIMD acceleration
+pub fn compute_gxhash(content: &str) -> String {
+    let hash = gxhash::gxhash128(content.as_bytes(), 0);
+    format!("{:032x}", hash)
 }
 
 // Conversion functions removed - we now work directly with hex strings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 // Module declarations
+pub mod collection_utils;
 pub mod consts;
 pub mod database;
 pub mod database_utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 // Module declarations
+pub mod consts;
 pub mod database;
 pub mod database_utils;
 pub mod git;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Module declarations
-mod database;
+pub mod database;
 pub mod database_utils;
 pub mod git;
 pub mod hash;
@@ -8,9 +8,9 @@ pub mod perf_monitor;
 pub mod pipeline;
 pub mod symbol_walkback;
 pub mod text_utils;
-mod treesitter_analyzer;
-mod types;
-mod vectorizer;
+pub mod treesitter_analyzer;
+pub mod types;
+pub mod vectorizer;
 
 // Query functionality modules
 pub mod callchain;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Use mimalloc as the global allocator for better performance (10-20% faster)
+// Works on both Linux and macOS (including M1/M2)
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 // Module declarations
 pub mod database;
 pub mod database_utils;

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use std::collections::HashMap;
+use gxhash::{HashMap, HashMapExt};
 use std::sync::Mutex;
 
 const LINES_PER_PAGE: usize = 50;

--- a/src/perf_monitor.rs
+++ b/src/perf_monitor.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use once_cell::sync::Lazy;
-use std::collections::HashMap;
+use gxhash::{HashMap, HashMapExt};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};

--- a/src/perf_monitor.rs
+++ b/src/perf_monitor.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use once_cell::sync::Lazy;
 use gxhash::{HashMap, HashMapExt};
+use once_cell::sync::Lazy;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};

--- a/src/perf_monitor.rs
+++ b/src/perf_monitor.rs
@@ -17,6 +17,7 @@ pub fn enable_performance_monitoring() {
 }
 
 /// Check if performance monitoring is enabled
+#[inline]
 pub fn is_performance_monitoring_enabled() -> bool {
     PERF_MONITORING_ENABLED.load(Ordering::Relaxed)
 }
@@ -138,6 +139,7 @@ impl Drop for PerfGuard {
 }
 
 /// Create a performance guard for the current scope
+#[inline]
 pub fn perf_guard(name: impl Into<String>) -> PerfGuard {
     PerfGuard::new(name)
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -586,13 +586,10 @@ impl PipelineBuilder {
                                 batch.macros.extend(parsed.macros);
 
                                 // Create processed file record
-                                let file_path_str = {
-                                    let raw_path = parsed.path.to_string_lossy().to_string();
-                                    if raw_path.starts_with("./") {
-                                        raw_path.strip_prefix("./").unwrap().to_string()
-                                    } else {
-                                        raw_path
-                                    }
+                                let file_path_str = match parsed.path.to_str() {
+                                    Some(s) if s.starts_with("./") => s[2..].to_owned(),
+                                    Some(s) => s.to_owned(),
+                                    None => parsed.path.to_string_lossy().into_owned(),
                                 };
 
                                 batch.processed_files.push(
@@ -849,13 +846,10 @@ impl PipelineBuilder {
 
         for (file_path, git_file_sha) in git_manifest {
             // Normalize path for lookup (same as database storage)
-            let file_path_str = {
-                let raw_path = file_path.to_string_lossy().to_string();
-                if raw_path.starts_with("./") {
-                    raw_path.strip_prefix("./").unwrap().to_string()
-                } else {
-                    raw_path
-                }
+            let file_path_str = match file_path.to_str() {
+                Some(s) if s.starts_with("./") => s[2..].to_owned(),
+                Some(s) => s.to_owned(),
+                None => file_path.to_string_lossy().into_owned(),
             };
 
             let lookup_key = (file_path_str, git_file_sha.clone());

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -149,7 +149,7 @@
 use anyhow::Result;
 use crossbeam_channel::bounded;
 use indicatif::{ProgressBar, ProgressStyle};
-use std::collections::HashSet;
+use gxhash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -191,7 +191,7 @@ pub struct PipelineBuilder {
 
     // Tracking for incremental processing
     pub newly_processed_files: Arc<Mutex<HashSet<String>>>, // git_sha:filename pairs
-    pub git_sha: Option<String>,                            // Current git SHA for the source root
+    pub git_sha: Option<String>,                              // Current git SHA for the source root
 
     // Force reprocessing mode for incremental scans
     pub force_reprocess: bool,
@@ -284,7 +284,7 @@ impl PipelineBuilder {
     pub async fn build_and_run_with_git_files(
         self,
         _files: Vec<PathBuf>,
-        git_files: Option<std::collections::HashMap<PathBuf, GitFileEntry>>,
+        git_files: Option<HashMap<PathBuf, GitFileEntry>>,
     ) -> Result<()> {
         let num_threads = num_cpus::get();
         tracing::info!("=== PIPELINE START: {} threads available ===", num_threads);
@@ -805,7 +805,7 @@ impl PipelineBuilder {
     }
 
     /// Load git manifest of current commit - returns (file_path, git_file_sha) for all files
-    async fn load_git_manifest(&self) -> Result<std::collections::HashMap<PathBuf, String>> {
+    async fn load_git_manifest(&self) -> Result<HashMap<PathBuf, String>> {
         // Get current commit SHA
         let repo = gix::discover(&self.source_root)
             .map_err(|e| anyhow::anyhow!("Not in a git repository: {}", e))?;
@@ -818,7 +818,7 @@ impl PipelineBuilder {
             .tree()
             .map_err(|e| anyhow::anyhow!("Failed to get tree for HEAD commit: {}", e))?;
 
-        let mut manifest = std::collections::HashMap::new();
+        let mut manifest = HashMap::new();
 
         // Walk the entire git tree
         use gix::traverse::tree::Recorder;
@@ -841,7 +841,7 @@ impl PipelineBuilder {
     /// Filter manifest files against database - return files that need processing
     fn filter_files_by_manifest(
         &self,
-        git_manifest: &std::collections::HashMap<PathBuf, String>,
+        git_manifest: &HashMap<PathBuf, String>,
         processed_files_set: &HashSet<(String, String)>,
     ) -> Result<Vec<(PathBuf, String)>> {
         let mut files_to_process = Vec::new();

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -561,14 +561,13 @@ impl PipelineBuilder {
                     let start = Instant::now();
                     let mut total_processed = 0;
 
-                    let mut batch = ProcessedBatch {
-                        functions: Vec::new(),
-                        types: Vec::new(),
-                        macros: Vec::new(),
-                        processed_files: Vec::new(),
-                    };
-
                     let mut batch_size = 2000;
+                    let mut batch = ProcessedBatch {
+                        functions: Vec::with_capacity(batch_size),
+                        types: Vec::with_capacity(batch_size),
+                        macros: Vec::with_capacity(batch_size / 5), // Fewer macros typically
+                        processed_files: Vec::with_capacity(50),    // ~1 file per batch avg
+                    };
                     let mut last_batch_time = Instant::now();
 
                     loop {
@@ -634,10 +633,10 @@ impl PipelineBuilder {
                                     let batch_to_send = std::mem::replace(
                                         &mut batch,
                                         ProcessedBatch {
-                                            functions: Vec::new(),
-                                            types: Vec::new(),
-                                            macros: Vec::new(),
-                                            processed_files: Vec::new(),
+                                            functions: Vec::with_capacity(batch_size),
+                                            types: Vec::with_capacity(batch_size),
+                                            macros: Vec::with_capacity(batch_size / 5),
+                                            processed_files: Vec::with_capacity(50),
                                         },
                                     );
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -148,8 +148,8 @@
 // ==============================================================================
 use anyhow::Result;
 use crossbeam_channel::bounded;
-use indicatif::{ProgressBar, ProgressStyle};
 use gxhash::{HashMap, HashMapExt, HashSet, HashSetExt};
+use indicatif::{ProgressBar, ProgressStyle};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -191,7 +191,7 @@ pub struct PipelineBuilder {
 
     // Tracking for incremental processing
     pub newly_processed_files: Arc<Mutex<HashSet<String>>>, // git_sha:filename pairs
-    pub git_sha: Option<String>,                              // Current git SHA for the source root
+    pub git_sha: Option<String>,                            // Current git SHA for the source root
 
     // Force reprocessing mode for incremental scans
     pub force_reprocess: bool,

--- a/src/search.rs
+++ b/src/search.rs
@@ -588,10 +588,10 @@ async fn query_function_or_macro_to_writer_with_options(
             writeln!(writer, "\n{} Macro:", "==>".bold().blue())?;
             display_macro_to_writer(&macro_info, writer)?;
             // Get and display call relationships for the macro too (use macro's calls field directly)
-            let macro_calls = macro_info.calls.clone().unwrap_or_default();
+            let macro_calls = macro_info.calls.as_deref().unwrap_or(&[]);
             display_call_relationships_with_options(
                 &macro_info.name,
-                &macro_calls,
+                macro_calls,
                 &[],
                 writer,
                 true,
@@ -735,13 +735,13 @@ async fn query_function_or_macro_to_writer_with_options(
             // Found macro only
             display_macro_to_writer(&macro_info, writer)?;
             // Get and display call relationships for macros too (use macro's calls field directly)
-            let calls = macro_info.calls.clone().unwrap_or_default();
+            let calls = macro_info.calls.as_deref().unwrap_or(&[]);
             let called_by = db
                 .get_function_callers_git_aware(&macro_info.name, git_sha)
                 .await?;
             display_call_relationships_with_truncation(
                 &macro_info.name,
-                &calls,
+                calls,
                 &called_by,
                 writer,
                 true,

--- a/src/search.rs
+++ b/src/search.rs
@@ -2,8 +2,8 @@
 use crate::{CodeVectorizer, DatabaseManager};
 use anstream::stdout;
 use anyhow::Result;
-use owo_colors::OwoColorize as _;
 use gxhash::{HashSet, HashSetExt};
+use owo_colors::OwoColorize as _;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use owo_colors::OwoColorize as _;
 use gxhash::{HashSet, HashSetExt};
 use std::fs::File;
-use std::io::Write;
+use std::io::{BufWriter, Write};
 
 use crate::display::{
     display_function_to_writer_with_options, display_macro_to_writer, display_type_to_writer,
@@ -253,7 +253,7 @@ pub async fn dump_functions(db: &DatabaseManager, output_file: &str) -> Result<(
     let functions = db.get_all_functions_metadata_only().await?;
     let json = serde_json::to_string_pretty(&functions)?;
 
-    let mut file = File::create(output_file)?;
+    let mut file = BufWriter::new(File::create(output_file)?);
     file.write_all(json.as_bytes())?;
 
     println!(
@@ -272,7 +272,7 @@ pub async fn dump_types(db: &DatabaseManager, output_file: &str) -> Result<()> {
     let types = db.get_all_types_metadata_only().await?;
     let json = serde_json::to_string_pretty(&types)?;
 
-    let mut file = File::create(output_file)?;
+    let mut file = BufWriter::new(File::create(output_file)?);
     file.write_all(json.as_bytes())?;
 
     println!(
@@ -291,7 +291,7 @@ pub async fn dump_typedefs(db: &DatabaseManager, output_file: &str) -> Result<()
     let typedefs = db.get_all_typedefs().await?;
     let json = serde_json::to_string_pretty(&typedefs)?;
 
-    let mut file = File::create(output_file)?;
+    let mut file = BufWriter::new(File::create(output_file)?);
     file.write_all(json.as_bytes())?;
 
     println!(
@@ -310,7 +310,7 @@ pub async fn dump_macros(db: &DatabaseManager, output_file: &str) -> Result<()> 
     let macros = db.get_all_macros_metadata_only().await?;
     let json = serde_json::to_string_pretty(&macros)?;
 
-    let mut file = File::create(output_file)?;
+    let mut file = BufWriter::new(File::create(output_file)?);
     file.write_all(json.as_bytes())?;
 
     println!(
@@ -352,7 +352,7 @@ pub async fn dump_calls(db: &DatabaseManager, output_file: &str) -> Result<()> {
 
     let json = serde_json::to_string_pretty(&json_calls)?;
 
-    let mut file = File::create(output_file)?;
+    let mut file = BufWriter::new(File::create(output_file)?);
     file.write_all(json.as_bytes())?;
 
     println!(
@@ -379,7 +379,7 @@ pub async fn dump_processed_files(db: &DatabaseManager, output_file: &str) -> Re
 
     let json = serde_json::to_string_pretty(&json_records)?;
 
-    let mut file = File::create(output_file)?;
+    let mut file = BufWriter::new(File::create(output_file)?);
     file.write_all(json.as_bytes())?;
 
     println!(
@@ -405,7 +405,7 @@ pub async fn dump_content(db: &DatabaseManager, output_file: &str) -> Result<()>
 
     let json = serde_json::to_string_pretty(&json_records)?;
 
-    let mut file = File::create(output_file)?;
+    let mut file = BufWriter::new(File::create(output_file)?);
     file.write_all(json.as_bytes())?;
 
     println!(
@@ -440,7 +440,7 @@ pub async fn dump_symbol_filename(db: &DatabaseManager, output_file: &str) -> Re
 
     let json = serde_json::to_string_pretty(&json_records)?;
 
-    let mut file = File::create(output_file)?;
+    let mut file = BufWriter::new(File::create(output_file)?);
     file.write_all(json.as_bytes())?;
 
     println!(
@@ -459,7 +459,7 @@ pub async fn dump_git_commits(db: &DatabaseManager, output_file: &str) -> Result
     let commits = db.get_all_git_commits().await?;
     let json = serde_json::to_string_pretty(&commits)?;
 
-    let mut file = File::create(output_file)?;
+    let mut file = BufWriter::new(File::create(output_file)?);
     file.write_all(json.as_bytes())?;
 
     println!(

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,6 +3,7 @@ use crate::{CodeVectorizer, DatabaseManager};
 use anstream::stdout;
 use anyhow::Result;
 use owo_colors::OwoColorize as _;
+use gxhash::{HashSet, HashSetExt};
 use std::fs::File;
 use std::io::Write;
 
@@ -806,7 +807,7 @@ async fn query_function_or_macro_to_writer_with_options(
                     }
 
                     // Collect and display callers for all matched function definitions and macros
-                    let mut all_callers = std::collections::HashSet::new();
+                    let mut all_callers = HashSet::new();
                     for func in &regex_definitions {
                         let func_callers = get_function_callers(db, &func.name).await?;
                         all_callers.extend(func_callers);
@@ -863,7 +864,7 @@ async fn query_function_or_macro_to_writer_with_options(
 
                     // For regex results with multiple function definitions, collect unique function names and show consolidated callers
                     if regex_definitions.len() > 1 {
-                        let mut all_callers = std::collections::HashSet::new();
+                        let mut all_callers = HashSet::new();
                         for func in &regex_definitions {
                             let func_callers = get_function_callers(db, &func.name).await?;
                             all_callers.extend(func_callers);
@@ -930,7 +931,7 @@ async fn query_function_or_macro_to_writer_with_options(
 
                     // For regex results with multiple macros, collect unique callers and show consolidated callers
                     if regex_macros.len() > 1 {
-                        let mut all_callers = std::collections::HashSet::new();
+                        let mut all_callers = HashSet::new();
                         for macro_info in &regex_macros {
                             let macro_callers = get_function_callers(db, &macro_info.name).await?;
                             all_callers.extend(macro_callers);

--- a/src/symbol_walkback.rs
+++ b/src/symbol_walkback.rs
@@ -5,11 +5,14 @@
 //! to find enclosing function, struct, or macro definitions. This is much faster than
 //! full TreeSitter parsing while still accurately identifying modified symbols.
 
-use std::collections::HashSet;
+use gxhash::{HashSet, HashSetExt};
 
 /// Extract symbols by walking back from modified lines to find function/struct/macro definitions
 /// Returns formatted symbol names (e.g., "function_name()", "struct foo", "#MACRO")
-pub fn extract_symbols_by_walkback(content: &str, modified_lines: &HashSet<usize>) -> Vec<String> {
+pub fn extract_symbols_by_walkback(
+    content: &str,
+    modified_lines: &HashSet<usize>,
+) -> Vec<String> {
     let mut symbols = HashSet::new();
     let lines: Vec<&str> = content.lines().collect();
 

--- a/src/symbol_walkback.rs
+++ b/src/symbol_walkback.rs
@@ -9,10 +9,7 @@ use gxhash::{HashSet, HashSetExt};
 
 /// Extract symbols by walking back from modified lines to find function/struct/macro definitions
 /// Returns formatted symbol names (e.g., "function_name()", "struct foo", "#MACRO")
-pub fn extract_symbols_by_walkback(
-    content: &str,
-    modified_lines: &HashSet<usize>,
-) -> Vec<String> {
+pub fn extract_symbols_by_walkback(content: &str, modified_lines: &HashSet<usize>) -> Vec<String> {
     let mut symbols = HashSet::new();
     let lines: Vec<&str> = content.lines().collect();
 

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use anyhow::Result;
 use regex::Regex;
-use std::collections::HashMap;
+use gxhash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use std::path::Path;
 use std::sync::LazyLock;
 use streaming_iterator::StreamingIterator;
@@ -471,7 +471,7 @@ impl TreeSitterAnalyzer {
 
             if let Some(name) = function_name {
                 // Track which capture patterns were matched to determine if function has body
-                let mut matched_patterns = std::collections::HashSet::new();
+                let mut matched_patterns = HashSet::new();
                 for capture in m.captures {
                     let capture_name = self.function_query.capture_names()[capture.index as usize];
                     matched_patterns.insert(capture_name);
@@ -2041,9 +2041,7 @@ impl TreeSitterAnalyzer {
         &self,
         raw_functions: Vec<FunctionInfo>,
     ) -> Vec<FunctionInfo> {
-        use std::collections::HashMap;
-
-        let mut seen_functions = HashMap::<String, FunctionInfo>::new();
+        let mut seen_functions = HashMap::<String, FunctionInfo>::default();
 
         for func in raw_functions {
             let key = func.name.clone();
@@ -2090,9 +2088,7 @@ impl TreeSitterAnalyzer {
     /// Deduplicate types within a single file
     /// Simple deduplication by (name, kind) - types should be unique within a file anyway
     fn deduplicate_types_within_file(&self, raw_types: Vec<TypeInfo>) -> Vec<TypeInfo> {
-        use std::collections::HashMap;
-
-        let mut seen_types = HashMap::<(String, String), TypeInfo>::new();
+        let mut seen_types = HashMap::<(String, String), TypeInfo>::default();
 
         for type_info in raw_types {
             let key = (type_info.name.clone(), type_info.kind.clone());
@@ -2122,9 +2118,7 @@ impl TreeSitterAnalyzer {
     /// Deduplicate macros within a single file  
     /// Simple deduplication by name - macros should be unique within a file anyway
     fn deduplicate_macros_within_file(&self, raw_macros: Vec<MacroInfo>) -> Vec<MacroInfo> {
-        use std::collections::HashMap;
-
-        let mut seen_macros = HashMap::<String, MacroInfo>::new();
+        let mut seen_macros = HashMap::<String, MacroInfo>::default();
 
         for macro_info in raw_macros {
             let key = macro_info.name.clone();

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use anyhow::Result;
-use regex::Regex;
 use gxhash::{HashMap, HashMapExt, HashSet, HashSetExt};
+use regex::Regex;
 use smallvec::SmallVec;
 use std::path::Path;
 use std::sync::LazyLock;

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -1035,7 +1035,7 @@ impl TreeSitterAnalyzer {
         node: tree_sitter::Node,
         source: &str,
     ) -> Vec<ParameterInfo> {
-        let mut parameters = Vec::new();
+        let mut parameters = Vec::with_capacity(8); // Most functions have <8 parameters
 
         // Walk through the parameter_list node to find parameter_declaration children
         let mut cursor = node.walk();
@@ -1072,7 +1072,7 @@ impl TreeSitterAnalyzer {
         node: tree_sitter::Node,
         source: &str,
     ) -> Vec<ParameterInfo> {
-        let mut parameters = Vec::new();
+        let mut parameters = Vec::with_capacity(8); // Most functions have <8 parameters
         let text = &source[node.byte_range()];
 
         // Remove newlines and normalize whitespace for easier parsing
@@ -1803,7 +1803,7 @@ impl TreeSitterAnalyzer {
 
     /// Generate common variations of type names for lookup
     fn generate_type_name_variants(&self, base_name: &str) -> Vec<String> {
-        let mut variants = Vec::new();
+        let mut variants = Vec::with_capacity(6); // Max 6 variants (struct/union/enum + with/without prefix)
 
         // Add struct prefix if not present
         if !base_name.starts_with("struct ")

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
+use gxhash::{HashMap, HashMapExt};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FunctionInfo {
@@ -77,15 +77,15 @@ pub struct MacroInfo {
 /// Git commit metadata with changed symbols
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitCommitInfo {
-    pub git_sha: String,                    // The commit SHA
-    pub parent_sha: Vec<String>,            // Parent commit SHAs (multiple for merges)
-    pub author: String,                     // Author name and email
-    pub subject: String,                    // Single line commit title
-    pub message: String,                    // Full commit message
+    pub git_sha: String,                      // The commit SHA
+    pub parent_sha: Vec<String>,              // Parent commit SHAs (multiple for merges)
+    pub author: String,                       // Author name and email
+    pub subject: String,                      // Single line commit title
+    pub message: String,                      // Full commit message
     pub tags: HashMap<String, Vec<String>>, // Tags from commit message (Signed-off-by:, etc.)
-    pub diff: String,                       // Full unified diff
-    pub symbols: Vec<String>,               // Changed symbols (filename:symbol() format)
-    pub files: Vec<String>,                 // List of files changed by this commit
+    pub diff: String,                         // Full unified diff
+    pub symbols: Vec<String>,                 // Changed symbols (filename:symbol() format)
+    pub files: Vec<String>,                   // List of files changed by this commit
 }
 
 /// Global type registry for cross-file type resolution

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use gxhash::{HashMap, HashMapExt};
+use crate::consts::{SMALLVEC_FIELD_SIZE, SMALLVEC_PARAM_SIZE};
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FunctionInfo {
@@ -10,7 +12,7 @@ pub struct FunctionInfo {
     pub line_start: u32,
     pub line_end: u32,
     pub return_type: String,
-    pub parameters: Vec<ParameterInfo>,
+    pub parameters: SmallVec<[ParameterInfo; SMALLVEC_PARAM_SIZE]>, // Most functions have <=10 parameters
     pub body: String,
     #[serde(default)]
     pub calls: Option<Vec<String>>, // Function names called by this function
@@ -36,7 +38,7 @@ pub struct TypeInfo {
     pub line_start: u32,
     pub kind: String,
     pub size: Option<u64>,
-    pub members: Vec<FieldInfo>,
+    pub members: SmallVec<[FieldInfo; SMALLVEC_FIELD_SIZE]>, // Most structs have <=20 fields
     pub definition: String, // Added to store raw type definition with comments
     #[serde(default)]
     pub types: Option<Vec<String>>, // Type names referenced by this type

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use gxhash::{HashMap, HashMapExt};
 use crate::consts::{SMALLVEC_FIELD_SIZE, SMALLVEC_PARAM_SIZE};
+use gxhash::{HashMap, HashMapExt};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
@@ -79,15 +79,15 @@ pub struct MacroInfo {
 /// Git commit metadata with changed symbols
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitCommitInfo {
-    pub git_sha: String,                      // The commit SHA
-    pub parent_sha: Vec<String>,              // Parent commit SHAs (multiple for merges)
-    pub author: String,                       // Author name and email
-    pub subject: String,                      // Single line commit title
-    pub message: String,                      // Full commit message
+    pub git_sha: String,                    // The commit SHA
+    pub parent_sha: Vec<String>,            // Parent commit SHAs (multiple for merges)
+    pub author: String,                     // Author name and email
+    pub subject: String,                    // Single line commit title
+    pub message: String,                    // Full commit message
     pub tags: HashMap<String, Vec<String>>, // Tags from commit message (Signed-off-by:, etc.)
-    pub diff: String,                         // Full unified diff
-    pub symbols: Vec<String>,                 // Changed symbols (filename:symbol() format)
-    pub files: Vec<String>,                   // List of files changed by this commit
+    pub diff: String,                       // Full unified diff
+    pub symbols: Vec<String>,               // Changed symbols (filename:symbol() format)
+    pub files: Vec<String>,                 // List of files changed by this commit
 }
 
 /// Global type registry for cross-file type resolution

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,4 @@
+# tools
+
+### analyze_kernel_stats.py 
+install uv and ./analyze_kernel_stats.py path_to_repo or uv run analyze_kernel_stats path_to_repo

--- a/tools/analyze_kernel_stats.py
+++ b/tools/analyze_kernel_stats.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "tree-sitter>=0.23.0",
+#     "tree-sitter-c>=0.23.0",
+# ]
+# ///
+"""
+Analyze Linux kernel C code to determine optimal SmallVec sizes.
+
+This script parses C files using tree-sitter and collects statistics on:
+1. Number of parameters per function
+2. Number of fields per struct/union/enum
+
+Usage:
+    uv run analyze_kernel_stats.py /path/to/linux
+
+    or:
+
+    ./analyze_kernel_stats.py /path/to/linux
+"""
+
+import sys
+import os
+from pathlib import Path
+from collections import Counter
+import tree_sitter_c as tsc
+from tree_sitter import Language, Parser, Query
+
+def get_c_files(root_path):
+    """Find all .c and .h files in the directory."""
+    root = Path(root_path)
+    for ext in ['*.c', '*.h']:
+        yield from root.rglob(ext)
+
+def count_parameters(node, source_code):
+    """Count parameters in a parameter_list node."""
+    if node.type != 'parameter_list':
+        return 0
+
+    # Count parameter_declaration children
+    count = 0
+    for child in node.children:
+        if child.type == 'parameter_declaration':
+            count += 1
+        # Handle variadic parameters (...)
+        elif child.type == '...':
+            count += 1
+
+    return count
+
+def count_fields(node, source_code):
+    """Count fields in a struct/union/enum body."""
+    if node.type not in ['field_declaration_list', 'enumerator_list']:
+        return 0
+
+    count = 0
+    for child in node.children:
+        if child.type == 'field_declaration':
+            # A field_declaration can declare multiple fields: "int a, b, c;"
+            # Count the number of declarators
+            declarators = [c for c in child.children if c.type in ['field_identifier', 'pointer_declarator', 'array_declarator']]
+            count += max(1, len(declarators))
+        elif child.type == 'enumerator':
+            count += 1
+
+    return count
+
+def analyze_file(file_path, parser):
+    """Analyze a single C file and return statistics."""
+    try:
+        with open(file_path, 'rb') as f:
+            source_code = f.read()
+
+        tree = parser.parse(source_code)
+        root_node = tree.root_node
+
+        param_counts = []
+        field_counts = []
+
+        # Walk the tree to find functions and types
+        def walk_tree(node):
+            # Function definitions
+            if node.type == 'function_definition':
+                for child in node.children:
+                    if child.type == 'function_declarator':
+                        for subchild in child.children:
+                            if subchild.type == 'parameter_list':
+                                count = count_parameters(subchild, source_code)
+                                param_counts.append(count)
+
+            # Function declarations (prototypes)
+            elif node.type == 'declaration':
+                for child in node.children:
+                    if child.type == 'function_declarator':
+                        for subchild in child.children:
+                            if subchild.type == 'parameter_list':
+                                count = count_parameters(subchild, source_code)
+                                param_counts.append(count)
+
+            # Struct/union definitions
+            elif node.type in ['struct_specifier', 'union_specifier']:
+                for child in node.children:
+                    if child.type == 'field_declaration_list':
+                        count = count_fields(child, source_code)
+                        field_counts.append(count)
+
+            # Enum definitions
+            elif node.type == 'enum_specifier':
+                for child in node.children:
+                    if child.type == 'enumerator_list':
+                        count = count_fields(child, source_code)
+                        field_counts.append(count)
+
+            # Recurse
+            for child in node.children:
+                walk_tree(child)
+
+        walk_tree(root_node)
+        return param_counts, field_counts
+
+    except Exception as e:
+        # Skip files that can't be parsed
+        return [], []
+
+def calculate_percentiles(data, percentiles=[50, 75, 90, 95, 99]):
+    """Calculate percentiles from a sorted list."""
+    if not data:
+        return {p: 0 for p in percentiles}
+
+    sorted_data = sorted(data)
+    n = len(sorted_data)
+
+    result = {}
+    for p in percentiles:
+        index = int(n * p / 100)
+        if index >= n:
+            index = n - 1
+        result[p] = sorted_data[index]
+
+    return result
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <path-to-linux-kernel>")
+        sys.exit(1)
+
+    kernel_path = sys.argv[1]
+    if not os.path.isdir(kernel_path):
+        print(f"Error: {kernel_path} is not a directory")
+        sys.exit(1)
+
+    print(f"Analyzing C files in {kernel_path}...")
+    print("This may take several minutes...\n")
+
+    # Initialize tree-sitter parser
+    C_LANGUAGE = Language(tsc.language())
+    parser = Parser(C_LANGUAGE)
+
+    all_param_counts = []
+    all_field_counts = []
+
+    files_processed = 0
+    for file_path in get_c_files(kernel_path):
+        param_counts, field_counts = analyze_file(file_path, parser)
+        all_param_counts.extend(param_counts)
+        all_field_counts.extend(field_counts)
+
+        files_processed += 1
+        if files_processed % 1000 == 0:
+            print(f"Processed {files_processed} files... "
+                  f"({len(all_param_counts)} functions, {len(all_field_counts)} types)")
+
+    print(f"\n{'='*70}")
+    print(f"Total files processed: {files_processed}")
+    print(f"Total functions found: {len(all_param_counts)}")
+    print(f"Total types found: {len(all_field_counts)}")
+    print(f"{'='*70}\n")
+
+    # Parameter statistics
+    print("FUNCTION PARAMETER COUNTS:")
+    print("-" * 70)
+    if all_param_counts:
+        param_counter = Counter(all_param_counts)
+        print(f"Mean: {sum(all_param_counts) / len(all_param_counts):.2f}")
+        print(f"Max: {max(all_param_counts)}")
+
+        print("\nDistribution (most common):")
+        for count, freq in param_counter.most_common(15):
+            percentage = (freq / len(all_param_counts)) * 100
+            bar = '█' * int(percentage)
+            print(f"  {count:2d} params: {freq:7d} ({percentage:5.2f}%) {bar}")
+
+        print("\nPercentiles:")
+        percentiles = calculate_percentiles(all_param_counts)
+        for p, value in percentiles.items():
+            print(f"  {p:3d}th percentile: {value}")
+
+        # Calculate coverage for different SmallVec sizes
+        print("\nCoverage by SmallVec size:")
+        for size in [2, 3, 4, 5, 6, 8, 10]:
+            covered = sum(1 for c in all_param_counts if c <= size)
+            percentage = (covered / len(all_param_counts)) * 100
+            print(f"  Size {size:2d}: {percentage:5.2f}% of functions fit on stack")
+
+    print(f"\n{'='*70}\n")
+
+    # Field statistics
+    print("STRUCT/UNION/ENUM FIELD COUNTS:")
+    print("-" * 70)
+    if all_field_counts:
+        field_counter = Counter(all_field_counts)
+        print(f"Mean: {sum(all_field_counts) / len(all_field_counts):.2f}")
+        print(f"Max: {max(all_field_counts)}")
+
+        print("\nDistribution (most common):")
+        for count, freq in field_counter.most_common(15):
+            percentage = (freq / len(all_field_counts)) * 100
+            bar = '█' * int(percentage)
+            print(f"  {count:2d} fields: {freq:7d} ({percentage:5.2f}%) {bar}")
+
+        print("\nPercentiles:")
+        percentiles = calculate_percentiles(all_field_counts)
+        for p, value in percentiles.items():
+            print(f"  {p:3d}th percentile: {value}")
+
+        # Calculate coverage for different SmallVec sizes
+        print("\nCoverage by SmallVec size:")
+        for size in [4, 6, 8, 10, 12, 16, 20]:
+            covered = sum(1 for c in all_field_counts if c <= size)
+            percentage = (covered / len(all_field_counts)) * 100
+            print(f"  Size {size:2d}: {percentage:5.2f}% of types fit on stack")
+
+    print(f"\n{'='*70}\n")
+
+    # Recommendations
+    print("RECOMMENDATIONS:")
+    print("-" * 70)
+
+    if all_param_counts:
+        p90 = calculate_percentiles(all_param_counts, [90])[90]
+        print(f"Function parameters: SmallVec<[ParameterInfo; {p90}]>")
+        print(f"  (covers 90% of functions)")
+
+    if all_field_counts:
+        p90 = calculate_percentiles(all_field_counts, [90])[90]
+        print(f"Struct/union/enum fields: SmallVec<[FieldInfo; {p90}]>")
+        print(f"  (covers 90% of types)")
+
+    print()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR has a collection of performance improvements for semcode. The commits in this PR are structured such that it *should* be easy (or at least, not hard) to pick and choose the ones we want.

To enable the refactoring and edits this required, this PR also adds a bunch of tests and benchmarks.

I collected some high level data on this PR to help make going over it easier.

### Benchmarks delta between commit in which initial benchmarks were added and HEAD
```
❯ critcmp before after
group                                                      after                                    before
-----                                                      -----                                    ------
batch_insertion/combined_insert/100                        1.00     19.1±0.68ms  5.1 KElem/sec      5.66    108.1±2.58ms   925 Elem/sec
batch_insertion/combined_insert/1000                       1.00     23.8±0.83ms 41.0 KElem/sec      5.16    122.8±2.84ms  8.0 KElem/sec
batch_insertion/combined_insert/5000                       1.00     35.9±1.67ms 136.0 KElem/sec     4.06    145.6±3.13ms 33.5 KElem/sec
batch_processing/large_batches_10000_rows                  1.00  1492.2±48.22µs  6.4 MElem/sec
batch_processing/large_batches_with_filter                 1.00  1011.6±22.37µs  9.4 MElem/sec
batch_processing/small_batches_1000_rows                   1.00    366.2±7.36µs  2.6 MElem/sec
collect_paths/collect_1000_paths                           1.00   299.1±13.65µs  3.2 MElem/sec
collect_paths/collect_1000_paths_with_duplicates           1.00    300.2±4.37µs  3.2 MElem/sec
collect_paths/collect_100_paths                            1.00      2.2±0.03µs 43.4 MElem/sec
collect_paths/collect_10_paths                             1.00    256.4±4.80ns 37.2 MElem/sec
collect_paths/collect_5000_paths                           1.00   626.6±14.95µs  7.6 MElem/sec
content_deduplication/hash_all_bodies                      1.00     58.6±0.44µs 16.3 MElem/sec      3.73   218.8±10.11µs  4.4 MElem/sec
dump_operations/dump_functions/100                         1.00   770.0±43.42µs 126.8 KElem/sec     1.15   884.8±29.74µs 110.4 KElem/sec
dump_operations/dump_functions/1000                        1.00  1749.7±102.57µs 558.1 KElem/sec    1.23      2.2±0.12ms 452.0 KElem/sec
dump_operations/dump_functions/5000                        1.00      5.0±0.52ms 975.8 KElem/sec     1.31      6.5±0.47ms 745.6 KElem/sec
dump_operations/dump_macros/100                            1.00   817.7±28.36µs 119.4 KElem/sec     1.12   915.8±27.37µs 106.6 KElem/sec
dump_operations/dump_macros/1000                           1.00  1083.4±64.15µs 901.4 KElem/sec     1.13  1221.4±51.45µs 799.5 KElem/sec
dump_operations/dump_macros/5000                           1.00  1903.1±117.15µs  2.5 MElem/sec     1.29      2.4±0.15ms 1995.4 KElem/sec
dump_operations/dump_types/100                             1.00   846.9±38.99µs 115.3 KElem/sec     1.08   917.1±25.57µs 106.5 KElem/sec
dump_operations/dump_types/1000                            1.00  1340.5±90.95µs 728.5 KElem/sec     1.10  1477.9±59.83µs 660.8 KElem/sec
dump_operations/dump_types/5000                            1.00      3.2±0.33ms 1510.3 KElem/sec    1.17      3.8±0.29ms 1295.7 KElem/sec
filter_with_limit/filter_1000_items_complex_predicate      1.00    421.3±3.53ns  2.2 GElem/sec
filter_with_limit/filter_1000_items_no_limit               1.00    306.5±4.33µs  3.1 MElem/sec
filter_with_limit/filter_1000_items_with_limit             1.00    128.6±0.95ns  7.2 GElem/sec
filter_with_limit/filter_100_items_no_limit                1.00    107.9±0.37ns 884.0 MElem/sec
filter_with_limit/filter_100_items_with_limit              1.00     45.6±0.23ns  2.0 GElem/sec
filter_with_limit/filter_5000_items_no_limit               1.00   688.3±11.80µs  6.9 MElem/sec
filter_with_limit/filter_5000_items_with_limit             1.00    391.0±1.45ns 11.9 GElem/sec
hashmap_operations/hashmap_insert_1000                     1.00     75.0±0.59µs 12.7 MElem/sec      1.19     89.1±1.31µs 10.7 MElem/sec
hashmap_operations/hashmap_lookup_1000                     1.02     45.2±0.39µs 21.1 MElem/sec      1.00     44.4±0.47µs 21.5 MElem/sec
hashmap_operations/hashset_contains_10000                  1.01    471.6±4.10µs 20.2 MElem/sec      1.00    469.1±4.82µs 20.3 MElem/sec
hashmap_operations/hashset_from_iter_10000                 1.00    222.2±3.65µs 42.9 MElem/sec      1.88    418.2±6.25µs 22.8 MElem/sec
json_operations/deserialize_parameters                     1.01    366.3±1.19ns        ? ?/sec      1.00    362.0±1.16ns        ? ?/sec
json_operations/serialize_parameters                       1.00    197.9±1.02ns        ? ?/sec      1.07    211.9±3.08ns        ? ?/sec
map_building/build_map_1000_rows                           1.00     56.3±0.48µs 16.9 MElem/sec
map_building/build_map_100_rows                            1.00      4.0±0.03µs 24.0 MElem/sec
map_building/build_map_10_batches_1000_rows                1.00   179.6±12.36µs  5.3 MElem/sec
regex_search/grep_function_bodies                          1.00     10.2±0.36ms        ? ?/sec      1.20     12.3±0.27ms        ? ?/sec
search_operations/find_function_git_aware                  1.00      3.4±0.16ms   290 Elem/sec      1.11      3.8±0.23ms   260 Elem/sec
search_operations/search_functions_exact                   1.00      2.3±0.12ms   434 Elem/sec      1.15      2.6±0.12ms   377 Elem/sec
search_operations/search_functions_fuzzy                   1.00     75.4±2.96ms    13 Elem/sec      1.21     91.0±2.88ms    10 Elem/sec
sql_string_formatting/format_1000_strings                  1.00    258.1±7.70µs  3.7 MElem/sec
sql_string_formatting/format_1000_strings_with_escaping    1.00    256.4±6.14µs  3.7 MElem/sec
sql_string_formatting/format_100_strings                   1.00     59.3±5.55µs 1646.1 KElem/sec
sql_string_formatting/format_10_strings                    1.00    395.6±6.28ns 24.1 MElem/sec
sql_string_formatting/format_5000_strings                  1.00   520.2±14.74µs  9.2 MElem/sec
text_preprocessing/preprocess/large                        1.00     11.0±0.06µs    95.5 MB/sec      1.03     11.3±0.20µs    93.1 MB/sec
text_preprocessing/preprocess/medium                       1.00      4.6±0.04µs    78.9 MB/sec      1.02      4.7±0.06µs    77.6 MB/sec
text_preprocessing/preprocess/small                        1.00   1123.4±9.49ns    38.2 MB/sec      1.08   1212.2±9.85ns    35.4 MB/sec
treesitter_analyze/full_analysis/complex_file              1.00      9.6±0.07ms   248.4 KB/sec      1.01      9.6±0.12ms   246.9 KB/sec
treesitter_analyze/full_analysis/complex_function          1.01      8.9±0.09ms    78.0 KB/sec      1.00      8.8±0.03ms    78.5 KB/sec
treesitter_analyze/full_analysis/simple_function           1.00      8.5±0.02ms     5.1 KB/sec      1.00      8.5±0.09ms     5.1 KB/sec
treesitter_analyze/full_analysis/struct_with_functions     1.01      8.9±0.15ms    47.6 KB/sec      1.00      8.8±0.05ms    48.3 KB/sec
vec_operations/vec_fields_medium                           1.00    409.8±3.02ns        ? ?/sec      1.07    437.7±3.09ns        ? ?/sec
vec_operations/vec_params_large                            1.00    713.8±1.85ns        ? ?/sec      1.03    734.4±7.23ns        ? ?/sec
vec_operations/vec_params_medium                           1.11    552.6±3.90ns        ? ?/sec      1.00    497.8±3.01ns        ? ?/sec
vec_operations/vec_params_small                            1.50    363.4±0.99ns        ? ?/sec      1.00    242.5±2.15ns        ? ?/sec
```
### Test coverage delta between first commit (main w/ test fix) and HEAD
#### main
```
     Summary [   0.373s] 21 tests run: 21 passed, 0 skipped
Filename                        Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bin/index.rs                       1956              1956     0.00%          53                53     0.00%        1152              1152     0.00%           0                 0         -
bin/query.rs                         84                84     0.00%           3                 3     0.00%          91                91     0.00%           0                 0         -
bin/query_impl/commands.rs          417               417     0.00%          37                37     0.00%         358               358     0.00%           0                 0         -
bin/semcode-lsp.rs                  411               411     0.00%          26                26     0.00%         218               218     0.00%           0                 0         -
bin/semcode-mcp.rs                 4117              4117     0.00%         113               113     0.00%        2509              2509     0.00%           0                 0         -
bin/test-vectors.rs                 111               111     0.00%           2                 2     0.00%          81                81     0.00%           0                 0         -
callchain.rs                        249               249     0.00%          15                15     0.00%         208               208     0.00%           0                 0         -
database/connection.rs             2660              2660     0.00%         240               240     0.00%        1823              1823     0.00%           0                 0         -
database/content.rs                 308               308     0.00%          28                28     0.00%         205               205     0.00%           0                 0         -
database/functions.rs               812               812     0.00%          31                31     0.00%         520               520     0.00%           0                 0         -
database/processed_files.rs         418               418     0.00%          23                23     0.00%         283               283     0.00%           0                 0         -
database/schema.rs                 1221              1221     0.00%          68                68     0.00%         679               679     0.00%           0                 0         -
database/search.rs                 1877              1877     0.00%          81                81     0.00%        1314              1314     0.00%           0                 0         -
database/symbol_filename.rs         107               107     0.00%           8                 8     0.00%          60                60     0.00%           0                 0         -
database/types.rs                  1433              1433     0.00%          77                77     0.00%         897               897     0.00%           0                 0         -
database/vectors.rs                 241               241     0.00%          18                18     0.00%         154               154     0.00%           0                 0         -
database_utils.rs                    74                 7    90.54%           6                 0   100.00%          40                 3    92.50%           0                 0         -
diffdump.rs                         418               418     0.00%          12                12     0.00%         282               282     0.00%           0                 0         -
display.rs                          652               652     0.00%          15                15     0.00%         342               342     0.00%           0                 0         -
git.rs                             1057              1025     3.03%          47                43     8.51%         671               652     2.83%           0                 0         -
hash.rs                              21                21     0.00%           3                 3     0.00%          11                11     0.00%           0                 0         -
lib.rs                               64                64     0.00%           3                 3     0.00%          27                27     0.00%           0                 0         -
pages.rs                            284                16    94.37%          14                 2    85.71%         157                16    89.81%           0                 0         -
perf_monitor.rs                     100               100     0.00%          11                11     0.00%          66                66     0.00%           0                 0         -
pipeline.rs                         722               722     0.00%          25                25     0.00%         462               462     0.00%           0                 0         -
search.rs                           159               159     0.00%          38                38     0.00%         178               178     0.00%           0                 0         -
symbol_walkback.rs                  377               245    35.01%          28                17    39.29%         216               138    36.11%           0                 0         -
text_utils.rs                       120                 4    96.67%          12                 0   100.00%          72                 0   100.00%           0                 0         -
treesitter_analyzer.rs             2245              2245     0.00%          70                70     0.00%        1554              1554     0.00%           0                 0         -
types.rs                             78                78     0.00%           7                 7     0.00%          64                64     0.00%           0                 0         -
vectorizer.rs                       207               172    16.91%          21                19     9.52%         150               116    22.67%           0                 0         -
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                             23000             22350     2.83%        1135              1088     4.14%       14844             14463     2.57%           0                 0         -
```
#### HEAD
```
────────────
     Summary [   1.091s] 73 tests run: 73 passed, 0 skipped
Filename                         Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bin/index.rs                        1975              1975     0.00%          53                53     0.00%        1168              1168     0.00%           0                 0         -
bin/query.rs                          84                84     0.00%           3                 3     0.00%          91                91     0.00%           0                 0         -
bin/query_impl/commands.rs           417               417     0.00%          37                37     0.00%         358               358     0.00%           0                 0         -
bin/semcode-lsp.rs                   411               411     0.00%          26                26     0.00%         218               218     0.00%           0                 0         -
bin/semcode-mcp.rs                  4117              4117     0.00%         113               113     0.00%        2509              2509     0.00%           0                 0         -
bin/test-vectors.rs                  111               111     0.00%           2                 2     0.00%          81                81     0.00%           0                 0         -
callchain.rs                         249               249     0.00%          15                15     0.00%         208               208     0.00%           0                 0         -
collection_utils.rs                  444                30    93.24%          44                 2    95.45%         242                12    95.04%           0                 0         -
database/batch_processing.rs        1012                21    97.92%          52                 1    98.08%         583                15    97.43%           0                 0         -
database/connection.rs              2657              2657     0.00%         240               240     0.00%        1811              1811     0.00%           0                 0         -
database/content.rs                  324               324     0.00%          29                29     0.00%         208               208     0.00%           0                 0         -
database/functions.rs                812               812     0.00%          31                31     0.00%         514               514     0.00%           0                 0         -
database/processed_files.rs          418               418     0.00%          23                23     0.00%         281               281     0.00%           0                 0         -
database/schema.rs                  1331              1331     0.00%          77                77     0.00%         685               685     0.00%           0                 0         -
database/search.rs                  1875              1875     0.00%          82                82     0.00%        1318              1318     0.00%           0                 0         -
database/sql_utils.rs                153                 0   100.00%          15                 0   100.00%          71                 0   100.00%           0                 0         -
database/symbol_filename.rs          107               107     0.00%           8                 8     0.00%          60                60     0.00%           0                 0         -
database/types.rs                   1433              1433     0.00%          77                77     0.00%         882               882     0.00%           0                 0         -
database/vectors.rs                  241               241     0.00%          18                18     0.00%         154               154     0.00%           0                 0         -
database_utils.rs                     74                 7    90.54%           6                 0   100.00%          40                 3    92.50%           0                 0         -
diffdump.rs                          418               418     0.00%          12                12     0.00%         282               282     0.00%           0                 0         -
display.rs                           652               652     0.00%          15                15     0.00%         342               342     0.00%           0                 0         -
git.rs                              1057              1025     3.03%          47                43     8.51%         671               652     2.83%           0                 0         -
hash.rs                               22                11    50.00%           3                 2    33.33%          12                 7    41.67%           0                 0         -
lib.rs                                64                64     0.00%           3                 3     0.00%          27                27     0.00%           0                 0         -
pages.rs                             284                16    94.37%          14                 2    85.71%         157                16    89.81%           0                 0         -
perf_monitor.rs                      100               100     0.00%          11                11     0.00%          66                66     0.00%           0                 0         -
pipeline.rs                          912               912     0.00%          28                28     0.00%         560               560     0.00%           0                 0         -
search.rs                            159               159     0.00%          38                38     0.00%         178               178     0.00%           0                 0         -
symbol_walkback.rs                   377               245    35.01%          28                17    39.29%         216               138    36.11%           0                 0         -
text_utils.rs                        120                 4    96.67%          12                 0   100.00%          72                 0   100.00%           0                 0         -
treesitter_analyzer.rs              2467              1702    31.01%          82                52    36.59%        1689              1078    36.18%           0                 0         -
types.rs                              78                78     0.00%           7                 7     0.00%          64                64     0.00%           0                 0         -
vectorizer.rs                        207               172    16.91%          21                19     9.52%         150               116    22.67%           0                 0         -
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                              25162             22178    11.86%        1272              1086    14.62%       15968             14102    11.69%           0                 0         -
```
### Indexing runtime and output delta between main and HEAD
#### main (runtime 76 seconds)
```
❯ ../semcode/target/release/semcode-index -s . --clear --perf
Clearing existing data...
Existing data cleared.
About to start pipeline processing with 62128 files...
[00:01:01] ########################################   91069/91069   files Processing complete                                                                                                               Pipeline processing completed successfully

=== Pipeline Processing Complete ===
Files processed: 91069
Functions indexed: 858812
Types indexed: 156968
Macros indexed: 134765

Starting database optimization...
Database optimization completed successfully

=== Embedded Data Statistics ===
Call relationships: embedded in function/macro JSON columns
Function-type mappings: embedded in function JSON columns
Type-type mappings: embedded in type JSON columns

To query this database, run:
  semcode --database ./.semcode.db

Printing performance statistics...

=== Performance Statistics ===
database_batch_insert          count=   109 avg=  553.50ms min=  318.47ms max= 4618.80ms total=  60331.05ms
database_optimization          count=     1 avg=12762.74ms min=12762.74ms max=12762.74ms total=  12762.74ms
db_insert_combined             count=   109 avg=  553.33ms min=  318.36ms max= 4618.49ms total=  60313.29ms
db_mark_files_processed        count=   109 avg=  109.23ms min=   47.87ms max=  465.86ms total=  11905.62ms
pipeline_processing            count=     1 avg=62227.89ms min=62227.89ms max=62227.89ms total=  62227.89ms
treesitter_parse               count= 91069 avg=   16.82ms min=    0.01ms max= 6074.82ms total=1531846.54ms

Total time tracked: 1739.39s

🎉 Indexing completed successfully!
```

#### HEAD (runtime 30 seconds)
```
❯ ../semcode_faster/target/release/semcode-index -s . --perf --clear
No existing database found at ./.semcode.db
About to start pipeline processing with 62021 files...
[00:00:18] ########################################   91069/91069   files Processing complete                                                                                                               Pipeline processing completed successfully

=== Pipeline Processing Complete ===
Files processed: 91069
Functions indexed: 858812
Types indexed: 156968
Macros indexed: 133231

Building database indexes...
✓ Indexes built successfully

Starting database optimization...
Database optimization completed successfully

=== Embedded Data Statistics ===
Call relationships: embedded in function/macro JSON columns
Function-type mappings: embedded in function JSON columns
Type-type mappings: embedded in type JSON columns

To query this database, run:
  semcode --database ./.semcode.db

Printing performance statistics...

=== Performance Statistics ===
database_batch_insert          count=   110 avg= 1065.17ms min=  237.08ms max=10725.53ms total= 117169.13ms
database_optimization          count=     1 avg=10517.27ms min=10517.27ms max=10517.27ms total=  10517.27ms
db_insert_combined             count=   110 avg= 1064.13ms min=  236.95ms max=10725.34ms total= 117054.53ms
db_mark_files_processed        count=   110 avg=  156.88ms min=   55.52ms max= 1069.54ms total=  17256.26ms
index_building                 count=     1 avg=  601.19ms min=  601.19ms max=  601.19ms total=    601.19ms
pipeline_processing            count=     1 avg=19032.46ms min=19032.46ms max=19032.46ms total=  19032.46ms
treesitter_parse               count= 90893 avg=   16.86ms min=    0.01ms max= 4813.82ms total=1532872.47ms

Total time tracked: 1814.50s

🎉 Indexing completed successfully!
```

### Overview of new tests (and how to run them fast/in like 1 second after first build)
```
❯ cargo nextest run
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.25s
warning: the following packages contain code that will be rejected by a future version of Rust: num-bigint-dig v0.8.4
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
────────────
 Nextest run ID 4c030323-97d0-44de-997c-820793b40480 with nextest profile: default
    Starting 73 tests across 6 binaries
        PASS [   0.004s] semcode collection_utils::tests::test_collect_paths_single
        PASS [   0.004s] semcode collection_utils::tests::test_collect_paths_unicode
        PASS [   0.004s] semcode collection_utils::tests::test_collect_paths_duplicates
        PASS [   0.004s] semcode collection_utils::tests::test_collect_paths_multiple
        PASS [   0.005s] semcode collection_utils::tests::test_collect_paths_custom_extractor
        PASS [   0.004s] semcode collection_utils::tests::test_filter_with_limit_no_limit
        PASS [   0.004s] semcode database::batch_processing::tests::test_build_map_with_duplicates
        PASS [   0.006s] semcode collection_utils::tests::test_filter_with_limit_preserve_order
        PASS [   0.006s] semcode collection_utils::tests::test_filter_with_limit_all_filtered_out
        PASS [   0.006s] semcode database::batch_processing::tests::test_build_map_empty
        PASS [   0.006s] semcode collection_utils::tests::test_filter_with_limit_large_collection
        PASS [   0.006s] semcode collection_utils::tests::test_filter_with_limit_strings
        PASS [   0.006s] semcode collection_utils::tests::test_collect_paths_empty
        PASS [   0.006s] semcode collection_utils::tests::test_collect_paths_with_special_chars
        PASS [   0.005s] semcode database::batch_processing::tests::test_process_batches_single_batch
        PASS [   0.006s] semcode collection_utils::tests::test_collect_paths_empty_strings
        PASS [   0.005s] semcode database_utils::tests::test_process_database_path_with_directory
        PASS [   0.006s] semcode database::batch_processing::tests::test_process_batches_complex_extraction
        PASS [   0.005s] semcode database::batch_processing::tests::test_process_batches_multiple_batches
        PASS [   0.006s] semcode collection_utils::tests::test_filter_with_limit_empty
        PASS [   0.006s] semcode database::batch_processing::tests::test_process_batches_mixed_filtering
        PASS [   0.006s] semcode database::batch_processing::tests::test_process_batches_with_filtering
        PASS [   0.006s] semcode database::batch_processing::tests::test_process_batches_empty
        PASS [   0.006s] semcode collection_utils::tests::test_filter_with_limit_under_limit
        PASS [   0.006s] semcode database::batch_processing::tests::test_build_map_multiple_batches
        PASS [   0.006s] semcode database::batch_processing::tests::test_build_map_string_to_string
        PASS [   0.005s] semcode database::sql_utils::tests::test_format_sql_strings_empty
        PASS [   0.006s] semcode database::sql_utils::tests::test_format_sql_strings_multiple
        PASS [   0.006s] semcode database::batch_processing::tests::test_process_batches_all_filtered_out
        PASS [   0.007s] semcode database::batch_processing::tests::test_build_map_single_batch
        PASS [   0.006s] semcode database::sql_utils::tests::test_format_sql_strings_single
        PASS [   0.006s] semcode pages::tests::test_cache_removal_on_last_page
        PASS [   0.007s] semcode collection_utils::tests::test_filter_with_limit_over_limit
        PASS [   0.007s] semcode database_utils::tests::test_process_database_path_no_args_no_source
        PASS [   0.007s] semcode database_utils::tests::test_process_database_path_current_dir_source
        PASS [   0.007s] semcode database::batch_processing::tests::test_process_batches_string_extraction
        PASS [   0.008s] semcode database::batch_processing::tests::test_build_map_with_none_values
        PASS [   0.007s] semcode database::sql_utils::tests::test_format_sql_strings_unicode
        PASS [   0.007s] semcode pages::tests::test_no_pagination
        PASS [   0.007s] semcode database_utils::tests::test_process_database_path_no_args_with_source
        PASS [   0.008s] semcode collection_utils::tests::test_filter_with_limit_at_limit
        PASS [   0.007s] semcode pages::tests::test_invalid_page_number
        PASS [   0.008s] semcode database::batch_processing::tests::test_process_batches_empty_batch_in_sequence
        PASS [   0.008s] semcode collection_utils::tests::test_filter_with_limit_complex_predicate
        PASS [   0.008s] semcode database::batch_processing::tests::test_build_map_empty_batch_in_sequence
        PASS [   0.007s] semcode pages::tests::test_multiple_pages
        PASS [   0.007s] semcode pages::tests::test_single_page
        PASS [   0.008s] semcode database::sql_utils::tests::test_format_sql_strings_hashes
        PASS [   0.008s] semcode git::tests::test_get_git_sha_non_git_dir
        PASS [   0.008s] semcode database::sql_utils::tests::test_format_sql_strings_special_chars
        PASS [   0.007s] semcode pages::tests::test_unrelated_query_cleanup
        PASS [   0.008s] semcode database::sql_utils::tests::test_format_sql_strings_empty_string
        PASS [   0.008s] semcode database::sql_utils::tests::test_format_sql_strings_with_quotes
        PASS [   0.008s] semcode database_utils::tests::test_process_database_path_with_explicit_path
        PASS [   0.008s] semcode symbol_walkback::tests::test_is_type_definition
        PASS [   0.008s] semcode symbol_walkback::tests::test_extract_macro_name
        PASS [   0.008s] semcode symbol_walkback::tests::test_extract_function_name
        PASS [   0.010s] semcode git::tests::test_get_git_sha_current_dir
        PASS [   0.007s] semcode text_utils::tests::test_preprocess_code
        PASS [   0.008s] semcode text_utils::tests::test_preprocess_code_utf8_boundary
        PASS [   0.008s] semcode text_utils::tests::test_preprocess_code_preserves_line_structure
        PASS [   0.013s] semcode database::sql_utils::tests::test_format_sql_strings_large_batch
        PASS [   0.007s] semcode vectorizer::tests::test_preprocess_code_preserves_line_structure
        PASS [   0.013s] semcode collection_utils::tests::test_collect_paths_very_large_collection
        PASS [   0.007s] semcode vectorizer::tests::test_preprocess_code
        PASS [   0.013s] semcode database::batch_processing::tests::test_build_map_large_batch
        PASS [   0.014s] semcode database::sql_utils::tests::test_format_sql_strings_very_large_batch
        PASS [   0.016s] semcode collection_utils::tests::test_collect_paths_large_collection
        PASS [   0.017s] semcode database::batch_processing::tests::test_process_batches_large_batch
        PASS [   0.042s] semcode treesitter_analyzer::tests::test_function_analysis_with_parameters
        PASS [   0.041s] semcode treesitter_analyzer::tests::test_matched_patterns_clearing
        PASS [   0.043s] semcode treesitter_analyzer::tests::test_function_call_tracking
        PASS [   0.043s] semcode treesitter_analyzer::tests::test_type_analysis
────────────
     Summary [   0.049s] 73 tests run: 73 passed, 0 skipped
```

* part of the reason for the wall of data is I think all these things can be hooked into CI and might help w/ this a lot.