### PR TITLE
nomic2vec.py: Work around missing NomicBertModel::*_input_embeddings

### DIFF
--- a/scripts/nomic2vec.py
+++ b/scripts/nomic2vec.py
@@ -493,6 +493,17 @@ def main():
                 # Allow setting but always return self
                 pass
 
+        # NomicBertEmbedding doesn't implement {get,set}_input_embeddings, but
+        # it is required for distill_from_model. See:
+        # https://huggingface.co/nomic-ai/nomic-bert-2048/discussions/22
+        import types
+        def get_input_embeddings(self):
+            return self.embeddings.word_embeddings
+        def set_input_embeddings(self, value):
+            self.embeddings.word_embeddings = value
+        model.get_input_embeddings = types.MethodType(get_input_embeddings, model)
+        model.set_input_embeddings = types.MethodType(set_input_embeddings, model)
+
         try:
             # Get full stack trace to see where the error is coming from
             import traceback


### PR DESCRIPTION
NomicBertModel is missing get_input_embeddings/set_input_embeddings, which are required by model2vec's distilation pipeline. Patch in the two methods.

Before:
...
HuggingFace tokenizer defines a pad_token, but the Skeletoken model does not. Setting it to '<pad>'.

Full traceback of the error:
Traceback (most recent call last):
  File "/home/vsrinivas/WORK/semcode/./scripts/nomic2vec.py", line 501, in main
    m2v = distill_from_model(
        model=model,
    ...<3 lines>...
        device=args.device
    )
  File "/home/vsrinivas/semcode-vectors2/lib/python3.13/site-packages/model2vec/distill/distillation.py", line 107, in distill_from_model
    model = reshape_embeddings(model, original_tokenizer_model)
  File "/home/vsrinivas/semcode-vectors2/lib/python3.13/site-packages/skeletoken/external/transformers.py", line 58, in reshape_embeddings
    embedding = model.get_input_embeddings()
  File "/home/vsrinivas/semcode-vectors2/lib/python3.13/site-packages/transformers/modeling_utils.py", line 1036, in get_input_embeddings
    raise NotImplementedError(
        f"`get_input_embeddings` not auto‑handled for {self.__class__.__name__}; please override in the subclass."
    )
NotImplementedError: `get_input_embeddings` not auto‑handled for NomicBertModel; please override in the subclass.

After:
HuggingFace tokenizer defines a pad_token, but the Skeletoken model does not. Setting it to '<pad>'. Encoding tokens: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 249999/249999 [2:12:08<00:00, 31.53 tokens/s] ✓ Saved Model2Vec static model to /home/vsrinivas/WORK/semcode/nomic_v2_m2v Fixing tokenizer configuration for semcode compatibility...
  Adding [UNK] token to vocabulary
  Set unk_id to 1 for [UNK] token
  ✓ Updated tokenizer configuration
  ✓ Updated tokenizer_config.json
⚠ Verification warning: Number of tokens (250000) does not match number of vectors (249999). Please provide a token mapping or ensure the number of tokens matches the number of vectors.
  The model was saved successfully but may need additional configuration for some tools

All done. The static model is ready for high‑throughput CPU embedding.