### PR TITLE
mcp: return JSON-RPC errors at the top level

### DIFF
--- a/src/bin/semcode-mcp.rs
+++ b/src/bin/semcode-mcp.rs
@@ -2718,12 +2718,16 @@ impl McpServer {
             "tools/list" => self.handle_list_tools().await,
             "tools/call" => self.handle_tool_call(params).await,
             "ping" => json!({}),
-            _ => json!({
-                "error": {
-                    "code": -32601,
-                    "message": "Method not found"
-                }
-            }),
+            _ => {
+                return json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": {
+                        "code": -32601,
+                        "message": "Method not found"
+                    }
+                });
+            }
         };
 
         json!({


### PR DESCRIPTION
Replies to requests for unimplemented methods nested the error object
inside "result" instead of returning a top-level "error".  Such replies
violate JSON-RPC 2.0 and strict clients fail to parse them.

Return the error at the top level.

Assisted-by: copilot:claude-opus-4.8
Signed-off-by: Mike Rapoport <rppt@kernel.org>
