### PR TITLE
README: Add an install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ cargo build --release
 
 Binaries end up in target/release
 
+### (Optional) Installation
+
+Install to your ~/.cargo/bin (if specified in your $SHELL profile)
+
+```bash
+# From the root of the semcode repository
+cargo install --path .
+```
+
 ### Basic Usage
 
 ```bash


### PR DESCRIPTION
Add a few lines describing how to install the binary directly to a
user's ~/.cargo/bin for ease of re-use, without having to symlink the
target/ directory.

Signed-off-by: Derek Barbosa <debarbos@redhat.com>
