### PR TITLE
Multi branch indexing

### DIFF
--- a/docs/branching-example.md
+++ b/docs/branching-example.md
@@ -1,0 +1,404 @@
+# Semcode Multi-Branch Querying Example
+
+This document demonstrates semcode's ability to query code across different
+indexed branches, which is essential for tracking how code evolves across
+kernel versions.
+
+## Why Multi-Branch Support?
+
+The Linux kernel maintains multiple stable branches simultaneously (5.10.y,
+6.1.y, 6.6.y, 6.12.y, etc.), each receiving ongoing security fixes and
+backports. When analyzing CVEs, backports, or API evolution, you often need
+to query the same function across different kernel versions.
+
+**Primary use case: Backport decisions with autosel**
+
+When a fix lands in mainline, the stable team needs to determine:
+- Which LTS branches are affected by this bug?
+- Does the vulnerable code even exist in older branches?
+- Will the fix apply cleanly, or has the code changed too much?
+
+Multi-branch queries answer these questions instantly, without manually
+checking out each branch or running git-blame archaeology.
+
+Semcode's branch tracking helps you:
+1. **Index once, query many** - Index multiple stable branches and switch
+   between them instantly without re-indexing
+2. **Track branch freshness** - Know when a branch needs re-indexing because
+   new commits were pushed (e.g., a new 6.12.87 release)
+3. **Compare versions** - Understand how code evolved between kernel versions
+4. **Automate backport scope** - Programmatically determine which branches
+   need a fix by checking if the affected code exists
+
+## Listing Available Branches
+
+Use `list_branches` to see all indexed branches and their status:
+
+```
+=== Indexed Branches ===
+
+  origin/master (c9b47175) [origin]
+    Status: outdated
+
+  stable/linux-5.10.y (f964b940) [stable]
+    Status: up-to-date
+
+  stable/linux-6.1.y (50cbba13) [stable]
+    Status: up-to-date
+
+  stable/linux-6.12.y (dcbeffaf) [stable]
+    Status: up-to-date
+
+  stable/linux-6.17.y (5439375c) [stable]
+    Status: up-to-date
+
+  stable/linux-6.18.y (7d0a66e4) [stable]
+    Status: up-to-date
+
+Total: 8 branch(es) indexed
+```
+
+### Understanding Branch Status
+
+Each branch shows a **status** field:
+
+- **up-to-date**: The indexed commit matches the current branch tip. Queries
+  reflect the latest code.
+- **outdated**: The branch has received new commits since indexing. The
+  indexed SHA (shown in parentheses) is behind the current branch tip.
+
+When a branch is outdated, you can still query it - you'll just be querying
+against the older indexed version. To update, re-run the indexer:
+
+```bash
+# Re-index specific branches that are outdated
+semcode-index -s . --branches stable/linux-6.12.y,stable/linux-6.17.y
+
+# Or re-index all configured branches
+semcode-index -s . --branches stable/linux-5.10.y,stable/linux-6.1.y,stable/linux-6.12.y,stable/linux-6.17.y,stable/linux-6.18.y
+```
+
+### Typical Workflow: Keeping Stable Branches Current
+
+For kernel CVE analysis, you might set up a cron job or periodic task:
+
+```bash
+# 1. Fetch latest stable branches
+git fetch --all
+
+# 2. Check which branches need updating
+semcode list_branches  # Look for "outdated" status
+
+# 3. Re-index outdated branches
+semcode-index -s . --branches stable/linux-6.12.y,stable/linux-6.18.y
+```
+
+## Comparing Branches
+
+Use `compare_branches` to understand the relationship between two branches:
+
+```
+=== Branch Comparison: stable/linux-6.1.y vs stable/linux-6.18.y ===
+
+Branch Tips:
+  stable/linux-6.1.y: 50cbba13faa2
+  stable/linux-6.18.y: 7d0a66e4bb90
+
+Merge Base: 830b3c68c1fb
+
+Branches have diverged from merge base
+
+Indexing Status:
+  stable/linux-6.1.y: up-to-date (indexed at 50cbba13)
+  stable/linux-6.18.y: up-to-date (indexed at 7d0a66e4)
+```
+
+## Querying Functions Across Branches
+
+### Example: Tracking io_uring_setup Evolution
+
+The `branch` parameter works with most semcode tools. Here's how
+`io_uring_setup` changed between kernel 5.10 and 6.18:
+
+**Linux 5.10 (stable/linux-5.10.y):**
+
+```c
+// File: io_uring/io_uring.c:10311-10330
+static long io_uring_setup(u32 entries, struct io_uring_params __user *params)
+{
+    struct io_uring_params p;
+    int i;
+
+    if (copy_from_user(&p, params, sizeof(p)))
+        return -EFAULT;
+    for (i = 0; i < ARRAY_SIZE(p.resv); i++) {
+        if (p.resv[i])
+            return -EINVAL;
+    }
+
+    // Flags checked individually - only 7 flags supported
+    if (p.flags & ~(IORING_SETUP_IOPOLL | IORING_SETUP_SQPOLL |
+            IORING_SETUP_SQ_AFF | IORING_SETUP_CQSIZE |
+            IORING_SETUP_CLAMP | IORING_SETUP_ATTACH_WQ |
+            IORING_SETUP_R_DISABLED))
+        return -EINVAL;
+
+    return  io_uring_create(entries, &p, params);
+}
+```
+
+**Linux 6.18 (stable/linux-6.18.y):**
+
+```c
+// File: io_uring/io_uring.c:3924-3939
+static long io_uring_setup(u32 entries, struct io_uring_params __user *params)
+{
+    struct io_uring_params p;
+    int i;
+
+    if (copy_from_user(&p, params, sizeof(p)))
+        return -EFAULT;
+    for (i = 0; i < ARRAY_SIZE(p.resv); i++) {
+        if (p.resv[i])
+            return -EINVAL;
+    }
+
+    // Consolidated into IORING_SETUP_FLAGS macro
+    if (p.flags & ~IORING_SETUP_FLAGS)
+        return -EINVAL;
+    return io_uring_create(entries, &p, params);
+}
+```
+
+**Key differences observed:**
+1. File location moved from line 10311 to line 3924 (major refactoring)
+2. Individual flag checks consolidated into `IORING_SETUP_FLAGS` macro
+3. Code is cleaner and more maintainable in 6.18
+
+### Example: Code Organization Changes
+
+Using `grep_functions` with branch parameter shows how io_uring was
+reorganized:
+
+**Linux 5.10:** All io_uring code in `io_uring/io_uring.c`
+```
+io_uring/io_uring.c:io_poll_add_prep:5970
+io_uring/io_uring.c:io_sfr_prep:4683
+io_uring/io_uring.c:io_sq_thread:7562
+```
+
+**Linux 6.18:** Code split across multiple files
+```
+io_uring/register.c:io_register_restrictions:162
+io_uring/msg_ring.c:io_msg_send_fd:247
+io_uring/sqpoll.c:io_sq_offload_create:451
+io_uring/io_uring.h:io_lockdep_assert_cq_locked:186
+```
+
+## Integration with Autosel Backport Workflow
+
+When autosel (or a human maintainer) evaluates whether to backport a commit to
+stable branches, multi-branch queries answer critical questions:
+
+### Question 1: "How far back should we backport?"
+
+A fix in mainline might only apply to recent kernels if the vulnerable code
+was introduced after older LTS branches diverged.
+
+```bash
+# Does the vulnerable function exist in each stable branch?
+find_function(name="vulnerable_func", branch="stable/linux-5.10.y")  # Not found = no backport needed
+find_function(name="vulnerable_func", branch="stable/linux-6.1.y")   # Found = needs backport
+find_function(name="vulnerable_func", branch="stable/linux-6.6.y")   # Found = needs backport
+```
+
+**Real example**: The folio APIs don't exist in 5.10.y, so any fix involving
+`folio_test_slab` or similar functions only needs backporting to 5.15+.
+
+### Question 2: "Is the fix applicable as-is, or does it need modification?"
+
+Code often changes between versions. A fix that cleanly applies to 6.18 might
+need adaptation for 5.10.
+
+```bash
+# Compare function signatures across versions
+find_function(name="kfree", branch="stable/linux-5.10.y")  # In mm/slab.c, SLAB allocator
+find_function(name="kfree", branch="stable/linux-6.18.y")  # In mm/slub.c, SLUB allocator
+
+# Check if the fix's context matches
+grep_functions(pattern="specific_code_pattern", branch="stable/linux-5.10.y")
+grep_functions(pattern="specific_code_pattern", branch="stable/linux-6.1.y")
+```
+
+If the pattern doesn't exist in 5.10.y, the fix either doesn't apply or needs
+a different approach.
+
+### Question 3: "Is this a real issue in this LTS branch?"
+
+Sometimes a bug exists in mainline but was never present in older branches
+(e.g., introduced by a feature that wasn't backported).
+
+```bash
+# Check if the problematic code path exists
+find_callers(name="problematic_func", branch="stable/linux-5.10.y")  # 0 callers = not reachable
+find_callers(name="problematic_func", branch="stable/linux-6.12.y")  # 50 callers = affected
+
+# Verify the vulnerable pattern is present
+grep_functions(pattern="if.*NULL.*&&.*ptr->field", branch="stable/linux-5.10.y")
+```
+
+### Question 4: "What's the blast radius of this change?"
+
+Understanding how many callers/callees are affected helps assess risk.
+
+```bash
+# Compare caller counts - more callers = higher risk backport
+find_callers(name="affected_func", branch="stable/linux-5.10.y")   # 50 callers
+find_callers(name="affected_func", branch="stable/linux-6.18.y")   # 150 callers
+
+# The function grew significantly - the 6.18 fix might touch code paths
+# that don't exist in 5.10.y
+```
+
+### Typical Autosel Workflow with Semcode
+
+```
+1. Commit appears in mainline: "Fix NULL deref in foo_handler()"
+
+2. Autosel asks: "Should this go to stable?"
+   → LLM says yes, it's a bug fix
+
+3. Autosel asks: "Which stable branches need this?"
+   → Query each branch:
+     - 5.10.y: foo_handler doesn't exist (introduced in 5.15) → SKIP
+     - 5.15.y: foo_handler exists, vulnerable pattern present → BACKPORT
+     - 6.1.y:  foo_handler exists, vulnerable pattern present → BACKPORT
+     - 6.6.y:  foo_handler exists, vulnerable pattern present → BACKPORT
+     - 6.12.y: foo_handler exists, vulnerable pattern present → BACKPORT
+
+4. Autosel asks: "Will the patch apply cleanly?"
+   → Compare function bodies between mainline and each target branch
+   → Flag branches where context differs significantly
+```
+
+## Use Cases
+
+### 1. CVE Analysis Across Stable Branches
+
+When analyzing a security fix, check which stable branches have the fix:
+
+```
+# Check if a function exists in different branches
+find_function(name="vulnerable_func", branch="stable/linux-5.10.y")
+find_function(name="vulnerable_func", branch="stable/linux-6.1.y")
+```
+
+### 2. Backport Verification
+
+Verify a backport was applied correctly:
+
+```
+# Compare function implementation across branches
+find_function(name="fixed_function", branch="origin/master")
+find_function(name="fixed_function", branch="stable/linux-6.1.y")
+```
+
+### 3. API Evolution Tracking
+
+Track how APIs change over kernel versions:
+
+```
+# Find callers to understand usage patterns
+find_callers(name="old_api_function", branch="stable/linux-5.10.y")
+find_callers(name="new_api_function", branch="stable/linux-6.18.y")
+```
+
+### 4. Regression Investigation
+
+When a regression appears in a stable branch, compare with mainline:
+
+```
+compare_branches(branch1="stable/linux-6.12.y", branch2="origin/master")
+grep_functions(pattern="suspicious_pattern", branch="stable/linux-6.12.y")
+grep_functions(pattern="suspicious_pattern", branch="origin/master")
+```
+
+## Indexing Multiple Branches
+
+To index multiple branches for querying:
+
+```bash
+# Index specific branches
+semcode-index -s . --branches main,stable/linux-6.1.y,stable/linux-6.12.y
+
+# Query tool with default branch
+semcode --branch stable/linux-6.12.y
+```
+
+## MCP Tool Parameters
+
+All these MCP tools support the `branch` parameter:
+
+| Tool | Branch Support |
+|------|----------------|
+| `find_function` | Yes |
+| `find_type` | Yes |
+| `find_callers` | Yes |
+| `find_calls` | Yes |
+| `find_callchain` | Yes |
+| `grep_functions` | Yes |
+| `vgrep_functions` | Yes |
+| `list_branches` | N/A (lists all) |
+| `compare_branches` | Takes two branches |
+
+The `branch` parameter takes precedence over `git_sha` if both are provided.
+
+## Real-World Examples from Testing
+
+### API Evolution: Memory Allocator Changes
+
+The `kfree` function moved between allocators across kernel versions:
+
+| Version | File | Allocator |
+|---------|------|-----------|
+| 5.10.y | `mm/slab.c:3738` | SLAB |
+| 6.18.y | `mm/slub.c:6829` | SLUB |
+
+```bash
+# Query shows different implementations
+find_function(name="kfree", branch="stable/linux-5.10.y")  # SLAB version
+find_function(name="kfree", branch="stable/linux-6.18.y")  # SLUB version
+```
+
+### API Renaming: Profiling Annotations
+
+Some functions were renamed with `_noprof` suffixes for memory profiling:
+
+| 5.10.y | 6.18.y |
+|--------|--------|
+| `__kmalloc` | `__kmalloc_noprof` |
+
+This is why searching for `__kmalloc` in 6.18.y returns a bootloader stub
+instead of the main allocator - the real function was renamed.
+
+### Codebase Growth
+
+Caller counts show kernel growth over time:
+
+| Function | 5.10.y Callers | 6.18.y Callers | Growth |
+|----------|----------------|----------------|--------|
+| `kvfree` | 797 | 1,476 | +85% |
+| `kfree` | 24,731 | 28,294 | +14% |
+
+### New APIs
+
+Some APIs only exist in newer kernels:
+
+```bash
+# folio_test_slab doesn't exist in 5.10
+grep_functions(pattern="folio_test_slab", branch="stable/linux-5.10.y")  # 0 results
+grep_functions(pattern="folio_test_slab", branch="stable/linux-6.18.y")  # 5+ results
+```
+
+The `folio` abstraction was introduced after 5.10, so related APIs are
+missing from older branches.

--- a/docs/semcode-mcp.md
+++ b/docs/semcode-mcp.md
@@ -1,12 +1,15 @@
 # semcode usage guide
 
 All semcode functions are git aware and default to lookups on the current
-commit.  You can also pass a specific commit you're interested in.
+commit.  You can also pass a specific commit you're interested in, or a branch name.
 
 **Note on Regex Patterns**: All regex patterns in semcode are **case-insensitive by default**. This applies to all pattern matching including function names, commit messages, symbols, and lore email searches. You don't need to use the `(?i)` flag.
 
+**Branch Support**: Most query tools support a `branch` parameter as an alternative to `git_sha`. When you specify a branch name (e.g., "main", "develop"), it will be resolved to the current tip commit of that branch. Branch takes precedence over git_sha if both are provided.
+
 **find_function**: search for functions and macros
   - git_sha: indicates which commit to search (default: current)
+  - branch: branch name to search (alternative to git_sha, e.g., "main", "develop")
   - name: function/macro name, or a regex
   - also displays details on callers and callees
 **find_type**: search for types and typedefs
@@ -74,6 +77,20 @@ commit.  You can also pass a specific commit you're interested in.
     sha provided.  Mutually exclusive with git_range
   - page: optional page number for pagination (1-based).  Each page contains
     50 lines, results indicate current page and total pages.  Default: full results
+**list_branches**: list all indexed branches with their status
+  - No parameters required
+  - Shows branch names, indexed commit SHAs, and freshness status
+  - **up-to-date**: indexed commit matches current branch tip
+  - **outdated**: branch has new commits since indexing (re-index to update)
+  - Useful for tracking multiple stable branches (e.g., linux-5.10.y, 6.1.y, 6.12.y)
+    and knowing when they need re-indexing after new releases
+**compare_branches**: compare two branches and show their relationship
+  - branch1: first branch name (e.g., "main")
+  - branch2: second branch name (e.g., "feature-branch")
+  - Shows merge base, ahead/behind status, and indexing status for both branches
+**indexing_status**: check the status of background indexing operation
+  - No parameters required
+  - Shows current indexing progress, errors, and timing
 
 ## Recipes
 

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -27,6 +27,11 @@ struct Args {
     /// Path to local model directory (for semantic search)
     #[arg(long, value_name = "PATH")]
     model_path: Option<String>,
+
+    /// Query code at a specific branch instead of current HEAD
+    /// Example: --branch main
+    #[arg(long, value_name = "BRANCH")]
+    branch: Option<String>,
 }
 
 /// Check if the current commit needs indexing and perform incremental indexing if needed
@@ -192,7 +197,15 @@ async fn main() -> Result<()> {
                 let parts: Vec<&str> = parts_owned.iter().map(|s| s.as_str()).collect();
 
                 // Handle command and check if we should exit
-                if handle_command(&parts, &db_manager, &args.git_repo, &args.model_path).await? {
+                if handle_command(
+                    &parts,
+                    &db_manager,
+                    &args.git_repo,
+                    &args.model_path,
+                    &args.branch,
+                )
+                .await?
+                {
                     break;
                 }
             }

--- a/src/database/branches.rs
+++ b/src/database/branches.rs
@@ -1,0 +1,619 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Store for tracking indexed git branches.
+//!
+//! This module provides functionality to track which branches have been indexed,
+//! their tip commits, and when they were last indexed. This enables efficient
+//! multi-branch indexing by avoiding re-indexing branches that haven't changed.
+
+use anyhow::Result;
+use arrow::array::{Array, ArrayRef, Int64Array, RecordBatch, StringBuilder};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatchIterator;
+use futures::TryStreamExt;
+use lancedb::connection::Connection;
+use lancedb::query::{ExecutableQuery, QueryBase};
+use std::sync::Arc;
+
+/// Information about an indexed branch
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexedBranchInfo {
+    /// Branch name (e.g., "main", "origin/develop")
+    pub branch_name: String,
+    /// The commit SHA at the tip of the branch when indexed
+    pub tip_commit: String,
+    /// Unix timestamp of when the branch was last indexed
+    pub indexed_at: i64,
+    /// Remote name if this is a remote-tracking branch (e.g., "origin")
+    pub remote: Option<String>,
+}
+
+/// JSON-serializable version of IndexedBranchInfo
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct IndexedBranchInfoJson {
+    pub branch_name: String,
+    pub tip_commit: String,
+    pub indexed_at: i64,
+    pub remote: Option<String>,
+}
+
+impl From<IndexedBranchInfo> for IndexedBranchInfoJson {
+    fn from(info: IndexedBranchInfo) -> Self {
+        IndexedBranchInfoJson {
+            branch_name: info.branch_name,
+            tip_commit: info.tip_commit,
+            indexed_at: info.indexed_at,
+            remote: info.remote,
+        }
+    }
+}
+
+impl From<IndexedBranchInfoJson> for IndexedBranchInfo {
+    fn from(json: IndexedBranchInfoJson) -> Self {
+        IndexedBranchInfo {
+            branch_name: json.branch_name,
+            tip_commit: json.tip_commit,
+            indexed_at: json.indexed_at,
+            remote: json.remote,
+        }
+    }
+}
+
+/// Store for managing indexed branch records
+pub struct IndexedBranchStore {
+    connection: Connection,
+}
+
+impl IndexedBranchStore {
+    pub fn new(connection: Connection) -> Self {
+        Self { connection }
+    }
+
+    /// Get the Arrow schema for the indexed_branches table
+    pub fn get_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("branch_name", DataType::Utf8, false),
+            Field::new("tip_commit", DataType::Utf8, false),
+            Field::new("indexed_at", DataType::Int64, false),
+            Field::new("remote", DataType::Utf8, true),
+        ]))
+    }
+
+    /// Record that a branch has been indexed at a specific commit
+    pub async fn record_branch_indexed(&self, info: &IndexedBranchInfo) -> Result<()> {
+        // First, remove any existing record for this branch
+        self.remove_branch(&info.branch_name).await?;
+
+        let table = self
+            .connection
+            .open_table("indexed_branches")
+            .execute()
+            .await?;
+
+        // Build arrays for each column
+        let mut branch_name_builder = StringBuilder::new();
+        let mut tip_commit_builder = StringBuilder::new();
+        let mut indexed_at_builder = arrow::array::Int64Builder::new();
+        let mut remote_builder = StringBuilder::new();
+
+        branch_name_builder.append_value(&info.branch_name);
+        tip_commit_builder.append_value(&info.tip_commit);
+        indexed_at_builder.append_value(info.indexed_at);
+        match &info.remote {
+            Some(r) => remote_builder.append_value(r),
+            None => remote_builder.append_null(),
+        }
+
+        let schema = Self::get_schema();
+
+        let batch = RecordBatch::try_from_iter(vec![
+            (
+                "branch_name",
+                Arc::new(branch_name_builder.finish()) as ArrayRef,
+            ),
+            (
+                "tip_commit",
+                Arc::new(tip_commit_builder.finish()) as ArrayRef,
+            ),
+            (
+                "indexed_at",
+                Arc::new(indexed_at_builder.finish()) as ArrayRef,
+            ),
+            ("remote", Arc::new(remote_builder.finish()) as ArrayRef),
+        ])?;
+
+        let batches = vec![Ok(batch)];
+        let batch_iterator = RecordBatchIterator::new(batches.into_iter(), schema);
+        table.add(batch_iterator).execute().await?;
+
+        Ok(())
+    }
+
+    /// Get the tip commit for a specific branch
+    pub async fn get_branch_tip(&self, branch_name: &str) -> Result<Option<String>> {
+        let info = self.get_branch_info(branch_name).await?;
+        Ok(info.map(|i| i.tip_commit))
+    }
+
+    /// Get full information about a specific branch
+    pub async fn get_branch_info(&self, branch_name: &str) -> Result<Option<IndexedBranchInfo>> {
+        let table = self
+            .connection
+            .open_table("indexed_branches")
+            .execute()
+            .await?;
+
+        let escaped_name = branch_name.replace("'", "''");
+        let filter = format!("branch_name = '{escaped_name}'");
+
+        let results = table
+            .query()
+            .only_if(filter)
+            .limit(1)
+            .execute()
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        if results.is_empty() || results[0].num_rows() == 0 {
+            return Ok(None);
+        }
+
+        self.extract_record_from_batch(&results[0], 0)
+    }
+
+    /// List all indexed branches
+    pub async fn list_indexed_branches(&self) -> Result<Vec<IndexedBranchInfo>> {
+        let table = self
+            .connection
+            .open_table("indexed_branches")
+            .execute()
+            .await?;
+
+        let results = table
+            .query()
+            .execute()
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let mut branches = Vec::new();
+        for batch in &results {
+            for i in 0..batch.num_rows() {
+                if let Some(info) = self.extract_record_from_batch(batch, i)? {
+                    branches.push(info);
+                }
+            }
+        }
+
+        // Sort by branch name for consistent output
+        branches.sort_by(|a, b| a.branch_name.cmp(&b.branch_name));
+
+        Ok(branches)
+    }
+
+    /// Check if a branch is indexed at the current tip commit
+    pub async fn is_branch_current(&self, branch_name: &str, current_tip: &str) -> Result<bool> {
+        if let Some(info) = self.get_branch_info(branch_name).await? {
+            Ok(info.tip_commit == current_tip)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Remove a branch record (used when branch is deleted or before updating)
+    pub async fn remove_branch(&self, branch_name: &str) -> Result<()> {
+        let table = self
+            .connection
+            .open_table("indexed_branches")
+            .execute()
+            .await?;
+
+        let escaped_name = branch_name.replace("'", "''");
+        let filter = format!("branch_name = '{escaped_name}'");
+
+        table.delete(&filter).await?;
+        Ok(())
+    }
+
+    /// Remove all branches that match a remote prefix (e.g., "origin/")
+    pub async fn remove_branches_by_remote(&self, remote: &str) -> Result<usize> {
+        let branches = self.list_indexed_branches().await?;
+        let mut removed = 0;
+
+        for branch in branches {
+            if branch.remote.as_deref() == Some(remote) {
+                self.remove_branch(&branch.branch_name).await?;
+                removed += 1;
+            }
+        }
+
+        Ok(removed)
+    }
+
+    /// Get all branches that point to a specific commit
+    pub async fn get_branches_at_commit(&self, commit_sha: &str) -> Result<Vec<IndexedBranchInfo>> {
+        let table = self
+            .connection
+            .open_table("indexed_branches")
+            .execute()
+            .await?;
+
+        let escaped_sha = commit_sha.replace("'", "''");
+        let filter = format!("tip_commit = '{escaped_sha}'");
+
+        let results = table
+            .query()
+            .only_if(filter)
+            .execute()
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let mut branches = Vec::new();
+        for batch in &results {
+            for i in 0..batch.num_rows() {
+                if let Some(info) = self.extract_record_from_batch(batch, i)? {
+                    branches.push(info);
+                }
+            }
+        }
+
+        Ok(branches)
+    }
+
+    /// Get total count of indexed branches
+    pub async fn count(&self) -> Result<usize> {
+        let table = self
+            .connection
+            .open_table("indexed_branches")
+            .execute()
+            .await?;
+        Ok(table.count_rows(None).await?)
+    }
+
+    /// Extract an IndexedBranchInfo from a batch at the given row index
+    fn extract_record_from_batch(
+        &self,
+        batch: &RecordBatch,
+        row: usize,
+    ) -> Result<Option<IndexedBranchInfo>> {
+        let branch_name_array = batch
+            .column_by_name("branch_name")
+            .ok_or_else(|| anyhow::anyhow!("Missing branch_name column"))?
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .ok_or_else(|| anyhow::anyhow!("Invalid branch_name column type"))?;
+
+        let tip_commit_array = batch
+            .column_by_name("tip_commit")
+            .ok_or_else(|| anyhow::anyhow!("Missing tip_commit column"))?
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .ok_or_else(|| anyhow::anyhow!("Invalid tip_commit column type"))?;
+
+        let indexed_at_array = batch
+            .column_by_name("indexed_at")
+            .ok_or_else(|| anyhow::anyhow!("Missing indexed_at column"))?
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or_else(|| anyhow::anyhow!("Invalid indexed_at column type"))?;
+
+        let remote_array = batch
+            .column_by_name("remote")
+            .ok_or_else(|| anyhow::anyhow!("Missing remote column"))?
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .ok_or_else(|| anyhow::anyhow!("Invalid remote column type"))?;
+
+        let branch_name = branch_name_array.value(row).to_string();
+        let tip_commit = tip_commit_array.value(row).to_string();
+        let indexed_at = indexed_at_array.value(row);
+        let remote = if remote_array.is_null(row) {
+            None
+        } else {
+            Some(remote_array.value(row).to_string())
+        };
+
+        Ok(Some(IndexedBranchInfo {
+            branch_name,
+            tip_commit,
+            indexed_at,
+            remote,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    async fn create_test_store() -> (TempDir, IndexedBranchStore) {
+        let tmpdir = TempDir::new().unwrap();
+        let db_path = tmpdir.path().to_str().unwrap();
+        let connection = lancedb::connect(db_path).execute().await.unwrap();
+
+        // Create the table
+        let schema = IndexedBranchStore::get_schema();
+        let empty_batch = RecordBatch::new_empty(schema.clone());
+        let batches = vec![Ok(empty_batch)];
+        let batch_iterator = RecordBatchIterator::new(batches.into_iter(), schema);
+        connection
+            .create_table("indexed_branches", batch_iterator)
+            .execute()
+            .await
+            .unwrap();
+
+        let store = IndexedBranchStore::new(connection);
+        (tmpdir, store)
+    }
+
+    #[tokio::test]
+    async fn test_record_and_get_branch() {
+        let (_tmpdir, store) = create_test_store().await;
+
+        let info = IndexedBranchInfo {
+            branch_name: "main".to_string(),
+            tip_commit: "abc123def456".to_string(),
+            indexed_at: 1699900000,
+            remote: None,
+        };
+
+        store.record_branch_indexed(&info).await.unwrap();
+
+        let retrieved = store.get_branch_info("main").await.unwrap();
+        assert!(retrieved.is_some());
+        let retrieved = retrieved.unwrap();
+        assert_eq!(retrieved.branch_name, "main");
+        assert_eq!(retrieved.tip_commit, "abc123def456");
+        assert_eq!(retrieved.indexed_at, 1699900000);
+        assert!(retrieved.remote.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_record_remote_branch() {
+        let (_tmpdir, store) = create_test_store().await;
+
+        let info = IndexedBranchInfo {
+            branch_name: "origin/develop".to_string(),
+            tip_commit: "789abc123".to_string(),
+            indexed_at: 1699900100,
+            remote: Some("origin".to_string()),
+        };
+
+        store.record_branch_indexed(&info).await.unwrap();
+
+        let retrieved = store.get_branch_info("origin/develop").await.unwrap();
+        assert!(retrieved.is_some());
+        let retrieved = retrieved.unwrap();
+        assert_eq!(retrieved.remote, Some("origin".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_update_branch() {
+        let (_tmpdir, store) = create_test_store().await;
+
+        // Record initial version
+        let info1 = IndexedBranchInfo {
+            branch_name: "main".to_string(),
+            tip_commit: "commit1".to_string(),
+            indexed_at: 1699900000,
+            remote: None,
+        };
+        store.record_branch_indexed(&info1).await.unwrap();
+
+        // Update with new commit
+        let info2 = IndexedBranchInfo {
+            branch_name: "main".to_string(),
+            tip_commit: "commit2".to_string(),
+            indexed_at: 1699900100,
+            remote: None,
+        };
+        store.record_branch_indexed(&info2).await.unwrap();
+
+        // Should have only one record with the new commit
+        let retrieved = store.get_branch_info("main").await.unwrap().unwrap();
+        assert_eq!(retrieved.tip_commit, "commit2");
+        assert_eq!(retrieved.indexed_at, 1699900100);
+
+        // Count should be 1
+        assert_eq!(store.count().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_list_indexed_branches() {
+        let (_tmpdir, store) = create_test_store().await;
+
+        let branches = vec![
+            IndexedBranchInfo {
+                branch_name: "main".to_string(),
+                tip_commit: "commit1".to_string(),
+                indexed_at: 1699900000,
+                remote: None,
+            },
+            IndexedBranchInfo {
+                branch_name: "develop".to_string(),
+                tip_commit: "commit2".to_string(),
+                indexed_at: 1699900100,
+                remote: None,
+            },
+            IndexedBranchInfo {
+                branch_name: "origin/feature".to_string(),
+                tip_commit: "commit3".to_string(),
+                indexed_at: 1699900200,
+                remote: Some("origin".to_string()),
+            },
+        ];
+
+        for info in &branches {
+            store.record_branch_indexed(info).await.unwrap();
+        }
+
+        let listed = store.list_indexed_branches().await.unwrap();
+        assert_eq!(listed.len(), 3);
+
+        // Should be sorted by name
+        assert_eq!(listed[0].branch_name, "develop");
+        assert_eq!(listed[1].branch_name, "main");
+        assert_eq!(listed[2].branch_name, "origin/feature");
+    }
+
+    #[tokio::test]
+    async fn test_is_branch_current() {
+        let (_tmpdir, store) = create_test_store().await;
+
+        let info = IndexedBranchInfo {
+            branch_name: "main".to_string(),
+            tip_commit: "abc123".to_string(),
+            indexed_at: 1699900000,
+            remote: None,
+        };
+        store.record_branch_indexed(&info).await.unwrap();
+
+        assert!(store.is_branch_current("main", "abc123").await.unwrap());
+        assert!(!store.is_branch_current("main", "def456").await.unwrap());
+        assert!(!store
+            .is_branch_current("nonexistent", "abc123")
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_remove_branch() {
+        let (_tmpdir, store) = create_test_store().await;
+
+        let info = IndexedBranchInfo {
+            branch_name: "feature".to_string(),
+            tip_commit: "abc123".to_string(),
+            indexed_at: 1699900000,
+            remote: None,
+        };
+        store.record_branch_indexed(&info).await.unwrap();
+
+        assert!(store.get_branch_info("feature").await.unwrap().is_some());
+
+        store.remove_branch("feature").await.unwrap();
+
+        assert!(store.get_branch_info("feature").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_remove_branches_by_remote() {
+        let (_tmpdir, store) = create_test_store().await;
+
+        let branches = vec![
+            IndexedBranchInfo {
+                branch_name: "main".to_string(),
+                tip_commit: "commit1".to_string(),
+                indexed_at: 1699900000,
+                remote: None,
+            },
+            IndexedBranchInfo {
+                branch_name: "origin/main".to_string(),
+                tip_commit: "commit2".to_string(),
+                indexed_at: 1699900100,
+                remote: Some("origin".to_string()),
+            },
+            IndexedBranchInfo {
+                branch_name: "origin/develop".to_string(),
+                tip_commit: "commit3".to_string(),
+                indexed_at: 1699900200,
+                remote: Some("origin".to_string()),
+            },
+            IndexedBranchInfo {
+                branch_name: "upstream/main".to_string(),
+                tip_commit: "commit4".to_string(),
+                indexed_at: 1699900300,
+                remote: Some("upstream".to_string()),
+            },
+        ];
+
+        for info in &branches {
+            store.record_branch_indexed(info).await.unwrap();
+        }
+
+        let removed = store.remove_branches_by_remote("origin").await.unwrap();
+        assert_eq!(removed, 2);
+
+        let remaining = store.list_indexed_branches().await.unwrap();
+        assert_eq!(remaining.len(), 2);
+        assert!(remaining.iter().any(|b| b.branch_name == "main"));
+        assert!(remaining.iter().any(|b| b.branch_name == "upstream/main"));
+    }
+
+    #[tokio::test]
+    async fn test_get_branches_at_commit() {
+        let (_tmpdir, store) = create_test_store().await;
+
+        let shared_commit = "shared123";
+        let branches = vec![
+            IndexedBranchInfo {
+                branch_name: "main".to_string(),
+                tip_commit: shared_commit.to_string(),
+                indexed_at: 1699900000,
+                remote: None,
+            },
+            IndexedBranchInfo {
+                branch_name: "release".to_string(),
+                tip_commit: shared_commit.to_string(),
+                indexed_at: 1699900100,
+                remote: None,
+            },
+            IndexedBranchInfo {
+                branch_name: "develop".to_string(),
+                tip_commit: "different456".to_string(),
+                indexed_at: 1699900200,
+                remote: None,
+            },
+        ];
+
+        for info in &branches {
+            store.record_branch_indexed(info).await.unwrap();
+        }
+
+        let at_shared = store.get_branches_at_commit(shared_commit).await.unwrap();
+        assert_eq!(at_shared.len(), 2);
+        assert!(at_shared.iter().any(|b| b.branch_name == "main"));
+        assert!(at_shared.iter().any(|b| b.branch_name == "release"));
+    }
+
+    #[tokio::test]
+    async fn test_get_branch_tip() {
+        let (_tmpdir, store) = create_test_store().await;
+
+        let info = IndexedBranchInfo {
+            branch_name: "main".to_string(),
+            tip_commit: "abc123".to_string(),
+            indexed_at: 1699900000,
+            remote: None,
+        };
+        store.record_branch_indexed(&info).await.unwrap();
+
+        assert_eq!(
+            store.get_branch_tip("main").await.unwrap(),
+            Some("abc123".to_string())
+        );
+        assert_eq!(store.get_branch_tip("nonexistent").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_branch_name_with_special_chars() {
+        let (_tmpdir, store) = create_test_store().await;
+
+        // Test branch names with characters that need escaping
+        let info = IndexedBranchInfo {
+            branch_name: "feature/user's-branch".to_string(),
+            tip_commit: "abc123".to_string(),
+            indexed_at: 1699900000,
+            remote: None,
+        };
+        store.record_branch_indexed(&info).await.unwrap();
+
+        let retrieved = store
+            .get_branch_info("feature/user's-branch")
+            .await
+            .unwrap();
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().branch_name, "feature/user's-branch");
+    }
+}

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
+pub mod branches;
 pub mod calls;
 mod connection;
 pub mod content;

--- a/src/display.rs
+++ b/src/display.rs
@@ -157,6 +157,22 @@ fn print_command_help() {
     );
 
     println!();
+    println!("{}", "Branch Commands:".bold().cyan());
+    println!(
+        "  {} ({})                  - List indexed branches",
+        "branches".yellow(),
+        "br".yellow()
+    );
+    println!(
+        "  {}                        - Show current branch information",
+        "branch".yellow()
+    );
+    println!(
+        "  {} <b1> <b2>          - Compare two branches",
+        "compare".yellow()
+    );
+
+    println!();
     println!("{}", "General:".bold().cyan());
     println!(
         "  {} ({}, {}) - Check if database needs optimization",


### PR DESCRIPTION
Enables indexing and querying across multiple git branches.

The indexer accepts --branches to index several branches at once.

The query tool and MCP server accept a branch parameter to scope queries to a specific branch.

New REPL commands (branches, branch, compare) and MCP tools (list_branches, compare_branches) provide branch management.

The LSP server supports a target_branch configuration option.