### PR TITLE
Registrations that name no container

### DIFF
--- a/src/bin/query_impl/commands.rs
+++ b/src/bin/query_impl/commands.rs
@@ -238,6 +238,28 @@ async fn show_callchain_with_limits(
         .get_function_callees_git_aware(function_name, git_sha)
         .await?;
 
+    // A function reached only through a pointer has no direct callers, so
+    // without this the reverse side is silent about it while `callers`
+    // answers from the same index.
+    let reached_through_pointer = if up_levels > 0 {
+        let mut out = std::io::stdout();
+        semcode::callchain::write_indirect_reverse_chain(
+            db,
+            function_name,
+            git_sha,
+            up_levels.saturating_sub(1),
+            if calls_limit == 0 {
+                usize::MAX
+            } else {
+                calls_limit
+            },
+            &mut out,
+        )
+        .await?
+    } else {
+        0
+    };
+
     // Show callers with depth and limit control
     if !callers.is_empty() && up_levels > 0 {
         println!(
@@ -413,7 +435,11 @@ async fn show_callchain_with_limits(
     println!("Total direct callers: {}", callers.len());
     println!("Total direct callees: {}", callees.len());
 
-    if callers.is_empty() && callees.is_empty() {
+    if reached_through_pointer > 0 {
+        println!("Dispatching sites that reach it: {reached_through_pointer}");
+    }
+
+    if callers.is_empty() && callees.is_empty() && reached_through_pointer == 0 {
         println!(
             "{} This function is isolated (no callers or callees)",
             "Info:".yellow()

--- a/src/bin/semcode-mcp.rs
+++ b/src/bin/semcode-mcp.rs
@@ -1758,6 +1758,27 @@ async fn mcp_show_callchain_with_limits(
             .get_function_callees_git_aware(function_name, git_sha)
             .await?;
 
+        // A function reached only through a pointer has no direct callers, so
+        // without this the reverse side of the chain is silent about it while
+        // find_callers answers from the same index.
+        let dispatched = if up_levels > 0 {
+            semcode::callchain::write_indirect_reverse_chain(
+                db,
+                function_name,
+                git_sha,
+                up_levels.saturating_sub(1),
+                if calls_limit == 0 {
+                    usize::MAX
+                } else {
+                    calls_limit
+                },
+                &mut buffer,
+            )
+            .await?
+        } else {
+            0
+        };
+
         // Show callers with depth and limit control
         if !callers.is_empty() && up_levels > 0 {
             writeln!(
@@ -1921,7 +1942,11 @@ async fn mcp_show_callchain_with_limits(
         writeln!(buffer, "Total direct callers: {}", callers.len())?;
         writeln!(buffer, "Total direct callees: {}", callees.len())?;
 
-        if callers.is_empty() && callees.is_empty() {
+        if dispatched > 0 {
+            writeln!(buffer, "Dispatching sites that reach it: {dispatched}")?;
+        }
+
+        if callers.is_empty() && callees.is_empty() && dispatched == 0 {
             writeln!(buffer, "This function is isolated (no callers or callees)")?;
         }
     }

--- a/src/callchain.rs
+++ b/src/callchain.rs
@@ -646,6 +646,161 @@ pub async fn show_callees_to_writer(
     Ok(())
 }
 
+/// The sites that reach a function through a pointer, and the chain above each.
+///
+/// A function only ever called through a pointer has no direct callers, so a
+/// reverse chain built from calls alone renders it as a root: `callers
+/// super_cache_scan` named three sites while `callchain super_cache_scan`
+/// reported none, from the same index. The dispatching function is where the
+/// chain continues upward, and is walked like any other caller.
+///
+/// A site outside any function — a store into a table at file scope — has
+/// nothing above it and is named without a chain.
+///
+/// Returns the number of dispatching sites shown.
+/// One caller above a dispatching site, and the callers above it.
+///
+/// Kept separate from the tree printer used for a direct chain, which marks an
+/// unexpanded node with `(...)`. Here every entry is one already, and a column
+/// of them says nothing.
+fn write_caller_above(
+    node: &CallNode,
+    indent: usize,
+    remaining: usize,
+    writer: &mut dyn Write,
+) -> Result<()> {
+    let pad = "  ".repeat(indent);
+    if node.file.is_empty() {
+        writeln!(writer, "{}└─ {}", pad, node.name.yellow())?;
+    } else {
+        writeln!(
+            writer,
+            "{}└─ {} ({}:{})",
+            pad,
+            node.name.yellow(),
+            node.file.bright_black(),
+            node.line
+        )?;
+    }
+
+    if remaining > 1 {
+        for child in &node.children {
+            write_caller_above(child, indent + 1, remaining - 1, writer)?;
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn write_indirect_reverse_chain(
+    db: &DatabaseManager,
+    name: &str,
+    git_sha: &str,
+    depth: usize,
+    limit: usize,
+    writer: &mut dyn Write,
+) -> Result<usize> {
+    let indirect = db.find_indirect_callers(name, git_sha).await?;
+    if indirect.is_empty() {
+        return Ok(0);
+    }
+
+    // One entry per dispatching function: a function dispatching through the
+    // same member twice is one way in, not two.
+    let mut order: Vec<String> = Vec::new();
+    let mut sites: HashMap<String, Vec<&crate::database::resolution::IndirectCaller>> =
+        HashMap::new();
+    for caller in &indirect {
+        let key = if caller.caller_name.is_empty() {
+            format!("{}:{}", caller.site_file, caller.site_line)
+        } else {
+            caller.caller_name.clone()
+        };
+        if !sites.contains_key(&key) {
+            order.push(key.clone());
+        }
+        sites.entry(key).or_default().push(caller);
+    }
+
+    writeln!(
+        writer,
+        "\n{}",
+        "=== Reverse Chain (Through a Function Pointer) ==="
+            .bold()
+            .magenta()
+    )?;
+
+    let shown = order.len().min(limit.max(1));
+    for key in order.iter().take(shown) {
+        let group = &sites[key];
+        let first = group[0];
+        let more = if group.len() > 1 {
+            format!(" ({} sites)", group.len())
+        } else {
+            String::new()
+        };
+
+        if first.caller_name.is_empty() {
+            writeln!(
+                writer,
+                "{} at {}:{} dispatches {}{}",
+                "STORE".yellow(),
+                first.site_file.bright_black(),
+                first.site_line,
+                first.member,
+                more
+            )?;
+            continue;
+        }
+
+        writeln!(
+            writer,
+            "{} ({}:{}) dispatches {}{}",
+            first.caller_name.yellow(),
+            first.site_file.bright_black(),
+            first.site_line,
+            first.member,
+            more
+        )?;
+
+        // A chain above the site can only be walked by name, so the name must
+        // belong to the code the site is in. bcache writes its sysfs stores
+        // with a STORE() macro and lib/raid has another, so walking `STORE`
+        // answers with the callers of every macro sharing the name — the
+        // altivec xor routines, under a shrinker callback.
+        //
+        // One definition, in the file the site is in, or no chain.
+        let definitions = db
+            .find_all_functions_git_aware(&first.caller_name, git_sha)
+            .await?;
+        let names_the_site = definitions.len() == 1
+            && definitions
+                .first()
+                .is_some_and(|f| f.file_path == first.site_file);
+
+        if depth > 0 && names_the_site {
+            // One level deeper than is printed, so the printed nodes carry the
+            // file and line the deeper walk resolves for them.
+            let above =
+                build_reverse_callchain_with_git(db, &first.caller_name, depth + 1, Some(git_sha))
+                    .await?;
+            for child in &above.children {
+                write_caller_above(child, 1, depth, writer)?;
+            }
+        }
+    }
+
+    if order.len() > shown {
+        writeln!(
+            writer,
+            "{}",
+            format!("... and {} more dispatching sites", order.len() - shown).bright_black()
+        )?;
+    }
+
+    Ok(shown)
+}
+
 pub async fn show_callchain_to_writer(
     db: &DatabaseManager,
     name: &str,
@@ -693,6 +848,8 @@ pub async fn show_callchain_to_writer(
                 print_callchain_tree_to_writer(&reverse_chain, 0, writer)?;
             }
 
+            let dispatched = write_indirect_reverse_chain(db, name, git_sha, 2, 10, writer).await?;
+
             // Show forward callchain (callees)
             if !callees.is_empty() {
                 let callees_header =
@@ -704,7 +861,7 @@ pub async fn show_callchain_to_writer(
                 print_callchain_tree_to_writer(&forward_chain, 0, writer)?;
             }
 
-            if callers.is_empty() && callees.is_empty() {
+            if callers.is_empty() && callees.is_empty() && dispatched == 0 {
                 let info_msg = format!(
                     "\n{} This function is isolated (no callers or callees)",
                     "Info:".yellow()

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -861,6 +861,60 @@ impl DatabaseManager {
         Ok(resolved)
     }
 
+    /// Give a registration recorded through a field the container type it
+    /// was installed into.
+    ///
+    /// `s->s_shrink->scan_objects = f` knows `s` is a `struct super_block`
+    /// and that the receiver reads `s_shrink`; what that field is declared as
+    /// lives with struct super_block, so it is looked up here, where the
+    /// whole tree's types are available. A row whose path cannot be resolved
+    /// keeps an empty container and joins nothing, which is what it did
+    /// before it was recorded at all.
+    async fn resolve_chained_registrations(
+        &self,
+        registrations: &mut [crate::types::Registration],
+        manifest: &std::collections::HashMap<String, String>,
+    ) -> Result<()> {
+        let mut resolved: std::collections::HashMap<(String, String), Option<String>> =
+            std::collections::HashMap::new();
+
+        for registration in registrations.iter_mut() {
+            if !registration.container_type.is_empty() {
+                continue;
+            }
+            let (Some(base), Some(field)) = (
+                registration.container_base_type.as_deref(),
+                registration.container_field.as_deref(),
+            ) else {
+                continue;
+            };
+
+            let key = (base.to_string(), field.to_string());
+            let container = match resolved.get(&key) {
+                Some(known) => known.clone(),
+                None => {
+                    let mut current = Some(base.to_string());
+                    for step in field.split('.') {
+                        let Some(container_name) = current.take() else {
+                            break;
+                        };
+                        current = self
+                            .field_aggregate(&container_name, step, manifest)
+                            .await?;
+                    }
+                    resolved.insert(key, current.clone());
+                    current
+                }
+            };
+
+            if let Some(container) = container {
+                registration.container_type = container;
+            }
+        }
+
+        Ok(())
+    }
+
     /// What a field of a type is declared as, when every definition of that
     /// type at this revision agrees.
     ///
@@ -907,30 +961,39 @@ impl DatabaseManager {
         member: &str,
         git_sha: &str,
     ) -> Result<Vec<crate::types::Registration>> {
-        let manifest = self.generate_git_manifest(git_sha).await?;
+        let manifest = self.git_manifest_cached(git_sha).await?;
 
-        Ok(crate::database::resolution::at_revision(
-            self.registration_store
-                .find_by_slot(container_type, member)
-                .await?,
+        // Asking the store for the slot would miss every registration made
+        // through a field, because those rows do not know their container
+        // until it is resolved. Ask by member, resolve, then filter.
+        let mut registrations = crate::database::resolution::at_revision(
+            self.registration_store.find_by_member(member).await?,
             &manifest,
             |r| (r.file_path.as_str(), r.git_file_hash.as_str()),
-        ))
+        );
+        self.resolve_chained_registrations(&mut registrations, &manifest)
+            .await?;
+        registrations.retain(|r| r.container_type == container_type);
+
+        Ok(registrations)
     }
 
-    /// Every place a function is installed, at a revision.
     pub async fn find_registrations_of_git_aware(
         &self,
         target: &str,
         git_sha: &str,
     ) -> Result<Vec<crate::types::Registration>> {
-        let manifest = self.generate_git_manifest(git_sha).await?;
+        let manifest = self.git_manifest_cached(git_sha).await?;
 
-        Ok(crate::database::resolution::at_revision(
+        let mut registrations = crate::database::resolution::at_revision(
             self.registration_store.find_by_target(target).await?,
             &manifest,
             |r| (r.file_path.as_str(), r.git_file_hash.as_str()),
-        ))
+        );
+        self.resolve_chained_registrations(&mut registrations, &manifest)
+            .await?;
+
+        Ok(registrations)
     }
 
     /// Everything installed in one member of one type.
@@ -976,11 +1039,13 @@ impl DatabaseManager {
 
         let manifest = self.git_manifest_cached(git_sha).await?;
 
-        let registrations = at_revision(
+        let mut registrations = at_revision(
             self.registration_store.find_by_target(target).await?,
             &manifest,
             |r| (r.file_path.as_str(), r.git_file_hash.as_str()),
         );
+        self.resolve_chained_registrations(&mut registrations, &manifest)
+            .await?;
         let stated = at_revision(
             self.dispatch_site_store.find_by_target(target).await?,
             &manifest,

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -6700,6 +6700,8 @@ mod tests {
             line: 1,
             enclosing_function: String::new(),
             kind: RegistrationKind::DesignatedInit,
+            container_base_type: None,
+            container_field: None,
         }])
         .await
         .unwrap();
@@ -6762,6 +6764,8 @@ mod tests {
             line: 10,
             enclosing_function: String::new(),
             kind: RegistrationKind::DesignatedInit,
+            container_base_type: None,
+            container_field: None,
         };
 
         let rows = vec![

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -137,9 +137,12 @@ impl DatabaseManager {
     /// was built with.
     /// Forget files an older extractor read, after this one has read the tree.
     pub async fn forget_older_processed_files(&self) -> Result<usize> {
-        self.processed_file_store
-            .forget_older_than(crate::SCHEMA_VERSION)
-            .await
+        self.forget_processed_before(crate::SCHEMA_VERSION).await
+    }
+
+    /// The same, against a stated version, so a test can name one.
+    pub async fn forget_processed_before(&self, version: u32) -> Result<usize> {
+        self.processed_file_store.forget_older_than(version).await
     }
 
     pub async fn record_index_build(&self, extensions: &[String], no_macros: bool) -> Result<()> {

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -135,6 +135,13 @@ impl DatabaseManager {
 
     /// Mark the index as holding what this build writes, with the options it
     /// was built with.
+    /// Forget files an older extractor read, after this one has read the tree.
+    pub async fn forget_older_processed_files(&self) -> Result<usize> {
+        self.processed_file_store
+            .forget_older_than(crate::SCHEMA_VERSION)
+            .await
+    }
+
     pub async fn record_index_build(&self, extensions: &[String], no_macros: bool) -> Result<()> {
         self.schema_manager
             .set_index_build(extensions, no_macros)

--- a/src/database/processed_files.rs
+++ b/src/database/processed_files.rs
@@ -181,6 +181,29 @@ impl ProcessedFileStore {
     }
 
     /// Remove processed file records for a specific git_sha (e.g., when git commit changes)
+    /// Forget files read by an older extractor.
+    ///
+    /// Called once the whole tree has been read: a row still carrying an
+    /// older version at that point describes content that is not in the tree,
+    /// usually an earlier revision of a file the last commit touched. Keeping
+    /// it makes the index answer "older than this build" forever, so
+    /// re-indexing never clears the refusal it is supposed to clear. Losing
+    /// the row costs a re-read if that content ever comes back.
+    pub async fn forget_older_than(&self, version: u32) -> Result<usize> {
+        let table = self
+            .connection
+            .open_table("processed_files")
+            .execute()
+            .await?;
+        let before = table.count_rows(None).await?;
+        table
+            .delete(&format!(
+                "extractor_version IS NULL OR extractor_version < {version}"
+            ))
+            .await?;
+        Ok(before - table.count_rows(None).await?)
+    }
+
     pub async fn remove_for_git_sha(&self, git_sha: Option<&str>) -> Result<()> {
         let table = self
             .connection

--- a/src/database/registrations.rs
+++ b/src/database/registrations.rs
@@ -3,6 +3,7 @@
 // Storage for registrations: functions installed in struct members. These are
 // the targets a dispatch site resolves to, joined on (container_type, member).
 use anyhow::Result;
+use arrow::array::Array;
 use arrow::array::{ArrayRef, Int64Array, RecordBatch, RecordBatchIterator, StringArray};
 use arrow::array::{Int64Builder, StringBuilder};
 use futures::TryStreamExt;
@@ -37,6 +38,8 @@ impl RegistrationStore {
             .await?;
 
         let mut container = StringBuilder::new();
+        let mut container_base = StringBuilder::new();
+        let mut container_field = StringBuilder::new();
         let mut member = StringBuilder::new();
         let mut target = StringBuilder::new();
         let mut file_path = StringBuilder::new();
@@ -48,6 +51,8 @@ impl RegistrationStore {
 
         for r in &registrations {
             container.append_value(&r.container_type);
+            container_base.append_option(r.container_base_type.as_deref());
+            container_field.append_option(r.container_field.as_deref());
             member.append_value(&r.member);
             target.append_value(&r.target);
             file_path.append_value(&r.file_path);
@@ -60,6 +65,14 @@ impl RegistrationStore {
 
         let batch = RecordBatch::try_from_iter(vec![
             ("container_type", Arc::new(container.finish()) as ArrayRef),
+            (
+                "container_base_type",
+                Arc::new(container_base.finish()) as ArrayRef,
+            ),
+            (
+                "container_field",
+                Arc::new(container_field.finish()) as ArrayRef,
+            ),
             ("member", Arc::new(member.finish()) as ArrayRef),
             ("target", Arc::new(target.finish()) as ArrayRef),
             ("file_path", Arc::new(file_path.finish()) as ArrayRef),
@@ -147,6 +160,16 @@ impl RegistrationStore {
                 .to_string())
         };
 
+        // Absent on a row whose container the file stated outright, and on
+        // every row written before the columns existed.
+        let optional = |name: &str| -> Option<String> {
+            batch
+                .column_by_name(name)
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+                .filter(|values| values.is_valid(row) && !values.value(row).is_empty())
+                .map(|values| values.value(row).to_string())
+        };
+
         let kind_text = text("kind")?;
         let kind = RegistrationKind::from_column_value(&kind_text)
             .ok_or_else(|| anyhow::anyhow!("unknown registration kind '{kind_text}'"))?;
@@ -161,6 +184,8 @@ impl RegistrationStore {
             line: get_column::<Int64Array>(batch, "line")?.value(row) as u32,
             enclosing_function: text("enclosing_function")?,
             kind,
+            container_base_type: optional("container_base_type"),
+            container_field: optional("container_field"),
         })
     }
 }

--- a/src/database/resolution.rs
+++ b/src/database/resolution.rs
@@ -330,6 +330,8 @@ mod tests {
             line: 7,
             enclosing_function: String::new(),
             kind: RegistrationKind::DesignatedInit,
+            container_base_type: None,
+            container_field: None,
         }
     }
 

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -71,10 +71,22 @@ impl SchemaManager {
 
         if !table_names.iter().any(|n| n == "dispatch_sites") {
             self.create_dispatch_sites_table().await?;
+        } else {
+            self.recreate_without_columns(
+                "dispatch_sites",
+                &["receiver_base_type", "receiver_field"],
+            )
+            .await?;
         }
 
         if !table_names.iter().any(|n| n == "registrations") {
             self.create_registrations_table().await?;
+        } else {
+            self.recreate_without_columns(
+                "registrations",
+                &["container_base_type", "container_field"],
+            )
+            .await?;
         }
 
         if !table_names.iter().any(|n| n == "schema_meta") {
@@ -489,24 +501,41 @@ impl SchemaManager {
     /// index would report itself stale forever, and re-indexing would never
     /// settle it.
     async fn migrate_processed_files_table(&self) -> Result<()> {
-        let table = self
-            .connection
-            .open_table("processed_files")
-            .execute()
-            .await?;
-        let has_column = table
-            .schema()
-            .await?
-            .fields()
+        self.recreate_without_columns("processed_files", &["extractor_version"])
+            .await
+    }
+
+    /// Start a table again when this build writes columns it does not have.
+    ///
+    /// Creating tables only creates the ones that are missing, so a column
+    /// added to a table definition never reaches a database that already has
+    /// that table: every insert then fails with a schema mismatch, and the
+    /// index cannot be repaired by re-indexing, which is the one thing a user
+    /// will try.
+    ///
+    /// Dropping is safe for these tables because every row in them is derived
+    /// from a file, and the schema version that goes with a column change
+    /// makes each file be read again.
+    async fn recreate_without_columns(&self, name: &str, columns: &[&str]) -> Result<()> {
+        let table = self.connection.open_table(name).execute().await?;
+        let schema = table.schema().await?;
+        let missing: Vec<&str> = columns
             .iter()
-            .any(|field| field.name() == "extractor_version");
-        if has_column {
+            .copied()
+            .filter(|column| !schema.fields().iter().any(|f| f.name() == column))
+            .collect();
+        if missing.is_empty() {
             return Ok(());
         }
 
-        tracing::info!("processed_files predates the extractor version column: starting it again");
-        self.connection.drop_table("processed_files", &[]).await?;
-        self.create_processed_files_table().await
+        tracing::info!("{name} predates {missing:?}: starting the table again");
+        self.connection.drop_table(name, &[]).await?;
+        match name {
+            "processed_files" => self.create_processed_files_table().await,
+            "registrations" => self.create_registrations_table().await,
+            "dispatch_sites" => self.create_dispatch_sites_table().await,
+            other => Err(anyhow::anyhow!("no way to recreate {other}")),
+        }
     }
 
     async fn create_symbol_filename_table(&self) -> Result<()> {

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -30,7 +30,10 @@ pub enum OptimizeOutcome {
 /// 3: `receiver_field` holds the whole path of fields a receiver reads, not
 ///    only the first, so `a->b->c->m()` resolves. A version 2 row holds one
 ///    field where this reads a path.
-pub const SCHEMA_VERSION: u32 = 3;
+/// 4: a registration can be recorded before its container type is known,
+///    carrying the base and field path instead. A version 3 index has no
+///    such rows at all: it dropped those registrations.
+pub const SCHEMA_VERSION: u32 = 4;
 
 pub struct SchemaManager {
     connection: Connection,
@@ -196,6 +199,12 @@ impl SchemaManager {
     pub async fn create_registrations_table(&self) -> Result<()> {
         let schema = Arc::new(Schema::new(vec![
             Field::new("container_type", DataType::Utf8, false),
+            // For `base->field->member = f`: what the file proves about the
+            // base, and the path read from it. The container itself is
+            // whatever that field is declared as, which lives with the base's
+            // struct, so resolution finishes the job.
+            Field::new("container_base_type", DataType::Utf8, true),
+            Field::new("container_field", DataType::Utf8, true),
             Field::new("member", DataType::Utf8, false),
             Field::new("target", DataType::Utf8, false),
             Field::new("file_path", DataType::Utf8, false),

--- a/src/database_utils.rs
+++ b/src/database_utils.rs
@@ -60,13 +60,22 @@ pub fn process_database_path(database_arg: Option<&str>, source_dir: Option<&Pat
 fn resolve_path(path: &str) -> String {
     let path_obj = Path::new(path);
 
-    if path.ends_with(".semcode.db") {
+    if path.ends_with(".semcode.db") || is_database(path_obj) {
         path.to_string()
-    } else if path_obj.is_dir() {
-        path_obj.join(".semcode.db").to_string_lossy().to_string()
     } else {
-        path.to_string()
+        path_obj.join(".semcode.db").to_string_lossy().to_string()
     }
+}
+
+/// Whether a path is itself a database rather than a directory holding one.
+///
+/// Asked of what is on disk, so that one argument names one database whatever
+/// order the commands run in. Deciding on whether the directory merely exists
+/// splits it in two: `-d dir` writes the database at `dir` when nothing is
+/// there yet, and every later command reads `dir/.semcode.db`, which is
+/// empty, so a freshly written index answers every query with "not found".
+fn is_database(path: &Path) -> bool {
+    path.join("functions.lance").exists()
 }
 
 #[cfg(test)]
@@ -80,20 +89,18 @@ mod tests {
 
     #[test]
     fn test_process_database_path_with_explicit_path() {
-        // Test with explicit file path
-        let result = process_database_path(Some("/path/to/my.db"), None);
-        assert_eq!(result, "/path/to/my.db");
+        // A path naming the database itself is used as given.
+        let result = process_database_path(Some("/path/to/.semcode.db"), None);
+        assert_eq!(result, "/path/to/.semcode.db");
     }
 
     #[test]
     fn test_process_database_path_with_directory() {
-        // Test with directory - should append .semcode.db
-        // Note: In a real test environment, we'd need to create actual directories
-        // For now, we test the logic with a hypothetical directory
+        // Anything else names a directory to hold one, whether or not it is
+        // there yet: the indexer creates it, and a later query must be told
+        // the same place.
         let result = process_database_path(Some("/existing/dir"), None);
-        // This would be "/existing/dir/.semcode.db" if the directory exists
-        // For this unit test, it will treat it as a file since we don't have real filesystem
-        assert_eq!(result, "/existing/dir");
+        assert_eq!(result, "/existing/dir/.semcode.db");
     }
 
     #[test]
@@ -187,5 +194,42 @@ mod tests {
             Some(v) => std::env::set_var("SEMCODE_DB", v),
             None => std::env::remove_var("SEMCODE_DB"),
         }
+    }
+}
+
+#[cfg(test)]
+mod one_argument_one_database {
+    use super::*;
+
+    #[test]
+    fn a_directory_that_does_not_exist_yet_holds_the_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let fresh = dir.path().join("index");
+        assert_eq!(
+            resolve_path(fresh.to_str().unwrap()),
+            fresh.join(".semcode.db").to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn the_same_argument_names_the_same_database_once_it_exists() {
+        // What the indexer wrote is what a later query must read.
+        let dir = tempfile::tempdir().unwrap();
+        let arg = dir.path().join("index");
+        let written = resolve_path(arg.to_str().unwrap());
+        std::fs::create_dir_all(&written).unwrap();
+        std::fs::create_dir_all(Path::new(&written).join("functions.lance")).unwrap();
+
+        assert_eq!(resolve_path(arg.to_str().unwrap()), written);
+    }
+
+    #[test]
+    fn a_database_written_at_the_path_itself_is_read_there() {
+        // Databases already written this way keep working.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("functions.lance")).unwrap();
+        let arg = dir.path().to_str().unwrap();
+
+        assert_eq!(resolve_path(arg), arg);
     }
 }

--- a/src/git_range.rs
+++ b/src/git_range.rs
@@ -1186,10 +1186,19 @@ pub async fn process_git_tree(
         }
     }
 
-    // The tree has been read with this build, so the index now holds what
-    // this version writes, for the extensions it was told to read. Recorded
-    // last: an interrupted run leaves the older version in place and is
-    // re-read next time.
+    // The whole tree has been read with this build, so a file still recorded
+    // against an older extractor is content the tree no longer holds. Left in
+    // place it keeps the index answering "older than this build" for ever, so
+    // re-indexing never clears the refusal it is meant to clear.
+    match db_manager.forget_older_processed_files().await {
+        Ok(0) => {}
+        Ok(forgotten) => info!("Forgot {forgotten} files read by an older extractor"),
+        Err(e) => error!("Failed to forget files read by an older extractor: {e}"),
+    }
+
+    // The index now holds what this version writes, for the extensions it was
+    // told to read. Recorded last: an interrupted run leaves the older version
+    // in place and is re-read next time.
     db_manager.record_index_build(extensions, no_macros).await?;
 
     Ok(())

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -3922,6 +3922,36 @@ mod tests {
     }
 
     #[test]
+    fn a_path_keeps_every_field_however_long() {
+        // Four fields, mixed arrow and dot, which is what a chain through an
+        // embedded struct looks like.
+        let (_functions, sites) = analyze(
+            "struct l1 { int x; };\n\
+             int probe(struct l1 *a) { return a->b.c->d->run(); }\n",
+            "test.c",
+        );
+
+        let run = sites.iter().find(|s| s.member == "run").unwrap();
+        assert_eq!(run.receiver_base_type.as_deref(), Some("l1"));
+        assert_eq!(run.receiver_field.as_deref(), Some("b.c.d"));
+    }
+
+    #[test]
+    fn a_registration_keeps_every_field_however_long() {
+        let source = "struct l1 { int x; };\n\
+                      int setup(struct l1 *a) {\n\
+                      \ta->b->c->d->handler = my_handler;\n\
+                      \treturn 0;\n\
+                      }\n";
+        let registrations = registration_rows(source, "test.c");
+
+        assert_eq!(registrations.len(), 1, "{registrations:?}");
+        assert_eq!(registrations[0].container_base_type.as_deref(), Some("l1"));
+        assert_eq!(registrations[0].container_field.as_deref(), Some("b.c.d"));
+        assert_eq!(registrations[0].member, "handler");
+    }
+
+    #[test]
     fn a_chain_through_a_call_records_nothing() {
         // `ath9k_hw_common(_ah)->ops` needs the return type of a function,
         // which is a different lookup; reading half the chain would file the

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -1431,11 +1431,12 @@ impl TreeSitterAnalyzer {
                 // keep looking outward for a type.
                 "initializer_pair" => {
                     let designator = parent.child_by_field_name("designator")?;
-                    if designator.kind() != "field_designator" {
-                        // An array slot names no field, so the path breaks.
-                        return None;
+                    if designator.kind() == "field_designator" {
+                        path.push(source[designator.named_child(0)?.byte_range()].to_string());
                     }
-                    path.push(source[designator.named_child(0)?.byte_range()].to_string());
+                    // A subscript names a slot rather than a field, and every
+                    // slot of an array has the array's element type, so
+                    // passing through one leaves the path unchanged.
                     node = parent;
                 }
                 _ => node = parent,
@@ -4406,9 +4407,9 @@ mod tests {
     }
 
     #[test]
-    fn an_array_slot_breaks_the_path() {
-        // `[0] = { .run = impl }` names no field to look up, so the container
-        // cannot be reached from the type the file states.
+    fn an_array_slot_keeps_the_element_type() {
+        // Every slot of an array holds the array's element type, so passing
+        // through `[0]` changes nothing about which struct owns the member.
         let found = registration_rows(
             "struct entry { int (*run)(void); };\n\
              int impl(void);\n\
@@ -4416,10 +4417,27 @@ mod tests {
             "test.c",
         );
 
-        assert!(
-            found.iter().all(|r| r.member != "run"),
-            "recorded a container it cannot name: {found:?}"
+        let run = found
+            .iter()
+            .find(|r| r.member == "run")
+            .expect("array slot recorded nothing");
+        assert_eq!(run.container_type, "entry");
+        assert_eq!(run.container_base_type, None);
+    }
+
+    #[test]
+    fn an_array_slot_inside_a_field_keeps_the_path() {
+        let found = registration_rows(
+            "struct entry { int (*run)(void); };\n\
+             struct holder { struct entry table[4]; };\n\
+             int impl(void);\n\
+             static struct holder h = { .table = { [0] = { .run = impl } } };\n",
+            "test.c",
         );
+
+        let run = found.iter().find(|r| r.member == "run").unwrap();
+        assert_eq!(run.container_base_type.as_deref(), Some("holder"));
+        assert_eq!(run.container_field.as_deref(), Some("table"));
     }
 
     #[test]

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -1179,27 +1179,8 @@ impl TreeSitterAnalyzer {
                 (String::new(), Some(outer_type), Some(path.join(".")))
             };
 
-            let mut cursor = node.walk();
-            for pair in node.named_children(&mut cursor) {
-                if pair.kind() != "initializer_pair" {
-                    continue;
-                }
-
-                // `.member = ...`; an array designator is a slot, not a member.
-                let Some(designator) = pair.child_by_field_name("designator") else {
-                    continue;
-                };
-                if designator.kind() != "field_designator" {
-                    continue;
-                }
-                let member = designator
-                    .named_child(0)
-                    .map(|n| source[n.byte_range()].to_string())
-                    .unwrap_or_default();
-
-                let Some(value) = pair.child_by_field_name("value") else {
-                    continue;
-                };
+            for (member_node, value) in Self::initializer_members(node) {
+                let member = source[member_node.byte_range()].to_string();
                 // `.read = my_read` and `.read = &my_read` say the same thing.
                 let target_node = match value.kind() {
                     "identifier" => Some(value),
@@ -1223,8 +1204,8 @@ impl TreeSitterAnalyzer {
                     container_field: container_field.clone(),
                     member,
                     target,
-                    byte_start: pair.start_byte(),
-                    line: pair.start_position().row as u32 + 1,
+                    byte_start: member_node.start_byte(),
+                    line: member_node.start_position().row as u32 + 1,
                     kind: RegistrationKind::DesignatedInit,
                 });
             }
@@ -1380,6 +1361,55 @@ impl TreeSitterAnalyzer {
     /// compound literal that holds it. A nested initializer states no type of
     /// its own, and inferring one would need the member's declared type,
     /// which usually lives in another file.
+    /// The members one initializer list installs, as (member, value).
+    ///
+    /// A preprocessor line inside the list defeats the grammar:
+    ///
+    /// ```text
+    /// static const struct tcp_sock_af_ops tcp_sock_ipv4_specific = {
+    /// #ifdef CONFIG_TCP_AO
+    ///         .ao_lookup = tcp_v4_ao_lookup,
+    /// ```
+    ///
+    /// parses as an error, and `.ao_lookup = tcp_v4_ao_lookup` then recovers
+    /// as an *assignment* whose object is the previous pair's value. Reading
+    /// only `initializer_pair` children loses every member the first arm of a
+    /// conditional installs while keeping the ones after `#else`, which is how
+    /// half a struct goes missing with nothing looking wrong.
+    ///
+    /// An assignment cannot appear in an initializer list in C, so one here is
+    /// always that recovery, and the field it assigns to is the member. The
+    /// object it appears to assign through is an artefact and is ignored.
+    ///
+    /// A nested list is skipped: it is its own list with its own container,
+    /// and the walk reaches it separately.
+    fn initializer_members(list: tree_sitter::Node) -> Vec<(tree_sitter::Node, tree_sitter::Node)> {
+        let mut members = Vec::new();
+        let mut cursor = list.walk();
+
+        for child in list.named_children(&mut cursor) {
+            let named = match child.kind() {
+                "initializer_pair" => child
+                    .child_by_field_name("designator")
+                    .filter(|d| d.kind() == "field_designator")
+                    .and_then(|d| d.named_child(0))
+                    .zip(child.child_by_field_name("value")),
+                "assignment_expression" => child
+                    .child_by_field_name("left")
+                    .filter(|l| l.kind() == "field_expression")
+                    .and_then(|l| l.child_by_field_name("field"))
+                    .zip(child.child_by_field_name("right")),
+                _ => None,
+            };
+
+            if let Some(pair) = named {
+                members.push(pair);
+            }
+        }
+
+        members
+    }
+
     /// The type an initializer list fills in, and the path of fields to reach
     /// it from the type the file states.
     ///
@@ -4438,6 +4468,39 @@ mod tests {
         let run = found.iter().find(|r| r.member == "run").unwrap();
         assert_eq!(run.container_base_type.as_deref(), Some("holder"));
         assert_eq!(run.container_field.as_deref(), Some("table"));
+    }
+
+    #[test]
+    fn a_member_behind_a_config_option_is_recorded() {
+        // net/ipv4/tcp_ipv4.c guards half of tcp_sock_ipv4_specific this way.
+        // Which arm a build takes is not knowable here, and a function
+        // installed by either is one something can dispatch to.
+        let found = registration_rows(
+            "struct ops { int (*plain)(void); int (*guarded)(void); int (*other)(void); };\n\
+             int plain_impl(void);\n\
+             int guarded_impl(void);\n\
+             int other_impl(void);\n\
+             static struct ops o = {\n\
+             \t.plain = plain_impl,\n\
+             #ifdef CONFIG_SOMETHING\n\
+             \t.guarded = guarded_impl,\n\
+             #else\n\
+             \t.other = other_impl,\n\
+             #endif\n\
+             };\n",
+            "test.c",
+        );
+
+        let members: Vec<&str> = found.iter().map(|r| r.member.as_str()).collect();
+        assert!(members.contains(&"plain"), "{found:?}");
+        assert!(
+            members.contains(&"guarded"),
+            "the arm before #else was lost: {found:?}"
+        );
+        assert!(members.contains(&"other"), "{found:?}");
+        assert!(found.iter().all(|r| r.container_type == "ops"), "{found:?}");
+        let guarded = found.iter().find(|r| r.member == "guarded").unwrap();
+        assert_eq!(guarded.target, "guarded_impl");
     }
 
     #[test]

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -1168,8 +1168,15 @@ impl TreeSitterAnalyzer {
                 continue;
             }
 
-            let Some(container_type) = Self::initializer_container_type(node, source) else {
+            let Some((outer_type, path)) = Self::initializer_container(node, source) else {
                 continue;
+            };
+            // An empty path means the list fills the type the file named, so
+            // the container is known outright.
+            let (container_type, container_base_type, container_field) = if path.is_empty() {
+                (outer_type, None, None)
+            } else {
+                (String::new(), Some(outer_type), Some(path.join(".")))
             };
 
             let mut cursor = node.walk();
@@ -1212,8 +1219,8 @@ impl TreeSitterAnalyzer {
 
                 found.push(RawRegistration {
                     container_type: container_type.clone(),
-                    container_base_type: None,
-                    container_field: None,
+                    container_base_type: container_base_type.clone(),
+                    container_field: container_field.clone(),
                     member,
                     target,
                     byte_start: pair.start_byte(),
@@ -1373,16 +1380,39 @@ impl TreeSitterAnalyzer {
     /// compound literal that holds it. A nested initializer states no type of
     /// its own, and inferring one would need the member's declared type,
     /// which usually lives in another file.
-    fn initializer_container_type(list: tree_sitter::Node, source: &str) -> Option<String> {
+    /// The type an initializer list fills in, and the path of fields to reach
+    /// it from the type the file states.
+    ///
+    /// A list directly under a declaration or a compound literal names its
+    /// own type and the path is empty. A nested one does not:
+    ///
+    /// ```text
+    /// static struct nft_set_type nft_set_rbtree_type = {
+    ///         .ops = {
+    ///                 .activate = nft_rbtree_activate,
+    /// ```
+    ///
+    /// `activate` belongs to whatever `ops` is declared as within
+    /// `nft_set_type`, which lives with that struct rather than here. The
+    /// outer type and the path `ops` are what this file proves; resolution
+    /// turns them into the container, exactly as it does for a receiver that
+    /// reads through a field.
+    fn initializer_container(
+        list: tree_sitter::Node,
+        source: &str,
+    ) -> Option<(String, Vec<String>)> {
         let mut node = list;
+        let mut path: Vec<String> = Vec::new();
 
         while let Some(parent) = node.parent() {
             match parent.kind() {
                 // `(struct net_protocol) { .handler = tcp_v4_rcv }`
                 "compound_literal_expression" => {
-                    return parent
+                    let outer = parent
                         .child_by_field_name("type")
-                        .and_then(|t| Self::aggregate_type_name(t, source));
+                        .and_then(|t| Self::aggregate_type_name(t, source))?;
+                    path.reverse();
+                    return Some((outer, path));
                 }
                 // `static const struct file_operations fops = { ... };`
                 "init_declarator" | "declaration" => {
@@ -1391,12 +1421,23 @@ impl TreeSitterAnalyzer {
                     } else {
                         parent.parent()?
                     };
-                    return declaration
+                    let outer = declaration
                         .child_by_field_name("type")
-                        .and_then(|t| Self::aggregate_type_name(t, source));
+                        .and_then(|t| Self::aggregate_type_name(t, source))?;
+                    path.reverse();
+                    return Some((outer, path));
                 }
-                // A nested initializer: the inner type is not stated here.
-                "initializer_pair" | "initializer_list" => return None,
+                // One level in: remember which field this list is filling and
+                // keep looking outward for a type.
+                "initializer_pair" => {
+                    let designator = parent.child_by_field_name("designator")?;
+                    if designator.kind() != "field_designator" {
+                        // An array slot names no field, so the path breaks.
+                        return None;
+                    }
+                    path.push(source[designator.named_child(0)?.byte_range()].to_string());
+                    node = parent;
+                }
                 _ => node = parent,
             }
         }
@@ -4342,22 +4383,42 @@ mod tests {
     }
 
     #[test]
-    fn an_initializer_whose_type_is_not_stated_registers_nothing() {
-        // A nested initializer names no type here: the member's type is
-        // declared with the struct, usually in another file. Filing the
-        // registration under a guessed type would join it to the wrong
-        // dispatch sites.
-        let found = registrations_of(
+    fn a_nested_initializer_records_the_path_to_its_container() {
+        // The inner member belongs to whatever `in` is declared as, which is
+        // stated with struct outer rather than here. That used to be a reason
+        // to record nothing; it is now the same field lookup a chained
+        // receiver does, so record the outer type and the path.
+        let found = registration_rows(
             "struct outer { struct inner { int (*run)(void); } in; };\n\
              int impl(void);\n\
              static struct outer o = { .in = { .run = impl } };\n",
             "test.c",
         );
 
-        let members: Vec<&str> = found.iter().map(|(_, m, _, _)| m.as_str()).collect();
+        let run = found
+            .iter()
+            .find(|r| r.member == "run")
+            .expect("nested initializer not recorded at all");
+        assert_eq!(run.container_type, "");
+        assert_eq!(run.container_base_type.as_deref(), Some("outer"));
+        assert_eq!(run.container_field.as_deref(), Some("in"));
+        assert_eq!(run.target, "impl");
+    }
+
+    #[test]
+    fn an_array_slot_breaks_the_path() {
+        // `[0] = { .run = impl }` names no field to look up, so the container
+        // cannot be reached from the type the file states.
+        let found = registration_rows(
+            "struct entry { int (*run)(void); };\n\
+             int impl(void);\n\
+             static struct entry table[] = { [0] = { .run = impl } };\n",
+            "test.c",
+        );
+
         assert!(
-            !members.contains(&"run"),
-            "nested initializer registered under a guessed type: {found:?}"
+            found.iter().all(|r| r.member != "run"),
+            "recorded a container it cannot name: {found:?}"
         );
     }
 

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -93,6 +93,11 @@ struct MacroBodyFacts {
 #[derive(Debug, Clone)]
 struct RawRegistration {
     container_type: String,
+    /// For `base->field->member = f`: what the file proves about the base,
+    /// and the path of fields read from it. Set only when `container_type`
+    /// could not be read from the file directly.
+    container_base_type: Option<String>,
+    container_field: Option<String>,
     member: String,
     target: String,
     byte_start: usize,
@@ -104,6 +109,8 @@ impl RawRegistration {
     fn attribute(&self, enclosing: &str, file_path: &str, git_hash: &str) -> Registration {
         Registration {
             container_type: self.container_type.clone(),
+            container_base_type: self.container_base_type.clone(),
+            container_field: self.container_field.clone(),
             member: self.member.clone(),
             target: self.target.clone(),
             file_path: file_path.to_string(),
@@ -1205,6 +1212,8 @@ impl TreeSitterAnalyzer {
 
                 found.push(RawRegistration {
                     container_type: container_type.clone(),
+                    container_base_type: None,
+                    container_field: None,
                     member,
                     target,
                     byte_start: pair.start_byte(),
@@ -1270,15 +1279,34 @@ impl TreeSitterAnalyzer {
             let Some(receiver) = left.child_by_field_name("argument") else {
                 continue;
             };
-            if receiver.kind() != "identifier" {
-                continue;
-            }
-            let Some(container_type) = locals.get(&source[receiver.byte_range()]).cloned() else {
-                continue;
-            };
+            let receiver_text = collapse_whitespace(&source[receiver.byte_range()]);
+
+            // `x->member = f` names its container as soon as `x` is declared
+            // here. `s->s_shrink->scan_objects = f` does not: `s_shrink` is
+            // declared with struct super_block, in a header this file
+            // includes rather than contains. Record what is known — the type
+            // of the base and the path read from it — and let resolution
+            // finish it against the types table.
+            let (container_type, container_base_type, container_field) =
+                if receiver.kind() == "identifier" {
+                    match locals.get(&receiver_text) {
+                        Some(container) => (container.clone(), None, None),
+                        None => continue,
+                    }
+                } else {
+                    match field_path(&receiver_text) {
+                        Some((base, path)) => match locals.get(base) {
+                            Some(base_type) => (String::new(), Some(base_type.clone()), Some(path)),
+                            None => continue,
+                        },
+                        None => continue,
+                    }
+                };
 
             found.push(RawRegistration {
                 container_type,
+                container_base_type,
+                container_field,
                 member,
                 target,
                 byte_start: node.start_byte(),
@@ -3926,6 +3954,53 @@ mod tests {
     }
 
     #[test]
+    fn an_assignment_through_a_field_records_the_path() {
+        // fs/super.c installs every superblock's shrinker this way. `s` is
+        // declared here; what `s_shrink` points at is declared with struct
+        // super_block, so the container is resolved later.
+        let source = "struct super_block { struct shrinker *s_shrink; };\n\
+                      int setup(struct super_block *s) {\n\
+                      \ts->s_shrink->scan_objects = super_cache_scan;\n\
+                      \treturn 0;\n\
+                      }\n";
+        let registrations = registration_rows(source, "super.c");
+
+        assert_eq!(registrations.len(), 1, "{registrations:?}");
+        let entry = &registrations[0];
+        assert_eq!(entry.container_type, "");
+        assert_eq!(entry.container_base_type.as_deref(), Some("super_block"));
+        assert_eq!(entry.container_field.as_deref(), Some("s_shrink"));
+        assert_eq!(entry.member, "scan_objects");
+        assert_eq!(entry.target, "super_cache_scan");
+    }
+
+    #[test]
+    fn an_assignment_on_a_declared_name_still_names_its_container() {
+        // mm/workingset.c installs through a file-scope pointer, which the
+        // file types on its own; nothing is deferred.
+        let source = "static struct shrinker *workingset_shadow_shrinker;\n\
+                      int init(void) {\n\
+                      \tworkingset_shadow_shrinker->scan_objects = scan_shadow_nodes;\n\
+                      \treturn 0;\n\
+                      }\n";
+        let registrations = registration_rows(source, "workingset.c");
+
+        assert_eq!(registrations.len(), 1, "{registrations:?}");
+        assert_eq!(registrations[0].container_type, "shrinker");
+        assert_eq!(registrations[0].container_base_type, None);
+    }
+
+    #[test]
+    fn an_assignment_through_an_undeclared_base_records_nothing() {
+        let registrations = registration_rows(
+            "int setup(void) { p->q->handler = my_handler; return 0; }\n",
+            "test.c",
+        );
+
+        assert!(registrations.is_empty(), "{registrations:?}");
+    }
+
+    #[test]
     fn a_macro_that_declares_an_ops_table_registers_it() {
         // ACPI and the error-injection macros build tables this way: the
         // macro declares the thing it initialises, so its type is stated.
@@ -4110,6 +4185,15 @@ mod tests {
             "cast operand read as a call: {:?}",
             macro_calls(source, "CASTED")
         );
+    }
+
+    /// Whole rows, for tests that care about what was deferred.
+    fn registration_rows(source: &str, path: &str) -> Vec<crate::types::Registration> {
+        let mut analyzer = TreeSitterAnalyzer::new().unwrap();
+        analyzer
+            .analyze_source_with_metadata(source, Path::new(path), "testhash", None)
+            .unwrap()
+            .registrations
     }
 
     fn registrations_of(source: &str, path: &str) -> Vec<(String, String, String, String)> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -210,7 +210,10 @@ impl DispatchKind {
 /// a constant simply never joins.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Registration {
-    /// Struct or typedef whose member is being initialised.
+    /// Struct or typedef whose member is being initialised. Empty when the
+    /// file did not state it and `container_base_type` did: an assignment
+    /// through a field, `s->s_shrink->scan_objects = f`, knows what `s` is
+    /// but not what `s_shrink` is declared as. Resolution fills it in.
     pub container_type: String,
     pub member: String,
     /// Identifier the member is initialised with.
@@ -222,6 +225,11 @@ pub struct Registration {
     /// Function containing the initializer, empty at file scope.
     pub enclosing_function: String,
     pub kind: RegistrationKind,
+    /// For `base->field->member = f`, the type of the base and the path of
+    /// fields read from it. Set together, and only when the container type
+    /// could not be read from the file directly.
+    pub container_base_type: Option<String>,
+    pub container_field: Option<String>,
 }
 
 /// How a function came to be installed. Stored, so values are append-only.

--- a/tests/indirect_calls.rs
+++ b/tests/indirect_calls.rs
@@ -74,6 +74,11 @@ fn write_fixture(repo: &Path) {
          \t\t\t     struct shrink_control *sc)\n\
          {\n\
          \treturn shrinker->scan_objects(shrinker, sc);\n\
+         }\n\
+         unsigned long shrink_slab_all(struct shrinker *shrinker,\n\
+         \t\t\t      struct shrink_control *sc)\n\
+         {\n\
+         \treturn do_shrink_slab(shrinker, sc);\n\
          }\n",
     )
     .unwrap();
@@ -403,5 +408,65 @@ async fn a_path_of_three_fields_resolves_on_both_sides() {
     assert!(
         typed.contains(&"call_deep"),
         "a dispatch three fields deep was not matched: {indirect:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_callback_reached_only_through_a_pointer_has_a_chain_above_it() {
+    // A shrinker callback is called by nobody and reached by everybody. Built
+    // from calls alone the reverse chain renders it as a root, so `callers`
+    // named the dispatch while `callchain` reported none, from one index. The
+    // chain continues above the dispatching function.
+    let dir = tempfile::tempdir().unwrap();
+    let (db, git_sha) = index_fixture(dir.path()).await;
+
+    let mut rendered = Vec::new();
+    let shown = semcode::callchain::write_indirect_reverse_chain(
+        &db,
+        "super_cache_scan",
+        &git_sha,
+        2,
+        10,
+        &mut rendered,
+    )
+    .await
+    .unwrap();
+    let text = String::from_utf8(rendered).unwrap();
+
+    assert!(shown >= 1, "no dispatching site shown: {text}");
+    assert!(
+        text.contains("do_shrink_slab"),
+        "the dispatch is missing: {text}"
+    );
+    assert!(
+        text.contains("shrink_slab_all"),
+        "the chain above the dispatch is missing: {text}"
+    );
+}
+
+#[tokio::test]
+async fn a_function_with_ordinary_callers_gets_no_pointer_chain() {
+    // The section is for what calls cannot show. A function called by name
+    // has nothing to add here, and an empty heading is a wrong answer.
+    let dir = tempfile::tempdir().unwrap();
+    let (db, git_sha) = index_fixture(dir.path()).await;
+
+    let mut rendered = Vec::new();
+    let shown = semcode::callchain::write_indirect_reverse_chain(
+        &db,
+        "do_shrink_slab",
+        &git_sha,
+        2,
+        10,
+        &mut rendered,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(shown, 0);
+    assert!(
+        rendered.is_empty(),
+        "{}",
+        String::from_utf8_lossy(&rendered)
     );
 }

--- a/tests/indirect_calls.rs
+++ b/tests/indirect_calls.rs
@@ -40,6 +40,44 @@ fn write_fixture(repo: &Path) {
     )
     .unwrap();
 
+    // A callback installed through a field of a declared object, which is
+    // how every per-superblock, per-mount and per-pool shrinker is
+    // registered. The container type is not in this file: `s_shrink` is
+    // declared with struct super_block, in the header.
+    std::fs::write(
+        repo.join("shrinker.h"),
+        "struct shrink_control;\n\
+         struct shrinker {\n\
+         \tunsigned long (*scan_objects)(struct shrinker *, struct shrink_control *);\n\
+         };\n\
+         struct super_block { struct shrinker *s_shrink; };\n",
+    )
+    .unwrap();
+
+    std::fs::write(
+        repo.join("super.c"),
+        "#include \"shrinker.h\"\n\
+         unsigned long super_cache_scan(struct shrinker *shrink,\n\
+         \t\t\t       struct shrink_control *sc);\n\
+         int alloc_super(struct super_block *s)\n\
+         {\n\
+         \ts->s_shrink->scan_objects = super_cache_scan;\n\
+         \treturn 0;\n\
+         }\n",
+    )
+    .unwrap();
+
+    std::fs::write(
+        repo.join("shrinker.c"),
+        "#include \"shrinker.h\"\n\
+         unsigned long do_shrink_slab(struct shrinker *shrinker,\n\
+         \t\t\t     struct shrink_control *sc)\n\
+         {\n\
+         \treturn shrinker->scan_objects(shrinker, sc);\n\
+         }\n",
+    )
+    .unwrap();
+
     std::fs::write(
         repo.join("tcp.c"),
         "#include \"proto.h\"\n\
@@ -257,5 +295,46 @@ async fn the_member_call_is_not_recorded_as_a_call_to_a_function() {
     assert!(
         !callees.contains(&"handler".to_string()),
         "member name recorded as a callee: {callees:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_callback_installed_through_a_field_has_callers() {
+    // `s->s_shrink->scan_objects = super_cache_scan` names no container: what
+    // `s_shrink` points at is declared with struct super_block, elsewhere. The
+    // registration is recorded with the path and resolved at query time, or
+    // the function appears to have no callers at all.
+    let dir = tempfile::tempdir().unwrap();
+    let (db, git_sha) = index_fixture(dir.path()).await;
+
+    let registrations = db
+        .find_registrations_of_git_aware("super_cache_scan", &git_sha)
+        .await
+        .unwrap();
+    assert_eq!(registrations.len(), 1, "{registrations:?}");
+    assert_eq!(registrations[0].container_type, "shrinker");
+    assert_eq!(registrations[0].member, "scan_objects");
+
+    let indirect = db
+        .find_indirect_callers("super_cache_scan", &git_sha)
+        .await
+        .unwrap();
+    let typed: Vec<&str> = indirect
+        .iter()
+        .filter(|c| c.evidence.is_type_matched())
+        .map(|c| c.caller_name.as_str())
+        .collect();
+    assert!(
+        typed.contains(&"do_shrink_slab"),
+        "the dispatch that reaches it is missing: {indirect:?}"
+    );
+
+    let installed = db
+        .find_registrations_for_slot_git_aware("shrinker", "scan_objects", &git_sha)
+        .await
+        .unwrap();
+    assert!(
+        installed.iter().any(|r| r.target == "super_cache_scan"),
+        "implementors misses a registration made through a field: {installed:?}"
     );
 }

--- a/tests/indirect_calls.rs
+++ b/tests/indirect_calls.rs
@@ -78,6 +78,40 @@ fn write_fixture(repo: &Path) {
     )
     .unwrap();
 
+    // Four links: the container of the member is three field lookups from
+    // the only name the calling file declares. Both the registration and the
+    // dispatch have to walk the same path.
+    std::fs::write(
+        repo.join("deep.h"),
+        "struct leaf_ops { int (*run)(void); };\n\
+         struct level3 { struct leaf_ops *ops; };\n\
+         struct level2 { struct level3 *l3; };\n\
+         struct level1 { struct level2 *l2; };\n",
+    )
+    .unwrap();
+
+    std::fs::write(
+        repo.join("deep_install.c"),
+        "#include \"deep.h\"\n\
+         int deep_impl(void);\n\
+         int install_deep(struct level1 *top)\n\
+         {\n\
+         \ttop->l2->l3->ops->run = deep_impl;\n\
+         \treturn 0;\n\
+         }\n",
+    )
+    .unwrap();
+
+    std::fs::write(
+        repo.join("deep_call.c"),
+        "#include \"deep.h\"\n\
+         int call_deep(struct level1 *top)\n\
+         {\n\
+         \treturn top->l2->l3->ops->run();\n\
+         }\n",
+    )
+    .unwrap();
+
     std::fs::write(
         repo.join("tcp.c"),
         "#include \"proto.h\"\n\
@@ -336,5 +370,38 @@ async fn a_callback_installed_through_a_field_has_callers() {
     assert!(
         installed.iter().any(|r| r.target == "super_cache_scan"),
         "implementors misses a registration made through a field: {installed:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_path_of_three_fields_resolves_on_both_sides() {
+    // `top->l2->l3->ops->run` is three lookups from the only declared name,
+    // on the registration and on the dispatch. One hop was covered; the walk
+    // itself was not.
+    let dir = tempfile::tempdir().unwrap();
+    let (db, git_sha) = index_fixture(dir.path()).await;
+
+    let registrations = db
+        .find_registrations_of_git_aware("deep_impl", &git_sha)
+        .await
+        .unwrap();
+    assert_eq!(registrations.len(), 1, "{registrations:?}");
+    assert_eq!(
+        registrations[0].container_type, "leaf_ops",
+        "the walk stopped short: {registrations:?}"
+    );
+
+    let indirect = db
+        .find_indirect_callers("deep_impl", &git_sha)
+        .await
+        .unwrap();
+    let typed: Vec<&str> = indirect
+        .iter()
+        .filter(|c| c.evidence.is_type_matched())
+        .map(|c| c.caller_name.as_str())
+        .collect();
+    assert!(
+        typed.contains(&"call_deep"),
+        "a dispatch three fields deep was not matched: {indirect:?}"
     );
 }

--- a/tests/schema_version.rs
+++ b/tests/schema_version.rs
@@ -106,3 +106,36 @@ async fn a_file_read_by_this_extractor_may_be_skipped() {
         "a file this build read makes the index look stale"
     );
 }
+
+#[tokio::test]
+async fn a_file_read_by_an_older_extractor_is_forgotten() {
+    // After the whole tree has been read, a row still carrying an older
+    // version is content the tree does not have. Left in place, one such row
+    // makes the index answer "older than this build" for ever, and
+    // re-indexing never clears the refusal it is meant to clear.
+    let dir = tempfile::tempdir().unwrap();
+    let db = manager(dir.path()).await;
+
+    db.mark_file_processed(
+        "fs/super.c".to_string(),
+        Some("deadbeef".to_string()),
+        "cafe1234".to_string(),
+    )
+    .await
+    .unwrap();
+
+    // Nothing is older than this build, so nothing is forgotten.
+    assert_eq!(db.forget_older_processed_files().await.unwrap(), 0);
+    assert!(db
+        .processed_by_this_extractor()
+        .await
+        .unwrap()
+        .contains("cafe1234"));
+
+    // A row from an older extractor goes, and the index stops calling itself
+    // stale on the strength of it.
+    db.forget_processed_before(SCHEMA_VERSION + 1)
+        .await
+        .unwrap();
+    assert!(db.processed_by_this_extractor().await.unwrap().is_empty());
+}


### PR DESCRIPTION
# Registrations that name no container

Twelve patches. `callers super_cache_scan` answered "no functions call
super_cache_scan": fs/super.c installs a shrinker for every superblock, and
nothing recorded it.

    === Indirect Callers ===
    3 call sites can reach it through a function pointer:
      1. STORE at drivers/md/bcache/sysfs.c:863 [member_arrow]
         installed in shrinker::scan_objects at fs/super.c:406 (receiver type matches)
      2. do_shrink_slab at mm/shrinker.c:443 [member_arrow]
         installed in shrinker::scan_objects at fs/super.c:406 (receiver type matches)
      3. shrinker_debugfs_scan_write at mm/shrinker_debug.c:146 [member_arrow]
         installed in shrinker::scan_objects at fs/super.c:406 (receiver type matches)

## Shapes that recorded nothing

A registration was recorded only where the file stated the container
outright. Four shapes fell outside that and were dropped whole:

* **through a field** — `s->s_shrink->scan_objects = f` knows what `s` is, not
  what `s_shrink` points at. The split was not random: a shrinker owned by a
  module is a file-scope pointer and was recorded, one owned by a superblock,
  an XFS mount or a pool hangs off a field and was not;
* **nested in another initializer** — `.ops = { .activate = f }`;
* **in an array slot** — `[0] = { .run = f }`. A subscript was read as a dead
  end for naming no field, when it names none because every slot holds the
  array's element type, which the declaration already states;
* **guarded by the preprocessor** — a directive inside an initializer list has
  no node in the grammar. It parses as an error, and the pair after it
  recovers as an *assignment* through the previous pair's value, so the arm
  before `#else` was lost while the arm after it was recorded.

Each records what the file proves — the outer type and the path of fields to
the container — and resolves the rest against the types table at query time,
which is what a chained receiver on the dispatch side already did. Both arms
of a conditional are recorded: which one a build takes is not knowable from
the source, and a function installed by either is one something can dispatch
to.

## Measured

Designated initialisers naming an indexed function, over fs/ mm/ net/ kernel/
drivers/base/, against the same source-side list:

    24,132 pairs naming an indexed function
     1,563 recorded nowhere before   (6.5%)
       574 recorded nowhere after    (2.4%)

Most of what remains is `.init = init_module` and `.exit = cleanup_module`,
which the module macros generate.

Whole-tree registrations: assignment 291,795 -> 369,254, designated_init
405,099 -> 588,084.

    implementors shrinker.scan_objects    19 -> 39
    implementors nft_set_ops.activate      0 -> 7

## The reverse side of a call chain

`callers super_cache_scan` named three sites that reach it, and `callchain
super_cache_scan`, from the same index, reported `Total direct callers: 0` and
rendered it as a root. A callback is called by nobody and reached by
everybody, so a reverse chain built from calls alone is silent about exactly
the functions whose callers are worth asking for.

    === Reverse Chain (Through a Function Pointer) ===
    STORE (drivers/md/bcache/sysfs.c:863) dispatches scan_objects
    do_shrink_slab (mm/shrinker.c:443) dispatches scan_objects
      └─ shrink_slab_memcg (mm/shrinker.c:467)
      └─ shrink_slab (mm/shrinker.c:624)
    shrinker_debugfs_scan_write (mm/shrinker_debug.c:146) dispatches scan_objects

    Dispatching sites that reach it: 3

Each dispatching site is an entry into the chain, and the callers above it are
found the ordinary way. A chain can only be walked by name, so the name must
belong to the code the site is in: one definition, in the file the site is in,
or the site is named without a chain. bcache writes its sysfs stores with a
STORE() macro and lib/raid has another, and walking that name answered with
the altivec xor routines underneath a shrinker callback.

Three surfaces render a chain — the query command, the REPL and MCP — and all
three were separately silent here. They now call one implementation.

## Index bugs fixed

Three patches are not about registrations. Two columns added to a table
exposed the same defect twice, and both fail only on the *second* run:

* **a table is not migrated by creating tables** — creating tables only
  creates missing ones, so a column added to a definition never reaches a
  database that already has the table, and every insert fails with a schema
  mismatch. Each table now names the columns it expects and is started again
  when one is absent. `dispatch_sites` carried the same latent failure;
* **an index could get stuck calling itself stale** — staleness is asked of
  the files, and after a full re-read 4,205 rows of 68,481 still carried an
  older version, being content the tree no longer has. One such row makes the
  whole index answer "older than this build", so re-indexing produced the same
  refusal every time. Those rows are forgotten once the tree has been read;
* **one argument named two databases** — the path was resolved by asking
  whether the directory exists, so `semcode-index -d dir` wrote the database
  at `dir`, and every later command, now seeing a directory, opened an empty
  `dir/.semcode.db`. It looks exactly like an index that extracted nothing.

## Tests

The original defect end to end; a path of three fields on both sides; a
nested initializer; an array slot; a member behind `#ifdef`; a callback having
a chain above its dispatch, and a function with ordinary callers getting no
such section; a file read by an older extractor being forgotten; one argument
naming one database whichever command runs first. The regression harness re-indexes an existing database and
fails if a query is refused afterwards.