### PR TITLE
Cargo.toml: Add package fields for publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6195,7 +6195,7 @@ dependencies = [
 
 [[package]]
 name = "semcode"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 [package]
 name = "semcode"
-version = "0.1.0"
+version = "0.1.1"
+authors = ["Chris Mason <clm@meta.com>"]
+description = "Semantic code search for C/C++ codebases"
 edition = "2021"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/facebookexperimental/semcode"
 
 [dependencies]
 lancedb = "0.27"


### PR DESCRIPTION
7388cffcac1fbb224779aaf2627010b166fcb7d4 is published as v0.1.1 on crates.io: https://crates.io/crates/semcode/0.1.1

cc: @masoncl 