### PR TITLE
lore: fix date filtering being applied after FTS limit

### DIFF
--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -268,7 +268,8 @@ impl SchemaManager {
         let schema = Arc::new(Schema::new(vec![
             Field::new("git_commit_sha", DataType::Utf8, false), // Git commit SHA containing this email
             Field::new("from", DataType::Utf8, false),           // From header in the email
-            Field::new("date", DataType::Utf8, false),           // Date field
+            Field::new("date", DataType::Utf8, false),           // Date field (RFC 2822 format)
+            Field::new("date_timestamp", DataType::Int64, false), // Unix timestamp for efficient date filtering
             Field::new("message_id", DataType::Utf8, false),     // Message-ID header
             Field::new("in_reply_to", DataType::Utf8, true),     // In-Reply-To header (nullable)
             Field::new("subject", DataType::Utf8, false),        // Subject line

--- a/src/database/search.rs
+++ b/src/database/search.rs
@@ -2795,7 +2795,7 @@ impl VectorSearchManager {
         while let Some(batch) = temp_stream.try_next().await? {
             total_emails += batch.num_rows();
             let message_id_array = batch
-                .column(3)
+                .column(4)
                 .as_any()
                 .downcast_ref::<arrow::array::StringArray>()
                 .unwrap();
@@ -2907,7 +2907,7 @@ impl VectorSearchManager {
                                 tokio::task::spawn_blocking(move || -> Result<Vec<VectorEntry>> {
                                     // Extract email data from RecordBatch
                                     let message_id_array = record_batch
-                                        .column(3)
+                                        .column(4)
                                         .as_any()
                                         .downcast_ref::<arrow::array::StringArray>()
                                         .unwrap();
@@ -2917,17 +2917,17 @@ impl VectorSearchManager {
                                         .downcast_ref::<arrow::array::StringArray>()
                                         .unwrap();
                                     let subject_array = record_batch
-                                        .column(5)
+                                        .column(6)
                                         .as_any()
                                         .downcast_ref::<arrow::array::StringArray>()
                                         .unwrap();
                                     let recipients_array = record_batch
-                                        .column(7)
+                                        .column(8)
                                         .as_any()
                                         .downcast_ref::<arrow::array::StringArray>()
                                         .unwrap();
                                     let body_array = record_batch
-                                        .column(9)
+                                        .column(10)
                                         .as_any()
                                         .downcast_ref::<arrow::array::StringArray>()
                                         .unwrap();
@@ -3601,43 +3601,48 @@ impl VectorSearchManager {
                     .as_any()
                     .downcast_ref::<arrow::array::StringArray>()
                     .unwrap();
-                let message_id_array = batch
+                let date_timestamp_array = batch
                     .column(3)
                     .as_any()
-                    .downcast_ref::<arrow::array::StringArray>()
+                    .downcast_ref::<arrow::array::Int64Array>()
                     .unwrap();
-                let in_reply_to_array = batch
+                let message_id_array = batch
                     .column(4)
                     .as_any()
                     .downcast_ref::<arrow::array::StringArray>()
                     .unwrap();
-                let subject_array = batch
+                let in_reply_to_array = batch
                     .column(5)
                     .as_any()
                     .downcast_ref::<arrow::array::StringArray>()
                     .unwrap();
-                let references_array = batch
+                let subject_array = batch
                     .column(6)
                     .as_any()
                     .downcast_ref::<arrow::array::StringArray>()
                     .unwrap();
-                let recipients_array = batch
+                let references_array = batch
                     .column(7)
                     .as_any()
                     .downcast_ref::<arrow::array::StringArray>()
                     .unwrap();
-                let headers_array = batch
+                let recipients_array = batch
                     .column(8)
                     .as_any()
                     .downcast_ref::<arrow::array::StringArray>()
                     .unwrap();
-                let body_array = batch
+                let headers_array = batch
                     .column(9)
                     .as_any()
                     .downcast_ref::<arrow::array::StringArray>()
                     .unwrap();
-                let symbols_array = batch
+                let body_array = batch
                     .column(10)
+                    .as_any()
+                    .downcast_ref::<arrow::array::StringArray>()
+                    .unwrap();
+                let symbols_array = batch
+                    .column(11)
                     .as_any()
                     .downcast_ref::<arrow::array::StringArray>()
                     .unwrap();
@@ -3701,12 +3706,16 @@ impl VectorSearchManager {
                     let symbols: Vec<String> =
                         serde_json::from_str(symbols_json).unwrap_or_default();
 
+                    // Get date_timestamp from the batch
+                    let date_timestamp = date_timestamp_array.value(i);
+
                     results.push((
                         crate::types::LoreEmailInfo {
                             git_commit_sha: git_commit_sha_array.value(i).to_string(),
                             message_id,
                             from: from_array.value(i).to_string(),
                             date: email_date_str,
+                            date_timestamp,
                             subject: subject_array.value(i).to_string(),
                             in_reply_to: if in_reply_to_array.is_null(i) {
                                 None

--- a/src/types.rs
+++ b/src/types.rs
@@ -131,7 +131,8 @@ pub struct GitCommitInfo {
 pub struct LoreEmailInfo {
     pub git_commit_sha: String,      // Git commit SHA containing this email
     pub from: String,                // From header in the email
-    pub date: String,                // Date field
+    pub date: String,                // Date field (RFC 2822 format)
+    pub date_timestamp: i64,         // Unix timestamp for efficient date filtering
     pub message_id: String,          // Message-ID header
     pub in_reply_to: Option<String>, // In-Reply-To header (nullable)
     pub subject: String,             // Subject line


### PR DESCRIPTION
The lore search with --since/--until and --limit produced incorrect results: e.g. --limit 20 returned 0 results while --limit 30 returned 30 results. The root cause was that date filtering happened in Rust after the FTS query already applied its limit, so the FTS returned top-N candidates by text relevance (regardless of date), then date filtering removed most or all of them.

Add a date_timestamp (Unix epoch) field to LoreEmailInfo and the lore table schema, populated at indexing time from the RFC 2822 date header. Use this field to push date filtering into the database via .only_if() on FTS queries and SQL WHERE clauses on non-FTS queries, so the limit is applied to already-date-filtered results.

Specific changes:
- types.rs: add date_timestamp: i64 to LoreEmailInfo
- schema.rs: add date_timestamp Int64 column to lore table schema
- indexer.rs: add parse_rfc2822_to_timestamp() helper, populate date_timestamp when parsing emails
- connection.rs: rewrite search_lore_emails() to combine FTS with .only_if(date_timestamp filter) so limit applies post-date-filter; fix adaptive expansion loop early-exit when first iteration yields zero results; rewrite search_lore_emails_multi_field() to use new fetch_lore_emails_by_message_ids_with_filter() with SQL date filter; rewrite search_lore_emails_by_subject() to include date_timestamp in WHERE clause; update all lore read sites for the new column
- search.rs: fix column index offsets in update_lore_vectors() and fetch_emails_by_ids() to account for the new date_timestamp column at index 3

Assisted-by: Claude Code (claude-opus-4-6)