### PR TITLE
database: Honor SEMCODE_DB environment variable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,12 +99,14 @@ Semcode uses the following search order to locate the `.semcode.db` database dir
 
 **For semcode-index:**
 1. **-d flag**: If provided, use the specified path (direct database path or parent directory containing `.semcode.db`)
-2. **Source directory**: Look for `.semcode.db` in the source directory specified by `-s`
-3. **Current directory**: Fall back to `./.semcode.db` in the current working directory
+2. **SEMCODE_DB environment variable**: Same path semantics as `-d`
+3. **Source directory**: Look for `.semcode.db` in the source directory specified by `-s`
+4. **Current directory**: Fall back to `./.semcode.db` in the current working directory
 
 **For semcode (query tool), semcode-mcp, and semcode-lsp:**
 1. **-d flag / configuration**: If provided, use the specified path (direct database path or parent directory containing `.semcode.db`)
-2. **Workspace/Current directory**: Use `./.semcode.db` in the workspace or current working directory
+2. **SEMCODE_DB environment variable**: Same path semantics as `-d`
+3. **Workspace/Current directory**: Use `./.semcode.db` in the workspace or current working directory
 
 The `-d` flag can specify either:
 - A direct path to the database directory (e.g., `./my-custom.db`)

--- a/src/bin/semcode-lsp.rs
+++ b/src/bin/semcode-lsp.rs
@@ -41,6 +41,11 @@ impl SemcodeLspBackend {
 
         // Try to determine database path and git repo path from config or workspace
         let config = self.config.lock().await;
+        let env_db = std::env::var("SEMCODE_DB")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
         let (db_path, git_repo_path) = if let Some(path) = &config.database_path {
             // Custom database path provided
             let git_repo = std::env::current_dir()
@@ -48,6 +53,13 @@ impl SemcodeLspBackend {
                 .and_then(|p| p.to_str().map(|s| s.to_string()))
                 .unwrap_or_else(|| ".".to_string());
             (path.clone(), git_repo)
+        } else if let Some(env_path) = env_db {
+            // SEMCODE_DB environment variable
+            let git_repo = std::env::current_dir()
+                .ok()
+                .and_then(|p| p.to_str().map(|s| s.to_string()))
+                .unwrap_or_else(|| ".".to_string());
+            (env_path, git_repo)
         } else if let Some(uri) = workspace_uri {
             // Use workspace directory (process_database_path will add .semcode.db)
             let workspace_path = uri

--- a/src/database_utils.rs
+++ b/src/database_utils.rs
@@ -9,7 +9,9 @@ use std::path::Path;
 /// 1. If `database_arg` is provided:
 ///    - If it's a directory, look for `.semcode.db` within it
 ///    - Otherwise, use the path as-is (direct database path)
-/// 2. If `database_arg` is None:
+/// 2. If `database_arg` is None, check the `SEMCODE_DB` environment variable
+///    (same directory/suffix semantics as the `-d` flag)
+/// 3. If neither is set:
 ///    - For indexing operations: prefer `source_dir/.semcode.db`, fallback to current directory
 ///    - For query operations: use current directory `./.semcode.db`
 ///
@@ -21,23 +23,17 @@ use std::path::Path;
 /// String representation of the database path to use
 pub fn process_database_path(database_arg: Option<&str>, source_dir: Option<&Path>) -> String {
     match database_arg {
-        Some(path) => {
-            let path_obj = Path::new(path);
-
-            // If path already ends with .semcode.db, use it as-is (avoid double appending)
-            if path.ends_with(".semcode.db") {
-                path.to_string()
-            } else if path_obj.is_dir() {
-                // If the path is a directory, look for .semcode.db within it
-                let semcode_db_path = path_obj.join(".semcode.db");
-                semcode_db_path.to_string_lossy().to_string()
-            } else {
-                // If it's a specific file path, use it as-is
-                path.to_string()
-            }
-        }
+        Some(path) => resolve_path(path),
         None => {
-            // No -d flag provided - behavior depends on whether we have a source directory
+            // Check SEMCODE_DB environment variable before falling back to
+            // source-dir or current-dir defaults.
+            if let Ok(env_path) = std::env::var("SEMCODE_DB") {
+                let env_path = env_path.trim();
+                if !env_path.is_empty() {
+                    return resolve_path(env_path);
+                }
+            }
+
             match source_dir {
                 Some(source_path) => {
                     // For indexing operations: prefer source directory unless it's current directory
@@ -58,10 +54,29 @@ pub fn process_database_path(database_arg: Option<&str>, source_dir: Option<&Pat
     }
 }
 
+/// Normalize a database path: append `.semcode.db` to directories, pass
+/// paths that already end with `.semcode.db` through unchanged, and
+/// return anything else as-is.
+fn resolve_path(path: &str) -> String {
+    let path_obj = Path::new(path);
+
+    if path.ends_with(".semcode.db") {
+        path.to_string()
+    } else if path_obj.is_dir() {
+        path_obj.join(".semcode.db").to_string_lossy().to_string()
+    } else {
+        path.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::path::Path;
+    use std::sync::Mutex;
+
+    /// Serializes tests that read or write the SEMCODE_DB environment variable.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_process_database_path_with_explicit_path() {
@@ -83,24 +98,94 @@ mod tests {
 
     #[test]
     fn test_process_database_path_no_args_no_source() {
-        // Test query mode (no source directory)
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved = std::env::var("SEMCODE_DB").ok();
+        std::env::remove_var("SEMCODE_DB");
+
         let result = process_database_path(None, None);
         assert_eq!(result, "./.semcode.db");
+
+        if let Some(v) = saved {
+            std::env::set_var("SEMCODE_DB", v);
+        }
     }
 
     #[test]
     fn test_process_database_path_no_args_with_source() {
-        // Test index mode with source directory
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved = std::env::var("SEMCODE_DB").ok();
+        std::env::remove_var("SEMCODE_DB");
+
         let source_path = Path::new("/source/code");
         let result = process_database_path(None, Some(source_path));
         assert_eq!(result, "/source/code/.semcode.db");
+
+        if let Some(v) = saved {
+            std::env::set_var("SEMCODE_DB", v);
+        }
     }
 
     #[test]
     fn test_process_database_path_current_dir_source() {
-        // Test index mode with current directory as source
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved = std::env::var("SEMCODE_DB").ok();
+        std::env::remove_var("SEMCODE_DB");
+
         let source_path = Path::new(".");
         let result = process_database_path(None, Some(source_path));
         assert_eq!(result, "./.semcode.db");
+
+        if let Some(v) = saved {
+            std::env::set_var("SEMCODE_DB", v);
+        }
+    }
+
+    #[test]
+    fn test_env_var_used_when_no_flag() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved = std::env::var("SEMCODE_DB").ok();
+        std::env::set_var("SEMCODE_DB", "/data/my-project.semcode.db");
+
+        let result = process_database_path(None, None);
+        assert_eq!(result, "/data/my-project.semcode.db");
+
+        // Also overrides source_dir fallback
+        let result = process_database_path(None, Some(Path::new("/source/code")));
+        assert_eq!(result, "/data/my-project.semcode.db");
+
+        match saved {
+            Some(v) => std::env::set_var("SEMCODE_DB", v),
+            None => std::env::remove_var("SEMCODE_DB"),
+        }
+    }
+
+    #[test]
+    fn test_flag_overrides_env_var() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved = std::env::var("SEMCODE_DB").ok();
+        std::env::set_var("SEMCODE_DB", "/env/path.semcode.db");
+
+        let result = process_database_path(Some("/flag/path.semcode.db"), None);
+        assert_eq!(result, "/flag/path.semcode.db");
+
+        match saved {
+            Some(v) => std::env::set_var("SEMCODE_DB", v),
+            None => std::env::remove_var("SEMCODE_DB"),
+        }
+    }
+
+    #[test]
+    fn test_empty_env_var_ignored() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved = std::env::var("SEMCODE_DB").ok();
+        std::env::set_var("SEMCODE_DB", "");
+
+        let result = process_database_path(None, None);
+        assert_eq!(result, "./.semcode.db");
+
+        match saved {
+            Some(v) => std::env::set_var("SEMCODE_DB", v),
+            None => std::env::remove_var("SEMCODE_DB"),
+        }
     }
 }


### PR DESCRIPTION
The MCP host process controls the semcode-mcp command line, so there is no way to pass a -d flag to override the database location. An environment variable is the only mechanism available for directing semcode-mcp to a database that lives outside the current working directory.

This also enables semcode to share the same database (and thus the same lore archives and source code commits) across multiple copies of the same source code base, avoiding the storage of gigabytes of data.

Add SEMCODE_DB to the database path resolution order, between the -d flag and the source-dir / current-directory fallbacks. The variable receives the same path normalization as the flag: a path ending in .semcode.db is used as-is, an existing directory gets .semcode.db appended, and anything else is taken literally.
