### PR TITLE
indexer: handle missing parent objects in shallow clones and root commits

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -116,12 +116,24 @@ pub fn list_shas_in_range(repo: &gix::Repository, range: &str) -> Result<Vec<Str
             .all()?
     } else {
         // Exclude commits reachable from from_spec
-        let from_commit = resolve_to_commit(repo, from_spec)?;
-        let from_id = from_commit.id().detach();
-        repo.rev_walk([to_id])
-            .with_hidden([from_id])
-            .sorting(Sorting::ByCommitTime(Default::default()))
-            .all()?
+        match resolve_to_commit(repo, from_spec) {
+            Ok(from_commit) => {
+                let from_id = from_commit.id().detach();
+                repo.rev_walk([to_id])
+                    .with_hidden([from_id])
+                    .sorting(Sorting::ByCommitTime(Default::default()))
+                    .all()?
+            }
+            Err(e) => {
+                // Parent commit not found in local object store (shallow clone or root commit).
+                // Fall back to returning just the single target commit.
+                info!(
+                    "Could not resolve '{}' ({}); falling back to single-commit indexing",
+                    from_spec, e
+                );
+                return Ok(vec![to_id.to_string()]);
+            }
+        }
     };
 
     let mut shas = Vec::new();


### PR DESCRIPTION
## Problem

Running `semcode-index --source /path/to/repo` without `--git` fails with:

```
Error: An object with id 69695f5331d4d670eff76376faa3aeb5d68733e3 could not be found
```

This happens on:
- **Shallow clones** (`git clone --depth 1`) — the HEAD commit has parent SHAs recorded in it, but those parent objects are not present in the local object store
- **Root commits** — repos initialized from tarballs (e.g. `git init && git add . && git commit`) with no parent at all

## Root Cause

When no `--git` flag is provided, `run_pipeline` auto-detects HEAD and constructs the range `SHA^..SHA` (parent-to-HEAD). `list_shas_in_range` then calls `resolve_to_commit(repo, "SHA^")`, which gix implements by looking up the parent object in the local store — failing with the above error when it doesn't exist.

## Fix

In `list_shas_in_range`, catch the error from resolving `from_spec` and fall back to returning just `[to_commit_sha]`. This means indexing proceeds with the single HEAD commit, which is the correct behaviour for the auto-detect case.

## Test

```bash
# Shallow clone
git clone --depth 1 https://github.com/torvalds/linux linux-shallow
semcode-index --source linux-shallow --database ./linux-shallow.db

# Tarball-initialized repo
tar xf linux-6.18.6.tar.xz && cd linux-6.18.6
git init && git add . && git commit -m "initial"
semcode-index --source . --database ./code.db
```