### PR TITLE
Fix path issue of marketplace.json

### DIFF
--- a/plugin/marketplace.json
+++ b/plugin/marketplace.json
@@ -13,7 +13,7 @@
         "name": "Semcode"
       },
       "homepage": "https://github.com/masoncl/semcode",
-      "source": "./semcode",
+      "source": "./plugin/semcode",
       "mcpServers": [
         "./mcp/semcode.json"
       ]


### PR DESCRIPTION
The source path in marketplace.json should be under plugin, otherwise,
Failed to install plugin "semcode@semcode-local":
Source path does not exist: /home/chenyu/src/semcode/semcode