### PR TITLE
Scratch/riel/chained registrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,8 +109,15 @@ Semcode uses the following search order to locate the `.semcode.db` database dir
 3. **Workspace/Current directory**: Use `./.semcode.db` in the workspace or current working directory
 
 The `-d` flag can specify either:
-- A direct path to the database directory (e.g., `./my-custom.db`)
-- A parent directory containing `.semcode.db` (e.g., `-d /path/to/project` will use `/path/to/project/.semcode.db`)
+- A direct path to the database directory: a name ending in `.db` (e.g.
+  `./my-custom.db`), or an existing directory that is already a database
+- A parent directory to hold one (e.g., `-d /path/to/project` uses
+  `/path/to/project/.semcode.db`), whether or not it exists yet
+
+The same argument names the same database whichever command runs first.
+Resolving on whether a directory happens to exist splits it in two: the
+indexer writes to a path nothing occupies, and every later query looks inside
+the directory that has just been created.
 
 ### Running the Tools
 

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -975,9 +975,12 @@ impl DatabaseManager {
 
         // Asking the store for the slot would miss every registration made
         // through a field, because those rows do not know their container
-        // until it is resolved. Ask by member, resolve, then filter.
+        // until it is resolved. Ask for this container's rows and the ones
+        // that have yet to name theirs, resolve, then filter.
         let mut registrations = crate::database::resolution::at_revision(
-            self.registration_store.find_by_member(member).await?,
+            self.registration_store
+                .find_by_member_for_container(container_type, member)
+                .await?,
             &manifest,
             |r| (r.file_path.as_str(), r.git_file_hash.as_str()),
         );

--- a/src/database/registrations.rs
+++ b/src/database/registrations.rs
@@ -124,6 +124,26 @@ impl RegistrationStore {
 
     /// Everything installed in a member of this name, whatever the type.
     /// Weaker than find_by_slot, and the caller has to say it means that.
+    /// Rows for a member that could still turn out to be this container's.
+    ///
+    /// A row made through a field does not know its container until it is
+    /// resolved, so it has to be read; every other container's rows do not.
+    /// Asking by member alone reads them all — `read` and `owner` match
+    /// thousands across a kernel — and resolves each one before discarding it.
+    pub async fn find_by_member_for_container(
+        &self,
+        container_type: &str,
+        member: &str,
+    ) -> Result<Vec<Registration>> {
+        let quote = |v: &str| v.replace('\'', "''");
+        self.query(&format!(
+            "member = '{}' AND (container_type = '{}' OR container_type = '')",
+            quote(member),
+            quote(container_type)
+        ))
+        .await
+    }
+
     pub async fn find_by_member(&self, member: &str) -> Result<Vec<Registration>> {
         self.query(&format!("member = '{}'", member.replace('\'', "''")))
             .await

--- a/src/database_utils.rs
+++ b/src/database_utils.rs
@@ -60,7 +60,7 @@ pub fn process_database_path(database_arg: Option<&str>, source_dir: Option<&Pat
 fn resolve_path(path: &str) -> String {
     let path_obj = Path::new(path);
 
-    if path.ends_with(".semcode.db") || is_database(path_obj) {
+    if path.ends_with(".db") || is_database(path_obj) {
         path.to_string()
     } else {
         path_obj.join(".semcode.db").to_string_lossy().to_string()
@@ -69,11 +69,14 @@ fn resolve_path(path: &str) -> String {
 
 /// Whether a path is itself a database rather than a directory holding one.
 ///
-/// Asked of what is on disk, so that one argument names one database whatever
-/// order the commands run in. Deciding on whether the directory merely exists
-/// splits it in two: `-d dir` writes the database at `dir` when nothing is
-/// there yet, and every later command reads `dir/.semcode.db`, which is
-/// empty, so a freshly written index answers every query with "not found".
+/// Asked of the name, and of what is on disk — never of whether the directory
+/// merely exists, which splits one argument into two databases: `-d dir`
+/// writes the database at `dir` when nothing is there yet, and every later
+/// command reads `dir/.semcode.db`, which is empty, so a freshly written
+/// index answers every query with "not found".
+///
+/// A name ending in `.db` is a database, as documented, so `-d ./my.db` puts
+/// it where it says and not a level below.
 fn is_database(path: &Path) -> bool {
     path.join("functions.lance").exists()
 }
@@ -200,6 +203,18 @@ mod tests {
 #[cfg(test)]
 mod one_argument_one_database {
     use super::*;
+
+    #[test]
+    fn a_name_ending_in_db_is_the_database_before_it_exists() {
+        // Documented as a direct path, so it must not gain a level the first
+        // time it is written.
+        let dir = tempfile::tempdir().unwrap();
+        let named = dir.path().join("my-custom.db");
+        assert_eq!(
+            resolve_path(named.to_str().unwrap()),
+            named.to_string_lossy()
+        );
+    }
 
     #[test]
     fn a_directory_that_does_not_exist_yet_holds_the_database() {

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -4670,6 +4670,33 @@ mod tests {
     }
 
     #[test]
+    fn a_positional_group_records_the_outer_type() {
+        // A known limitation, pinned rather than fixed.
+        //
+        // `{ { .run = impl } }` initialises outer's first member, whose type
+        // is inner, so filing run under outer is wrong here. It is right when
+        // the member is an anonymous struct or union, which C flattens into
+        // the outer type, and the two are indistinguishable from one file: the
+        // member list lives with the type, elsewhere.
+        //
+        // Refusing every positional group costs far more than it saves. Over a
+        // Linux tree it dropped ~95,000 registrations to remove 4,004 whose
+        // container does not declare the member, because the great majority
+        // are the anonymous case and correct. Deciding it needs the type,
+        // which is why the fix belongs where types are known.
+        let found = registration_rows(
+            "struct inner { int (*run)(void); };\n\
+             struct outer { struct inner in; };\n\
+             int impl(void);\n\
+             static struct outer o = { { .run = impl } };\n",
+            "test.c",
+        );
+
+        let run = found.iter().find(|r| r.member == "run").unwrap();
+        assert_eq!(run.container_type, "outer");
+    }
+
+    #[test]
     fn an_array_slot_keeps_the_element_type() {
         // Every slot of an array holds the array's element type, so passing
         // through `[0]` changes nothing about which struct owns the member.


### PR DESCRIPTION
Fix a few issues that came in with the function pointer work:
- better filtering when querying for functions referenced in unknown-name structures
- fix database path when it ends in .db (a fix to make directory names consistently treated broke this)
- pin to positional outer initializer; not strictly correct, but in practice it seems to be the best we can do, at least in the Linux kernel