### PR TITLE
Scratch/riel/anonymous members

### DIFF
--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -25,7 +25,8 @@ use crate::database::vectors::VectorStore;
 use crate::types::{FunctionInfo, TypeInfo, TypedefInfo};
 use crate::vectorizer::CodeVectorizer;
 use crate::workdir::WorkdirIndex;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 // Optimal batch size for LanceDB operations
 pub const OPTIMAL_BATCH_SIZE: usize = 65536;
@@ -53,6 +54,8 @@ pub struct DatabaseManager {
     /// The last manifest generated, kept because a single query asks for the
     /// same revision several times. Building one walks the whole tree.
     manifest_cache: std::sync::RwLock<Option<(String, GitManifest)>>,
+    /// Identifiers that are compiler attributes, read once per process.
+    attribute_names: std::sync::OnceLock<Arc<HashSet<String>>>,
 }
 
 impl DatabaseManager {
@@ -86,6 +89,7 @@ impl DatabaseManager {
             branch_store: IndexedBranchStore::new(connection.clone()),
             workdir_index: std::sync::RwLock::new(None),
             manifest_cache: std::sync::RwLock::new(None),
+            attribute_names: std::sync::OnceLock::new(),
         })
     }
 
@@ -1842,6 +1846,70 @@ impl DatabaseManager {
     /// # Behavior
     /// Returns the first matching type found without considering git history.
     /// The returned type may not match the version in your working directory.
+    /// Names that are compiler attributes rather than members.
+    ///
+    /// `struct { ... } __packed;` and `struct { ... } lru_gen;` parse the
+    /// same, so the extractor records both as named members. The first names
+    /// nothing: C flattens an anonymous member into the type that holds it,
+    /// and `mm->mm_mt` is the field, not `mm->__randomize_layout.mm_mt`.
+    ///
+    /// Deciding needs what the identifier expands to, which is written in
+    /// another file, so it is asked here where the whole index is readable.
+    /// An alias is followed: `____cacheline_aligned_in_smp` expands to
+    /// `____cacheline_aligned`, which expands to an attribute.
+    async fn attribute_names(&self) -> Result<Arc<HashSet<String>>> {
+        if let Some(known) = self.attribute_names.get() {
+            return Ok(known.clone());
+        }
+
+        let macros = self.function_store.object_like_macros().await?;
+        let bodies: HashMap<&str, &str> = macros
+            .iter()
+            .map(|(name, body)| (name.as_str(), body.as_str()))
+            .collect();
+
+        let mut attributes = HashSet::new();
+        for (name, body) in &bodies {
+            let mut current = *body;
+            // Alias chains are short; the bound stops a cycle.
+            for _ in 0..8 {
+                if current.contains("__attribute__") {
+                    attributes.insert((*name).to_string());
+                    break;
+                }
+                match bodies.get(current.trim()) {
+                    Some(next) => current = next,
+                    None => break,
+                }
+            }
+        }
+
+        let attributes = Arc::new(attributes);
+        let _ = self.attribute_names.set(attributes.clone());
+        Ok(attributes)
+    }
+
+    /// Drop from a field path what is an attribute rather than a member.
+    fn flatten_anonymous_members(types: &mut Vec<TypeInfo>, attributes: &HashSet<String>) {
+        for ty in types {
+            ty.members.retain_mut(|field| {
+                let kept: Vec<&str> = field
+                    .name
+                    .split('.')
+                    .filter(|part| !attributes.contains(*part))
+                    .collect();
+
+                // Nothing left means the member was the anonymous aggregate
+                // itself, which C gives no name and nothing can refer to.
+                if kept.is_empty() {
+                    return false;
+                }
+                field.name = kept.join(".");
+                true
+            });
+        }
+    }
+
     pub async fn find_type(&self, name: &str) -> Result<Option<TypeInfo>> {
         self.type_store.find_by_name(name).await
     }
@@ -1924,6 +1992,8 @@ impl DatabaseManager {
                 .cmp(&b.file_path)
                 .then(a.line_start.cmp(&b.line_start))
         });
+        let attributes = self.attribute_names().await?;
+        Self::flatten_anonymous_members(&mut merged, &attributes);
         Ok(merged)
     }
 
@@ -7058,5 +7128,68 @@ mod tests {
             .unwrap();
         assert_eq!(function_counts["target"], 2);
         assert_eq!(type_counts["duplicate"], 3);
+    }
+}
+
+#[cfg(test)]
+mod anonymous_members {
+    use super::DatabaseManager;
+    use crate::types::{FieldInfo, TypeInfo};
+    use std::collections::HashSet;
+
+    fn field(name: &str) -> FieldInfo {
+        FieldInfo {
+            name: name.to_string(),
+            type_name: "int".to_string(),
+            offset: None,
+        }
+    }
+
+    fn ty(members: Vec<FieldInfo>) -> TypeInfo {
+        TypeInfo {
+            name: "mm_struct".to_string(),
+            file_path: "include/linux/mm_types.h".to_string(),
+            git_file_hash: "hash".to_string(),
+            line_start: 1,
+            kind: "struct".to_string(),
+            size: None,
+            members,
+            definition: String::new(),
+            types: None,
+        }
+    }
+
+    #[test]
+    fn an_attribute_leaves_the_path_of_a_flattened_member() {
+        // mm->mm_mt is the field. __randomize_layout is what the struct is
+        // marked with, and names nothing.
+        let attributes: HashSet<String> = ["__randomize_layout", "____cacheline_aligned_in_smp"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let mut types = vec![ty(vec![
+            field("__randomize_layout"),
+            field("__randomize_layout.mm_mt"),
+            field("__randomize_layout.____cacheline_aligned_in_smp.mm_count"),
+            field("__randomize_layout.lru_gen"),
+            field("cpu_bitmap"),
+        ])];
+
+        DatabaseManager::flatten_anonymous_members(&mut types, &attributes);
+
+        let names: Vec<&str> = types[0].members.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["mm_mt", "mm_count", "lru_gen", "cpu_bitmap"]);
+    }
+
+    #[test]
+    fn a_named_member_keeps_its_path() {
+        // `union { ... } u;` is a member, and u.flags says where flags lives.
+        let attributes: HashSet<String> = HashSet::new();
+        let mut types = vec![ty(vec![field("u"), field("u.flags")])];
+
+        DatabaseManager::flatten_anonymous_members(&mut types, &attributes);
+
+        let names: Vec<&str> = types[0].members.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["u", "u.flags"]);
     }
 }

--- a/src/database/functions.rs
+++ b/src/database/functions.rs
@@ -329,6 +329,68 @@ impl FunctionStore {
         Ok(())
     }
 
+    /// Object-like macros and what they expand to.
+    ///
+    /// Stored so a declaration can be read: an identifier where a member name
+    /// would be may be an attribute, and only the expansion says which.
+    pub async fn object_like_macros(&self) -> Result<Vec<(String, String)>> {
+        let table = self.connection.open_table("functions").execute().await?;
+        let batches: Vec<RecordBatch> = table
+            .query()
+            .only_if("return_type = ''")
+            .select(lancedb::query::Select::columns(&["name", "body_hash"]))
+            .execute()
+            .await?
+            .try_collect()
+            .await?;
+
+        let mut named_hashes: Vec<(String, String)> = Vec::new();
+        for batch in &batches {
+            let column = |i: usize| {
+                batch
+                    .column(i)
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("string column")
+            };
+            let (names, hashes) = (column(0), column(1));
+            for row in 0..batch.num_rows() {
+                if !hashes.is_null(row) {
+                    named_hashes
+                        .push((names.value(row).to_string(), hashes.value(row).to_string()));
+                }
+            }
+        }
+
+        let hashes: Vec<String> = named_hashes.iter().map(|(_, h)| h.clone()).collect();
+        let bodies = self.bulk_get_content(&hashes).await?;
+
+        let mut macros = Vec::new();
+        for (name, hash) in named_hashes {
+            let Some(definition) = bodies.get(&hash) else {
+                continue;
+            };
+            // `#define` and `# define` are both written, the second inside
+            // conditionals, which is exactly where an attribute macro lives.
+            let directive = definition
+                .trim_start()
+                .strip_prefix('#')
+                .map(str::trim_start);
+            if !directive.is_some_and(|d| d.starts_with("define")) {
+                continue;
+            }
+            // `#define NAME value` -> value, which is what an alias points at
+            // and what carries the attribute.
+            let expansion = definition
+                .split_once(&name)
+                .map(|(_, rest)| rest.trim())
+                .unwrap_or("");
+            macros.push((name, expansion.to_string()));
+        }
+
+        Ok(macros)
+    }
+
     pub async fn find_all_by_name(&self, name: &str) -> Result<Vec<FunctionInfo>> {
         let table = self.connection.open_table("functions").execute().await?;
         let escaped_name = name.replace("'", "''");

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -2447,16 +2447,42 @@ impl TreeSitterAnalyzer {
                     },
                 });
 
-                // Only add function-like macros (consistent with libclang mode)
-                // Note: from_macro() is only called when is_function_like is true,
-                // so all macros here are function-like by definition
-                if is_function_like {
+                // Function-like macros, and the object-like ones needed to
+                // read a declaration. `} __packed;` and `} lru_gen;` parse
+                // identically — a field_declaration with a field_identifier —
+                // so the only way to tell an attribute from a member name is
+                // to know what the identifier expands to, and that is written
+                // in another file.
+                let body_text = body.map(|b| &source[b.byte_range()]).unwrap_or("");
+                if is_function_like || Self::expands_to_an_attribute(body_text) {
                     macros.push(macro_info);
                 }
             }
         }
 
         Ok((macros, dispatch_sites, registrations))
+    }
+
+    /// Whether an object-like macro body is, or leads to, a compiler attribute.
+    ///
+    /// Kept wide on purpose. `__packed` states it outright, while
+    /// `____cacheline_aligned_in_smp` expands to `____cacheline_aligned`,
+    /// which states it, so an alias has to be kept to be followed later. The
+    /// alias is one identifier; a body of anything else is not on the way to
+    /// an attribute and is left out, which is what keeps this from meaning
+    /// "every #define in the tree" — there are six million of those.
+    fn expands_to_an_attribute(body: &str) -> bool {
+        let body = body.trim();
+
+        let is_identifier = || {
+            let mut chars = body.chars();
+            chars
+                .next()
+                .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+                && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+        };
+
+        body.contains("__attribute__") || is_identifier()
     }
 
     fn parse_parameters_from_node(
@@ -5113,5 +5139,36 @@ mod tests {
             .collect();
 
         assert_eq!(actual, expected);
+    }
+}
+
+#[cfg(test)]
+mod attribute_macros {
+    use super::TreeSitterAnalyzer;
+
+    #[test]
+    fn a_macro_stating_an_attribute_is_kept() {
+        assert!(TreeSitterAnalyzer::expands_to_an_attribute(
+            "__attribute__((packed))"
+        ));
+    }
+
+    #[test]
+    fn an_alias_is_kept_so_it_can_be_followed() {
+        // ____cacheline_aligned_in_smp expands to ____cacheline_aligned, which
+        // is where the attribute is stated. Dropping the alias loses the
+        // chain.
+        assert!(TreeSitterAnalyzer::expands_to_an_attribute(
+            "____cacheline_aligned"
+        ));
+    }
+
+    #[test]
+    fn a_value_is_not_an_attribute() {
+        // Six million #defines in a kernel; keeping the ones that cannot lead
+        // to an attribute is what makes this affordable.
+        assert!(!TreeSitterAnalyzer::expands_to_an_attribute("(1 << 4)"));
+        assert!(!TreeSitterAnalyzer::expands_to_an_attribute("0x40"));
+        assert!(!TreeSitterAnalyzer::expands_to_an_attribute(""));
     }
 }


### PR DESCRIPTION
Fix up issues that resulted in structures losing members due to the way they are declared:

fcc77dc db: read a field of an anonymous member by the name code writes
076175b analyzer: keep the object-like macros a declaration needs

    analyzer: keep the object-like macros a declaration needs

        struct mm_struct {
                struct {
                        ...
                } __randomize_layout;

    `} __randomize_layout;` and `} lru_gen;` parse identically — a
    field_declaration whose declarator is a field_identifier — so nothing in the
    grammar says the first names no member. Only the expansion does, and it is
    written in another file.

    Object-like macros were extracted and dropped on the floor, so no reader
    could ask. Keep the ones that can answer this: a body stating an attribute,
    and a body that is a single identifier, because an alias is how the answer is
    reached — `____cacheline_aligned_in_smp` expands to `____cacheline_aligned`,
    which expands to an attribute.