### PR TITLE
Add a --refresh-lore comand line option

### DIFF
--- a/docs/lore.md
+++ b/docs/lore.md
@@ -87,6 +87,19 @@ semcode-index --lore https://lore.kernel.org/lkml/0
 # In this example: .semcode.db/lore/linux-kernel
 ```
 
+### Refreshing Existing Archives
+
+To fetch new emails and index them without re-specifying archive names:
+
+```bash
+# Refresh all previously cloned lore archives
+semcode-index --refresh-lore
+```
+
+This discovers all git repositories under `<db_dir>/lore/`, fetches new
+commits from each remote, and indexes any emails not yet in the database.
+Use this for a simple one-command workflow to keep lore archives up to date.
+
 ### Optional: Generate Vector Embeddings for Semantic Search
 
 To enable semantic search with the `vlore` command:

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -160,7 +160,6 @@ async fn main() -> Result<()> {
 
     // Handle --diffinfo flag: process diff and exit
     if let Some(file_path) = args.diffinfo {
-
         // Get git SHA
         let git_sha = semcode::git::get_git_sha(&args.git_repo)?
             .unwrap_or_else(|| "0000000000000000000000000000000000000000".to_string());

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -159,8 +159,7 @@ async fn main() -> Result<()> {
     db_manager.create_tables().await?;
 
     // Handle --diffinfo flag: process diff and exit
-    if args.diffinfo.is_some() {
-        let file_path = args.diffinfo.unwrap();
+    if let Some(file_path) = args.diffinfo {
 
         // Get git SHA
         let git_sha = semcode::git::get_git_sha(&args.git_repo)?


### PR DESCRIPTION
The value of the local cache of lore email items increases significantly if it is kept up to date. I've thus introduced a convenience mechanism for updating all locally cached lore archives, and then processing the updates for all archives in parallel.

I'm unsure what your vision of semcode's lore cache is, so the question here is whether --refresh-lore fits in with your vision or if you have some other UX or purpose in mind.