### PR TITLE
Fix an occasional MCP dead loop

### DIFF
--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -2,6 +2,7 @@
 use crate::CallRelationship;
 use anyhow::Result;
 use arrow::array::{Array, StringArray};
+use arrow::record_batch::RecordBatch;
 use colored::*;
 use futures::TryStreamExt;
 use lancedb::connection::Connection;
@@ -2809,22 +2810,16 @@ impl DatabaseManager {
                 .try_collect::<Vec<_>>()
                 .await?;
 
-            // Extract function info from results
-            for batch in &function_results {
-                for i in 0..batch.num_rows() {
-                    if path_pattern.is_none() && limit > 0 && matching_functions.len() >= limit {
-                        limit_hit = true;
-                        break;
-                    }
-
-                    if let Some(func) = self
-                        .function_store
-                        .extract_function_from_batch(batch, i)
-                        .await?
-                    {
-                        matching_functions.push(func);
-                    }
+            let functions = self
+                .function_store
+                .extract_functions_from_batches(&function_results)
+                .await?;
+            for func in functions {
+                if path_pattern.is_none() && limit > 0 && matching_functions.len() >= limit {
+                    limit_hit = true;
+                    break;
                 }
+                matching_functions.push(func);
             }
         } else {
             // For larger result sets, use batched queries optimized for parallel processing
@@ -2847,10 +2842,13 @@ impl DatabaseManager {
                 chunks.len(), chunk_size, concurrent_limit,
                 std::thread::available_parallelism().map(|p| p.get()).unwrap_or(1));
 
+            // Collect all function batches from every chunk, then do a single bulk
+            // content fetch across all chunks to avoid repeated table opens.
+            let mut all_function_batches: Vec<RecordBatch> = Vec::new();
+
             let mut chunk_stream = stream::iter(chunks)
                 .map(|chunk| {
                     let functions_table = &functions_table;
-                    let function_store = &self.function_store;
                     async move {
                         let hash_list: Vec<String> =
                             chunk.iter().map(|hash| format!("'{hash}'")).collect();
@@ -2866,41 +2864,27 @@ impl DatabaseManager {
                             .try_collect::<Vec<_>>()
                             .await?;
 
-                        // Extract functions from this chunk with potential parallel batch processing
-                        let mut chunk_functions = Vec::new();
-                        for batch in &function_results {
-                            // For large batches, we could add more parallelism here if needed
-                            // Currently keeping sequential to avoid over-parallelization
-                            for i in 0..batch.num_rows() {
-                                if let Some(func) =
-                                    function_store.extract_function_from_batch(batch, i).await?
-                                {
-                                    chunk_functions.push(func);
-                                }
-                            }
-                        }
-
-                        Ok::<Vec<crate::types::FunctionInfo>, anyhow::Error>(chunk_functions)
+                        Ok::<Vec<RecordBatch>, anyhow::Error>(function_results)
                     }
                 })
                 .buffer_unordered(concurrent_limit);
 
-            // Collect results from parallel chunks
             while let Some(chunk_result) = chunk_stream.next().await {
-                let chunk_functions = chunk_result?;
+                all_function_batches.extend(chunk_result?);
+            }
 
-                for func in chunk_functions {
-                    if path_pattern.is_none() && limit > 0 && matching_functions.len() >= limit {
-                        limit_hit = true;
-                        break;
-                    }
-                    matching_functions.push(func);
-                }
+            let functions = self
+                .function_store
+                .extract_functions_from_batches(&all_function_batches)
+                .await?;
 
-                // Early termination if we've hit the limit
-                if limit_hit {
+            // Collect results, applying the limit
+            for func in functions {
+                if path_pattern.is_none() && limit > 0 && matching_functions.len() >= limit {
+                    limit_hit = true;
                     break;
                 }
+                matching_functions.push(func);
             }
         }
 

--- a/src/database/functions.rs
+++ b/src/database/functions.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use crate::database::connection::OPTIMAL_BATCH_SIZE;
 use crate::database::content::ContentStore;
+use crate::database::get_column;
 use crate::types::{FunctionInfo, ParameterInfo};
 
 #[derive(Debug, Clone)]
@@ -563,56 +564,16 @@ impl FunctionStore {
         batch: &RecordBatch,
         row: usize,
     ) -> Result<Option<FunctionMetadata>> {
-        let name_array = batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let file_path_array = batch
-            .column(1)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let git_file_hash_array = batch
-            .column(2)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let line_start_array = batch
-            .column(3)
-            .as_any()
-            .downcast_ref::<arrow::array::Int64Array>()
-            .unwrap();
-        let line_end_array = batch
-            .column(4)
-            .as_any()
-            .downcast_ref::<arrow::array::Int64Array>()
-            .unwrap();
-        let return_type_array = batch
-            .column(5)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let parameters_array = batch
-            .column(6)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let body_hash_array = batch
-            .column(7)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let calls_array = batch
-            .column(8)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let types_array = batch
-            .column(9)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
+        let name_array = get_column::<StringArray>(batch, "name")?;
+        let file_path_array = get_column::<StringArray>(batch, "file_path")?;
+        let git_file_hash_array = get_column::<StringArray>(batch, "git_file_hash")?;
+        let line_start_array = get_column::<arrow::array::Int64Array>(batch, "line_start")?;
+        let line_end_array = get_column::<arrow::array::Int64Array>(batch, "line_end")?;
+        let return_type_array = get_column::<StringArray>(batch, "return_type")?;
+        let parameters_array = get_column::<StringArray>(batch, "parameters")?;
+        let body_hash_array = get_column::<StringArray>(batch, "body_hash")?;
+        let calls_array = get_column::<StringArray>(batch, "calls")?;
+        let types_array = get_column::<StringArray>(batch, "types")?;
 
         let parameters: Vec<ParameterInfo> =
             serde_json::from_str::<Vec<ParameterInfo>>(parameters_array.value(row))?;
@@ -744,56 +705,16 @@ impl FunctionStore {
         batch: &RecordBatch,
         row: usize,
     ) -> Result<Option<FunctionInfo>> {
-        let name_array = batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let file_path_array = batch
-            .column(1)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let git_file_hash_array = batch
-            .column(2)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let line_start_array = batch
-            .column(3)
-            .as_any()
-            .downcast_ref::<arrow::array::Int64Array>()
-            .unwrap();
-        let line_end_array = batch
-            .column(4)
-            .as_any()
-            .downcast_ref::<arrow::array::Int64Array>()
-            .unwrap();
-        let return_type_array = batch
-            .column(5)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let parameters_array = batch
-            .column(6)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let body_hash_array = batch
-            .column(7)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let calls_array = batch
-            .column(8)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let types_array = batch
-            .column(9)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
+        let name_array = get_column::<StringArray>(batch, "name")?;
+        let file_path_array = get_column::<StringArray>(batch, "file_path")?;
+        let git_file_hash_array = get_column::<StringArray>(batch, "git_file_hash")?;
+        let line_start_array = get_column::<arrow::array::Int64Array>(batch, "line_start")?;
+        let line_end_array = get_column::<arrow::array::Int64Array>(batch, "line_end")?;
+        let return_type_array = get_column::<StringArray>(batch, "return_type")?;
+        let parameters_array = get_column::<StringArray>(batch, "parameters")?;
+        let body_hash_array = get_column::<StringArray>(batch, "body_hash")?;
+        let calls_array = get_column::<StringArray>(batch, "calls")?;
+        let types_array = get_column::<StringArray>(batch, "types")?;
 
         let parameters: Vec<ParameterInfo> =
             serde_json::from_str::<Vec<ParameterInfo>>(parameters_array.value(row))?;

--- a/src/database/functions.rs
+++ b/src/database/functions.rs
@@ -14,7 +14,7 @@ use crate::database::get_column;
 use crate::types::{FunctionInfo, ParameterInfo};
 
 #[derive(Debug, Clone)]
-struct FunctionMetadata {
+pub(crate) struct FunctionMetadata {
     pub name: String,
     pub file_path: String,
     pub git_file_hash: String,
@@ -311,15 +311,7 @@ impl FunctionStore {
             return Ok(Vec::new());
         }
 
-        let batch = &results[0];
-        let mut candidates = Vec::new();
-
-        // Extract all matching functions
-        for i in 0..batch.num_rows() {
-            if let Some(func) = self.extract_function_from_batch(batch, i).await? {
-                candidates.push(func);
-            }
-        }
+        let candidates = self.extract_functions_from_batches(&results).await?;
 
         if candidates.is_empty() {
             return Ok(Vec::new());
@@ -362,16 +354,7 @@ impl FunctionStore {
             .try_collect::<Vec<_>>()
             .await?;
 
-        let mut all_functions = Vec::new();
-
-        for batch in &results {
-            // Extract ALL matching functions without any filtering
-            for i in 0..batch.num_rows() {
-                if let Some(func) = self.extract_function_from_batch(batch, i).await? {
-                    all_functions.push(func);
-                }
-            }
-        }
+        let all_functions = self.extract_functions_from_batches(&results).await?;
 
         Ok(all_functions)
     }
@@ -400,18 +383,10 @@ impl FunctionStore {
             .try_collect::<Vec<_>>()
             .await?;
 
-        // Search through all batches for the exact hash match
-        for batch in &results {
-            for i in 0..batch.num_rows() {
-                if let Some(func) = self.extract_function_from_batch(batch, i).await? {
-                    if func.git_file_hash == git_hash_to_match {
-                        return Ok(Some(func));
-                    }
-                }
-            }
-        }
-
-        Ok(None)
+        let functions = self.extract_functions_from_batches(&results).await?;
+        Ok(functions
+            .into_iter()
+            .find(|f| f.git_file_hash == git_hash_to_match))
     }
 
     pub async fn get_all(&self) -> Result<Vec<FunctionInfo>> {
@@ -559,7 +534,7 @@ impl FunctionStore {
     }
 
     /// Extract function metadata from batch without content lookup
-    fn extract_function_metadata_from_batch(
+    pub(crate) fn extract_function_metadata_from_batch(
         &self,
         batch: &RecordBatch,
         row: usize,
@@ -613,11 +588,70 @@ impl FunctionStore {
     }
 
     /// Bulk fetch content for multiple hashes
-    async fn bulk_get_content(
+    pub async fn bulk_get_content(
         &self,
         hashes: &[String],
     ) -> Result<std::collections::HashMap<String, String>> {
         self.content_store.get_content_bulk(hashes).await
+    }
+
+    /// Extract all functions from a slice of batches using bulk content lookup.
+    ///
+    /// Iterates the batches to collect metadata and unique body hashes, then
+    /// issues a single bulk content fetch before assembling the final
+    /// `FunctionInfo` values.  This avoids one `open_table` call per row.
+    pub async fn extract_functions_from_batches(
+        &self,
+        batches: &[RecordBatch],
+    ) -> Result<Vec<FunctionInfo>> {
+        let mut all_metadata = Vec::new();
+        let mut body_hashes = std::collections::HashSet::new();
+
+        for batch in batches {
+            for i in 0..batch.num_rows() {
+                match self.extract_function_metadata_from_batch(batch, i) {
+                    Ok(Some(meta)) => {
+                        if let Some(ref h) = meta.body_hash {
+                            body_hashes.insert(h.clone());
+                        }
+                        all_metadata.push(meta);
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        tracing::warn!("Skipping row {i} in batch: {e}");
+                    }
+                }
+            }
+        }
+
+        let content_map = if !body_hashes.is_empty() {
+            let hash_vec: Vec<String> = body_hashes.into_iter().collect();
+            self.bulk_get_content(&hash_vec).await?
+        } else {
+            std::collections::HashMap::new()
+        };
+
+        let mut functions = Vec::with_capacity(all_metadata.len());
+        for meta in all_metadata {
+            let body = match meta.body_hash {
+                Some(ref h) => content_map.get(h).cloned().unwrap_or_default(),
+                None => String::new(),
+            };
+            functions.push(FunctionInfo {
+                name: meta.name,
+                file_path: meta.file_path,
+                git_file_hash: meta.git_file_hash,
+                line_start: meta.line_start,
+                line_end: meta.line_end,
+                return_type: meta.return_type,
+                parameters: meta.parameters,
+                body,
+                calls: meta.calls,
+                types: meta.types,
+            });
+        }
+
+        Ok(functions)
     }
 
     /// Get functions by a list of names (batch lookup) - optimized to minimize content queries
@@ -700,91 +734,4 @@ impl FunctionStore {
         Ok(result)
     }
 
-    pub async fn extract_function_from_batch(
-        &self,
-        batch: &RecordBatch,
-        row: usize,
-    ) -> Result<Option<FunctionInfo>> {
-        let name_array = get_column::<StringArray>(batch, "name")?;
-        let file_path_array = get_column::<StringArray>(batch, "file_path")?;
-        let git_file_hash_array = get_column::<StringArray>(batch, "git_file_hash")?;
-        let line_start_array = get_column::<arrow::array::Int64Array>(batch, "line_start")?;
-        let line_end_array = get_column::<arrow::array::Int64Array>(batch, "line_end")?;
-        let return_type_array = get_column::<StringArray>(batch, "return_type")?;
-        let parameters_array = get_column::<StringArray>(batch, "parameters")?;
-        let body_hash_array = get_column::<StringArray>(batch, "body_hash")?;
-        let calls_array = get_column::<StringArray>(batch, "calls")?;
-        let types_array = get_column::<StringArray>(batch, "types")?;
-
-        let parameters: Vec<ParameterInfo> =
-            serde_json::from_str::<Vec<ParameterInfo>>(parameters_array.value(row))?;
-
-        // Get function body from content table using hash (if not null)
-        let body = if body_hash_array.is_null(row) {
-            String::new() // Empty body for null hash
-        } else {
-            let hash_hex = body_hash_array.value(row);
-            tracing::info!(
-                "Retrieving function body for '{}' with hash: {}",
-                name_array.value(row),
-                hash_hex
-            );
-            match self.content_store.get_content(hash_hex).await? {
-                Some(content) => {
-                    tracing::info!(
-                        "Successfully retrieved content for '{}', size: {} bytes",
-                        name_array.value(row),
-                        content.len()
-                    );
-                    content
-                }
-                None => {
-                    tracing::error!(
-                        "Body content not found for function '{}' with hash: {} - this indicates a database consistency issue",
-                        name_array.value(row),
-                        hash_hex
-                    );
-                    // Check if content exists with a different lookup
-                    match self.content_store.content_exists(hash_hex).await {
-                        Ok(true) => {
-                            tracing::error!("Content exists check returned true but get_content returned None - possible race condition");
-                        }
-                        Ok(false) => {
-                            tracing::error!("Content definitely does not exist in content store");
-                        }
-                        Err(e) => {
-                            tracing::error!("Error checking content existence: {}", e);
-                        }
-                    }
-                    String::new() // Fallback to empty body if content not found
-                }
-            }
-        };
-
-        // Parse calls and types from JSON (they're nullable)
-        let calls = if calls_array.is_null(row) {
-            None
-        } else {
-            serde_json::from_str::<Vec<String>>(calls_array.value(row)).ok()
-        };
-
-        let types = if types_array.is_null(row) {
-            None
-        } else {
-            serde_json::from_str::<Vec<String>>(types_array.value(row)).ok()
-        };
-
-        Ok(Some(FunctionInfo {
-            name: name_array.value(row).to_string(),
-            file_path: file_path_array.value(row).to_string(),
-            git_file_hash: git_file_hash_array.value(row).to_string(),
-            line_start: line_start_array.value(row) as u32,
-            line_end: line_end_array.value(row) as u32,
-            return_type: return_type_array.value(row).to_string(),
-            parameters,
-            body,
-            calls,
-            types,
-        }))
-    }
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -12,4 +12,16 @@ mod types;
 mod vectors;
 
 pub use connection::DatabaseManager;
-// Re-export commonly used items if needed
+
+use anyhow::Result;
+use arrow::array::RecordBatch;
+
+/// Look up a column by name and downcast to the expected Arrow array type.
+pub(crate) fn get_column<'a, T: 'static>(batch: &'a RecordBatch, name: &str) -> Result<&'a T> {
+    batch
+        .column_by_name(name)
+        .ok_or_else(|| anyhow::anyhow!("missing column '{name}' in batch"))?
+        .as_any()
+        .downcast_ref::<T>()
+        .ok_or_else(|| anyhow::anyhow!("column '{name}' has unexpected type"))
+}

--- a/src/database/search.rs
+++ b/src/database/search.rs
@@ -9,6 +9,7 @@ use lancedb::query::{ExecutableQuery, QueryBase};
 use lancedb::DistanceType;
 
 use crate::database::content::ContentStore;
+use crate::database::get_column;
 use crate::types::{FieldInfo, FunctionInfo, ParameterInfo, TypeInfo, TypedefInfo};
 use crate::vectorizer::CodeVectorizer;
 use std::collections::HashMap;
@@ -2150,11 +2151,8 @@ impl VectorSearchManager {
 
             for batch in &function_results {
                 // Get body_hash column to look up similarity scores
-                let body_hash_array = batch
-                    .column(7) // body_hash is column 7 in functions table
-                    .as_any()
-                    .downcast_ref::<arrow::array::StringArray>()
-                    .unwrap();
+                let body_hash_array =
+                    get_column::<arrow::array::StringArray>(batch, "body_hash")?;
 
                 for i in 0..batch.num_rows() {
                     if let Ok(Some(func)) = self
@@ -2207,46 +2205,14 @@ impl VectorSearchManager {
         row: usize,
         content_store: &ContentStore,
     ) -> Result<Option<FunctionInfo>> {
-        let name_array = batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let file_path_array = batch
-            .column(1)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let git_hash_array = batch
-            .column(2)
-            .as_any()
-            .downcast_ref::<arrow::array::StringArray>()
-            .unwrap();
-        let line_start_array = batch
-            .column(3)
-            .as_any()
-            .downcast_ref::<arrow::array::Int64Array>()
-            .unwrap();
-        let line_end_array = batch
-            .column(4)
-            .as_any()
-            .downcast_ref::<arrow::array::Int64Array>()
-            .unwrap();
-        let return_type_array = batch
-            .column(5)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let parameters_array = batch
-            .column(6)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let body_hash_array = batch
-            .column(7)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
+        let name_array = get_column::<StringArray>(batch, "name")?;
+        let file_path_array = get_column::<StringArray>(batch, "file_path")?;
+        let git_hash_array = get_column::<StringArray>(batch, "git_file_hash")?;
+        let line_start_array = get_column::<arrow::array::Int64Array>(batch, "line_start")?;
+        let line_end_array = get_column::<arrow::array::Int64Array>(batch, "line_end")?;
+        let return_type_array = get_column::<StringArray>(batch, "return_type")?;
+        let parameters_array = get_column::<StringArray>(batch, "parameters")?;
+        let body_hash_array = get_column::<StringArray>(batch, "body_hash")?;
 
         let parameters: Vec<ParameterInfo> = serde_json::from_str(parameters_array.value(row))?;
 

--- a/src/database/search.rs
+++ b/src/database/search.rs
@@ -9,7 +9,7 @@ use lancedb::query::{ExecutableQuery, QueryBase};
 use lancedb::DistanceType;
 
 use crate::database::content::ContentStore;
-use crate::database::get_column;
+use crate::database::functions::FunctionStore;
 use crate::types::{FieldInfo, FunctionInfo, ParameterInfo, TypeInfo, TypedefInfo};
 use crate::vectorizer::CodeVectorizer;
 use std::collections::HashMap;
@@ -1773,15 +1773,15 @@ impl SearchManager {
 
 pub struct VectorSearchManager {
     connection: Connection,
-    content_store: ContentStore,
+    function_store: FunctionStore,
 }
 
 impl VectorSearchManager {
     pub fn new(connection: Connection) -> Self {
-        let content_store = ContentStore::new(connection.clone());
+        let function_store = FunctionStore::new(connection.clone());
         Self {
             connection,
-            content_store,
+            function_store,
         }
     }
 
@@ -2132,8 +2132,9 @@ impl VectorSearchManager {
         // Now query the functions table for these content hashes (in body_hash field)
         let functions_table = self.connection.open_table("functions").execute().await?;
 
-        // Process in chunks to avoid query size limits
-        let mut function_matches = Vec::new();
+        // Collect all record batches, then use FunctionStore to extract
+        // metadata and bulk-fetch content bodies in a single pass.
+        let mut all_batches = Vec::new();
         for chunk in content_hashes.chunks(100) {
             let hash_conditions: Vec<String> = chunk
                 .iter()
@@ -2149,31 +2150,66 @@ impl VectorSearchManager {
                 .try_collect::<Vec<_>>()
                 .await?;
 
-            for batch in &function_results {
-                // Get body_hash column to look up similarity scores
-                let body_hash_array =
-                    get_column::<arrow::array::StringArray>(batch, "body_hash")?;
+            all_batches.extend(function_results);
+        }
 
-                for i in 0..batch.num_rows() {
-                    if let Ok(Some(func)) = self
-                        .extract_function_from_batch(batch, i, &self.content_store)
-                        .await
-                    {
-                        // Get the similarity score for this function's body hash
-                        let similarity_score = if body_hash_array.is_null(i) {
-                            0.0 // Default score for functions without body hash
-                        } else {
-                            let body_hash = body_hash_array.value(i);
-                            score_map.get(body_hash).copied().unwrap_or(0.0)
-                        };
-
-                        function_matches.push(FunctionMatch {
-                            function: func,
-                            similarity_score,
-                        });
+        // Extract metadata to get body_hashes for score lookup, then
+        // bulk-fetch content and assemble FunctionInfo via the store.
+        let mut all_metadata = Vec::new();
+        for batch in &all_batches {
+            for i in 0..batch.num_rows() {
+                match self.function_store.extract_function_metadata_from_batch(batch, i) {
+                    Ok(Some(meta)) => {
+                        all_metadata.push(meta);
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        tracing::warn!("Skipping row {i} in batch: {e}");
                     }
                 }
             }
+        }
+
+        let body_hashes: Vec<String> = all_metadata
+            .iter()
+            .filter_map(|m| m.body_hash.clone())
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        let content_map = if !body_hashes.is_empty() {
+            self.function_store.bulk_get_content(&body_hashes).await?
+        } else {
+            HashMap::new()
+        };
+
+        let mut function_matches = Vec::new();
+        for meta in all_metadata {
+            let similarity_score = meta
+                .body_hash
+                .as_deref()
+                .and_then(|h| score_map.get(h).copied())
+                .unwrap_or(0.0);
+            let body = meta
+                .body_hash
+                .as_ref()
+                .and_then(|h| content_map.get(h).cloned())
+                .unwrap_or_default();
+
+            function_matches.push(FunctionMatch {
+                function: FunctionInfo {
+                    name: meta.name,
+                    file_path: meta.file_path,
+                    git_file_hash: meta.git_file_hash,
+                    line_start: meta.line_start,
+                    line_end: meta.line_end,
+                    return_type: meta.return_type,
+                    parameters: meta.parameters,
+                    body,
+                    calls: meta.calls,
+                    types: meta.types,
+                },
+                similarity_score,
+            });
         }
 
         // Sort by similarity score (highest first) to show most relevant matches first
@@ -2196,52 +2232,6 @@ impl VectorSearchManager {
             .search_similar_functions_with_scores(query_vector, limit, filter)
             .await?;
         Ok(matches.into_iter().map(|m| m.function).collect())
-    }
-
-    // Helper method to extract function data from a batch - similar to the one in functions.rs
-    async fn extract_function_from_batch(
-        &self,
-        batch: &arrow::record_batch::RecordBatch,
-        row: usize,
-        content_store: &ContentStore,
-    ) -> Result<Option<FunctionInfo>> {
-        let name_array = get_column::<StringArray>(batch, "name")?;
-        let file_path_array = get_column::<StringArray>(batch, "file_path")?;
-        let git_hash_array = get_column::<StringArray>(batch, "git_file_hash")?;
-        let line_start_array = get_column::<arrow::array::Int64Array>(batch, "line_start")?;
-        let line_end_array = get_column::<arrow::array::Int64Array>(batch, "line_end")?;
-        let return_type_array = get_column::<StringArray>(batch, "return_type")?;
-        let parameters_array = get_column::<StringArray>(batch, "parameters")?;
-        let body_hash_array = get_column::<StringArray>(batch, "body_hash")?;
-
-        let parameters: Vec<ParameterInfo> = serde_json::from_str(parameters_array.value(row))?;
-
-        // Get function body from content table using hash (if not null)
-        let body = if body_hash_array.is_null(row) {
-            String::new()
-        } else {
-            let body_hash = body_hash_array.value(row);
-            match content_store.get_content(body_hash).await? {
-                Some(content) => content,
-                None => {
-                    tracing::warn!("Body content not found for hash: {}", body_hash);
-                    String::new() // Fallback to empty body if content not found
-                }
-            }
-        };
-
-        Ok(Some(FunctionInfo {
-            name: name_array.value(row).to_string(),
-            file_path: file_path_array.value(row).to_string(),
-            git_file_hash: git_hash_array.value(row).to_string(),
-            line_start: line_start_array.value(row) as u32,
-            line_end: line_end_array.value(row) as u32,
-            return_type: return_type_array.value(row).to_string(),
-            parameters,
-            body,
-            calls: None, // Not populated from database extraction helper
-            types: None, // Not populated from database extraction helper
-        }))
     }
 
     pub async fn search_similar_by_name(


### PR DESCRIPTION
Every once in a while, when using semcode, my claude session starts to think for a very long time. "top" shows semcode-mcp grinding away at 100% on a CPU. After some analysis, it appears that claude has asked the semcode MCP for a particular search that is especially inefficient. The semcode MCP loop isn't infinite, but it will take hours to complete the search. This PR modifies semcode's search logic to avoid that pathological situation.