### PR TITLE
mcp: support SEMCODE_GIT_REPO environment variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ tokio = { version = "1.50.0", features = ["full"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_bytes = "0.11"
-clap = { version = "4.6", features = ["derive"] }
+clap = { version = "4.6", features = ["derive", "env"] }
 anyhow = "1.0"
 walkdir = "2.5"
 indicatif = "0.18.4"

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -49,7 +49,7 @@ struct Args {
     database: Option<String>,
 
     /// Path to the git repository for git-aware queries
-    #[arg(long, default_value = ".")]
+    #[arg(long, env = "SEMCODE_GIT_REPO", default_value = ".")]
     git_repo: String,
 
     /// Path to local model directory (for semantic search)
@@ -80,6 +80,50 @@ struct Args {
     /// Disable working directory overlay (only query committed code)
     #[arg(long)]
     git_only: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use std::env;
+
+    #[test]
+    fn test_git_repo_env_var() {
+        let key = "SEMCODE_GIT_REPO";
+        let value = "/tmp/test_repo";
+        env::set_var(key, value);
+
+        // No arguments provided, should use env var
+        let args = Args::try_parse_from(&["query"]).unwrap();
+        assert_eq!(args.git_repo, value);
+
+        env::remove_var(key);
+    }
+
+    #[test]
+    fn test_git_repo_priority() {
+        let key = "SEMCODE_GIT_REPO";
+        let env_value = "/tmp/env_repo";
+        let arg_value = "/tmp/arg_repo";
+        env::set_var(key, env_value);
+
+        // Argument should take priority over env var
+        let args = Args::try_parse_from(&["query", "--git-repo", arg_value]).unwrap();
+        assert_eq!(args.git_repo, arg_value);
+
+        env::remove_var(key);
+    }
+
+    #[test]
+    fn test_git_repo_default() {
+        let key = "SEMCODE_GIT_REPO";
+        env::remove_var(key);
+
+        // No arguments and no env var, should use default
+        let args = Args::try_parse_from(&["query"]).unwrap();
+        assert_eq!(args.git_repo, ".");
+    }
 }
 
 /// Check if the current commit needs indexing and perform incremental indexing if needed

--- a/src/bin/semcode-mcp.rs
+++ b/src/bin/semcode-mcp.rs
@@ -1814,7 +1814,7 @@ struct Args {
     database: Option<String>,
 
     /// Path to the git repository for git-aware queries
-    #[arg(long, default_value = ".")]
+    #[arg(long, env = "SEMCODE_GIT_REPO", default_value = ".")]
     git_repo: String,
 
     /// Path to custom model directory (defaults to ~/.cache/semcode/models/)
@@ -5680,6 +5680,45 @@ async fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
+    use std::env;
+
+    #[test]
+    fn test_git_repo_env_var() {
+        let key = "SEMCODE_GIT_REPO";
+        let value = "/tmp/test_repo_mcp";
+        env::set_var(key, value);
+
+        // No arguments provided, should use env var
+        let args = Args::try_parse_from(&["semcode-mcp"]).unwrap();
+        assert_eq!(args.git_repo, value);
+
+        env::remove_var(key);
+    }
+
+    #[test]
+    fn test_git_repo_priority() {
+        let key = "SEMCODE_GIT_REPO";
+        let env_value = "/tmp/env_repo_mcp";
+        let arg_value = "/tmp/arg_repo_mcp";
+        env::set_var(key, env_value);
+
+        // Argument should take priority over env var
+        let args = Args::try_parse_from(&["semcode-mcp", "--git-repo", arg_value]).unwrap();
+        assert_eq!(args.git_repo, arg_value);
+
+        env::remove_var(key);
+    }
+
+    #[test]
+    fn test_git_repo_default() {
+        let key = "SEMCODE_GIT_REPO";
+        env::remove_var(key);
+
+        // No arguments and no env var, should use default
+        let args = Args::try_parse_from(&["semcode-mcp"]).unwrap();
+        assert_eq!(args.git_repo, ".");
+    }
 
     #[test]
     fn test_indexing_state_new() {


### PR DESCRIPTION
Add SEMCODE_GIT_REPO environment variable support for specifying the git repository path in semcode-mcp and semcode. This allows the MCP host process to provide the repository location via the environment when command line arguments cannot be easily modified.

The priority order is:
1. --git-repo command line argument
2. SEMCODE_GIT_REPO environment variable
3. Current directory (default)

Enable the env feature for clap in Cargo.toml to support the env attribute in the Args struct.

Add test code to verify that the environment variable is correctly supported and respects the priority order.