### PR TITLE
ci: fix missing dependency, clean up old dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Action versions go stale quickly and a stale one is found by a deprecation
+# warning on a run that already cost twenty minutes. Let the bot say so
+# instead.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci: "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,26 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      # lancedb builds protobuf definitions through prost-build, which calls
-      # protoc and does not vendor it. The runner image has no protoc.
+      # protoc, and the .proto files it reads: lance-encoding imports
+      # google/protobuf/empty.proto, one of protobuf's well-known types, which
+      # ships in libprotobuf-dev and not alongside the compiler. Installing
+      # protobuf-compiler alone gets a protoc that runs and then fails with
+      # "google/protobuf/empty.proto: File not found".
+      # openssl and curl: gix reaches the network through curl built against
+      # openssl, and both -sys crates want headers and pkg-config to find them.
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends protobuf-compiler
+          sudo apt-get install -y --no-install-recommends \
+            protobuf-compiler libprotobuf-dev \
+            pkg-config libssl-dev libcurl4-openssl-dev
+
+      - name: Show what the build will use
+        run: |
+          protoc --version
+          ls /usr/include/google/protobuf/empty.proto
 
       - name: Install the toolchain
         run: |
@@ -50,7 +62,7 @@ jobs:
       # does not. The restore-key still gives a partial cache when the lock
       # file moves, which is most of the saving.
       - name: Cache cargo registry and build output
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index

--- a/src/git.rs
+++ b/src/git.rs
@@ -223,6 +223,55 @@ pub fn get_git_file_hash_with_fallback<P: AsRef<Path>>(file_path: P) -> Result<S
 mod tests {
     use super::*;
 
+    /// A repository with one commit on a branch called `main`.
+    ///
+    /// A test that asks the checkout it runs in about branches is asking
+    /// about whoever ran it. A CI checkout has no local branches at all — it
+    /// is detached at the merge commit of the pull request — which is a
+    /// perfectly ordinary repository, and one these tests cannot answer for.
+    fn repo_with_a_branch() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let run = |args: &[&str]| {
+            let status = std::process::Command::new("git")
+                .args(args)
+                .current_dir(dir.path())
+                .env("GIT_AUTHOR_NAME", "Semcode Test")
+                .env("GIT_AUTHOR_EMAIL", "semcode@example.com")
+                .env("GIT_COMMITTER_NAME", "Semcode Test")
+                .env("GIT_COMMITTER_EMAIL", "semcode@example.com")
+                .status()
+                .unwrap();
+            assert!(status.success(), "git {args:?} failed");
+        };
+
+        std::fs::write(dir.path().join("file.c"), "int main(void) { return 0; }\n").unwrap();
+        run(&["init", "-q"]);
+        run(&["add", "file.c"]);
+        run(&["commit", "-q", "-m", "one"]);
+        // Whatever init.defaultBranch happens to be, the tests name this one.
+        run(&["branch", "-M", "main"]);
+        dir
+    }
+
+    /// A clone of that repository, so `origin/main` exists to be listed.
+    ///
+    /// Whether a checkout has remote-tracking refs is a property of how it
+    /// was made, not of the code under test.
+    fn clone_of(origin: &tempfile::TempDir) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let status = std::process::Command::new("git")
+            .args([
+                "clone",
+                "-q",
+                origin.path().to_str().unwrap(),
+                dir.path().join("clone").to_str().unwrap(),
+            ])
+            .status()
+            .unwrap();
+        assert!(status.success(), "git clone failed");
+        dir
+    }
+
     #[test]
     fn test_get_git_sha_current_dir() {
         // This should work if running in a git repository
@@ -262,13 +311,13 @@ mod tests {
 
     #[test]
     fn test_list_branches_local() {
-        // List local branches only
-        let result = list_branches(".", false);
+        let repo = repo_with_a_branch();
+        let result = list_branches(repo.path().to_str().unwrap(), false);
         assert!(result.is_ok());
 
         let branches = result.unwrap();
-        // Should have at least one local branch (main/master)
-        assert!(!branches.is_empty());
+        assert_eq!(branches.len(), 1, "{branches:?}");
+        assert_eq!(branches[0].name, "main");
 
         // All should be local branches
         for branch in &branches {
@@ -282,13 +331,17 @@ mod tests {
 
     #[test]
     fn test_list_branches_with_remote() {
-        // List all branches including remote
-        let result = list_branches(".", true);
+        let origin = repo_with_a_branch();
+        let holder = clone_of(&origin);
+        let clone = holder.path().join("clone");
+        let result = list_branches(clone.to_str().unwrap(), true);
         assert!(result.is_ok());
 
         let branches = result.unwrap();
-        // Should have at least one branch
-        assert!(!branches.is_empty());
+        assert!(
+            branches.iter().any(|b| b.is_remote),
+            "a clone has a remote branch: {branches:?}"
+        );
 
         // Check that remote branches have proper attributes
         for branch in &branches {
@@ -303,13 +356,9 @@ mod tests {
 
     #[test]
     fn test_resolve_branch_main() {
-        // Try to resolve 'main' or 'master' branch
-        let main_result = resolve_branch(".", "main");
-        let master_result = resolve_branch(".", "master");
-
-        // At least one should succeed
-        let resolved = main_result.or(master_result);
-        assert!(resolved.is_ok());
+        let repo = repo_with_a_branch();
+        let resolved = resolve_branch(repo.path().to_str().unwrap(), "main");
+        assert!(resolved.is_ok(), "{resolved:?}");
 
         let sha = resolved.unwrap();
         assert_eq!(sha.len(), 40);


### PR DESCRIPTION
ci: install the protobuf files the build imports, and let the bot track actions

The first run failed to build lance-encoding:

    protoc failed: google/protobuf/empty.proto: File not found.
    Import "google/protobuf/empty.proto" was not found or had errors.

protoc was installed and ran. What was missing is the file it was asked to read: google/protobuf/empty.proto is one of protobuf's well-known types, which ship in libprotobuf-dev rather than with the compiler.

Add the libraries the build links against while here, which the first run also lacked: gix reaches the network through curl built against openssl, so openssl-sys and curl-sys want headers and pkg-config to find them. That would have been the next failure.

Print protoc's version and the path of the file that was missing, so a failure of this kind is one line to diagnose rather than a build log to read.

Take current majors of checkout and cache. The runner deprecated Node 20 and forced the older ones onto Node 24, which was a warning and not the failure, but a version chosen by hand is stale the week it is written: ask dependabot for github-actions updates so a deprecation arrives as a pull request rather than as a warning on a run that has already spent twenty minutes.

Assisted-by: claw:claude-opus-5