### PR TITLE
check file revisions and content at query time

### DIFF
--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -13,33 +13,6 @@ use tracing::info;
 use query_impl::commands::handle_command;
 use semcode::display::print_welcome_message_with_model;
 
-/// Rebuild the working directory index to pick up any file changes since the last query.
-/// Reuses cached analysis results for files whose mtime and size haven't changed.
-fn refresh_workdir_index(db_manager: &DatabaseManager, git_repo: &str) {
-    let repo_path = std::path::Path::new(git_repo);
-    let previous = db_manager.take_workdir_index();
-    match semcode::WorkdirIndex::build_incremental(repo_path, previous.as_ref()) {
-        Ok(workdir) => {
-            if workdir.is_empty() {
-                // No need to set — we already took it out
-            } else {
-                info!(
-                    "Working directory overlay: {} dirty, {} deleted, {} functions, {} types",
-                    workdir.dirty_file_count(),
-                    workdir.deleted_file_count(),
-                    workdir.function_count(),
-                    workdir.type_count(),
-                );
-                db_manager.set_workdir_index(workdir);
-            }
-        }
-        Err(e) => {
-            info!("Could not build working directory index: {}", e);
-            // No need to clear — we already took it out
-        }
-    }
-}
-
 #[derive(Parser, Debug)]
 #[command(name = "semcode")]
 #[command(about = "Query the semantic code database", long_about = None)]
@@ -332,6 +305,7 @@ async fn main() -> Result<()> {
 
     // Connect to database
     let db_manager = Arc::new(DatabaseManager::new(&database_path, args.git_repo.clone()).await?);
+    db_manager.set_git_only(args.git_only);
 
     // Ensure tables exist
     db_manager.create_tables().await?;
@@ -556,11 +530,6 @@ async fn main() -> Result<()> {
         // Convert to Vec<&str> for handle_command
         let parts: Vec<&str> = parts_owned.iter().map(|s| s.as_str()).collect();
 
-        // Rebuild workdir index to reflect current file state
-        if !args.git_only {
-            refresh_workdir_index(&db_manager, &args.git_repo);
-        }
-
         // Execute the command
         match handle_command(
             &parts,
@@ -622,11 +591,6 @@ async fn main() -> Result<()> {
 
                 // Convert to Vec<&str> for handle_command
                 let parts: Vec<&str> = parts_owned.iter().map(|s| s.as_str()).collect();
-
-                // Rebuild workdir index to reflect current file state
-                if !args.git_only {
-                    refresh_workdir_index(&db_manager, &args.git_repo);
-                }
 
                 // Handle command and check if we should exit
                 if handle_command(

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -592,6 +592,14 @@ async fn main() -> Result<()> {
                 // Convert to Vec<&str> for handle_command
                 let parts: Vec<&str> = parts_owned.iter().map(|s| s.as_str()).collect();
 
+                // A new top-level command: let the working-copy overlay (if
+                // one already exists) know it may be due for a freshness
+                // check, so an edit made since the last command becomes
+                // visible to whichever query in this one first needs it,
+                // without re-checking on every workdir-consuming call this
+                // single command makes internally.
+                db_manager.note_repl_command();
+
                 // Handle command and check if we should exit
                 if handle_command(
                     &parts,

--- a/src/bin/semcode-lsp.rs
+++ b/src/bin/semcode-lsp.rs
@@ -103,29 +103,6 @@ impl SemcodeLspBackend {
         }
     }
 
-    /// Rebuild the working directory index to reflect current file state.
-    async fn refresh_workdir_index(&self) {
-        let db_guard = self.database.lock().await;
-        let db = match db_guard.as_ref() {
-            Some(db) => db,
-            None => return,
-        };
-        let repo_path_guard = self.git_repo_path.lock().await;
-        let repo_path = match repo_path_guard.as_ref() {
-            Some(p) => p.clone(),
-            None => return,
-        };
-        drop(repo_path_guard);
-
-        let path = std::path::Path::new(&repo_path);
-        let previous = db.take_workdir_index();
-        if let Ok(workdir) = semcode::WorkdirIndex::build_incremental(path, previous.as_ref()) {
-            if !workdir.is_empty() {
-                db.set_workdir_index(workdir);
-            }
-        }
-    }
-
     /// Returns true if the index was written by an older semcode.
     ///
     /// Refuse queries when the index might not contain what we need to
@@ -156,7 +133,6 @@ impl SemcodeLspBackend {
         if self.index_is_stale().await {
             return None;
         }
-        self.refresh_workdir_index().await;
 
         let db_guard = self.database.lock().await;
         let db = db_guard.as_ref()?;
@@ -221,8 +197,6 @@ impl SemcodeLspBackend {
     }
 
     async fn find_function_references(&self, function_name: &str) -> Vec<Location> {
-        self.refresh_workdir_index().await;
-
         let db_guard = self.database.lock().await;
         let db = match db_guard.as_ref() {
             Some(db) => db,

--- a/src/bin/semcode-mcp.rs
+++ b/src/bin/semcode-mcp.rs
@@ -2839,8 +2839,12 @@ impl McpServer {
 
     /// Resolve git SHA from either git_sha or branch argument.
     /// If branch is provided, resolve it to a SHA. Otherwise use git_sha or default.
-    /// When using the default HEAD SHA (no explicit git_sha or branch), refreshes
-    /// the working directory overlay so queries reflect uncommitted changes.
+    ///
+    /// No overlay bookkeeping needed here any more: `DatabaseManager` checks
+    /// the working copy against the *requested* revision itself now, per
+    /// candidate file, and only trusts it when that revision is the one
+    /// actually checked out — an explicit SHA or branch other than HEAD
+    /// naturally answers from the index alone, correctly, with no scan.
     fn resolve_git_sha_or_branch(
         &self,
         git_sha_arg: Option<&str>,
@@ -2849,11 +2853,7 @@ impl McpServer {
         // Branch takes precedence if provided
         if let Some(branch) = branch_arg {
             match git::resolve_branch(&self.git_repo_path, branch) {
-                Ok(sha) => {
-                    // Explicit branch — disable workdir overlay
-                    self.db.clear_workdir_index();
-                    return sha;
-                }
+                Ok(sha) => return sha,
                 Err(e) => {
                     eprintln!("Warning: Failed to resolve branch '{}': {}", branch, e);
                     // Fall through to git_sha or default
@@ -2861,31 +2861,7 @@ impl McpServer {
             }
         }
 
-        if git_sha_arg.is_some() {
-            // Explicit git SHA — disable workdir overlay
-            self.db.clear_workdir_index();
-        } else {
-            // Using default HEAD — refresh workdir overlay
-            self.refresh_workdir_index();
-        }
-
         self.resolve_git_sha(git_sha_arg)
-    }
-
-    /// Rebuild the working directory index to reflect current file state.
-    fn refresh_workdir_index(&self) {
-        let repo_path = std::path::Path::new(&self.git_repo_path);
-        let previous = self.db.take_workdir_index();
-        match semcode::WorkdirIndex::build_incremental(repo_path, previous.as_ref()) {
-            Ok(workdir) => {
-                if !workdir.is_empty() {
-                    self.db.set_workdir_index(workdir);
-                }
-            }
-            Err(e) => {
-                tracing::info!("Could not build working directory index: {}", e);
-            }
-        }
     }
 
     /// Check if the database appears to be empty and return a helpful message if so
@@ -3234,7 +3210,8 @@ impl McpServer {
         let workspace = std::path::Path::new(&self.git_repo_path);
         let result = match semcode::git::get_git_sha(workspace) {
             Ok(Some(git_sha)) => {
-                self.refresh_workdir_index();
+                // Current HEAD: the working copy represents it, so
+                // candidate-level checks answer with no eager scan.
                 semcode::file_survey::survey_file_json_with_references(
                     workspace,
                     std::path::Path::new(path),

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -1299,6 +1299,47 @@ impl DatabaseManager {
     /// Returns the "best match" from all indexed versions without considering git history.
     /// Prefers .c over .h files, implementations over declarations, but may not match
     /// the version currently in your working directory.
+    /// An answer given without establishing the revision.
+    ///
+    /// Every lookup below reaches this when the requested revision cannot be
+    /// mapped onto the files a symbol lives in: the paths do not exist at that
+    /// revision, the manifest is empty, or no row carries the content the
+    /// revision holds. Each case has the same meaning — the index cannot show
+    /// that the symbol is in that tree — and the same behaviour today, which
+    /// is to answer from every revision it has.
+    ///
+    /// Collected here so that behaviour has one name, one changelog entry, and
+    /// one place to change. Nothing about it changes in this patch.
+    async fn function_without_revision(&self, name: &str) -> Result<Option<FunctionInfo>> {
+        self.find_function(name).await
+    }
+
+    /// The same, for a lookup that returns every match rather than one.
+    async fn functions_without_revision(&self, name: &str) -> Result<Vec<FunctionInfo>> {
+        let all_functions = self
+            .function_store
+            .find_all_by_name_unfiltered(name)
+            .await?;
+        Ok(self.filter_implementations_only(all_functions))
+    }
+
+    /// The same, for types, which prefer a dirty-file match if there is one.
+    async fn types_without_revision(
+        &self,
+        name: &str,
+        workdir_matches: Vec<TypeInfo>,
+    ) -> Result<Vec<TypeInfo>> {
+        if !workdir_matches.is_empty() {
+            return Ok(workdir_matches);
+        }
+        Ok(self.find_type(name).await?.into_iter().collect())
+    }
+
+    /// The same, for typedefs.
+    async fn typedef_without_revision(&self, name: &str) -> Result<Option<TypedefInfo>> {
+        self.find_typedef(name).await
+    }
+
     pub async fn find_function(&self, name: &str) -> Result<Option<FunctionInfo>> {
         // Get all functions with this name and select the best one (prefers .c over .h, implementations over declarations)
         let all_matches = self
@@ -1330,7 +1371,7 @@ impl DatabaseManager {
                 name,
                 git_sha
             );
-            return self.find_function(name).await;
+            return self.function_without_revision(name).await;
         }
         self.find_function_with_manifest(name, &git_manifest).await
     }
@@ -1359,8 +1400,7 @@ impl DatabaseManager {
         }
 
         if resolved_hashes.is_empty() {
-            // Fallback: do a regular find to get any available functions
-            return self.find_function(name).await;
+            return self.function_without_revision(name).await;
         }
 
         // Step 3: Direct targeted search for each (filename, git_hash) combination
@@ -1524,12 +1564,7 @@ impl DatabaseManager {
             .await?;
         if resolved_hashes.is_empty() {
             tracing::warn!("No files resolved for '{}' at commit '{}'", name, git_sha);
-            // Fallback: get all functions and filter implementations
-            let all_functions = self
-                .function_store
-                .find_all_by_name_unfiltered(name)
-                .await?;
-            return Ok(self.filter_implementations_only(all_functions));
+            return self.functions_without_revision(name).await;
         }
 
         // Step 3: Direct targeted search for each (filename, git_hash) combination
@@ -1558,17 +1593,14 @@ impl DatabaseManager {
 
         // Step 4: Filter out declarations but keep all implementations
         if matches.is_empty() {
+            // Not a resolution failure: the revision is known and no row holds
+            // the content it has. The answer given is the same one.
             tracing::warn!(
                 "No exact matches found for '{}' at commit '{}', falling back",
                 name,
                 git_sha
             );
-            // Fallback: get all functions and filter implementations
-            let all_functions = self
-                .function_store
-                .find_all_by_name_unfiltered(name)
-                .await?;
-            return Ok(self.filter_implementations_only(all_functions));
+            return self.functions_without_revision(name).await;
         }
 
         // Filter out DB results from dirty/deleted files, then merge with workdir results
@@ -1952,11 +1984,7 @@ impl DatabaseManager {
                 name,
                 git_sha
             );
-            if !workdir_matches.is_empty() {
-                return Ok(workdir_matches);
-            }
-            // Fallback: do a regular find to get any available type
-            return Ok(self.find_type(name).await?.into_iter().collect());
+            return self.types_without_revision(name, workdir_matches).await;
         }
 
         // Step 3: Direct targeted search using git hashes
@@ -2147,8 +2175,7 @@ impl DatabaseManager {
                 name,
                 git_sha
             );
-            // Fallback: do a regular find to get any available typedef
-            return self.find_typedef(name).await;
+            return self.typedef_without_revision(name).await;
         }
 
         // Step 3: Direct targeted search using git hashes

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -3589,6 +3589,80 @@ impl DatabaseManager {
 
     // ==================== End Branch Management ====================
 
+    // ---- Revision reporting -----------------------------------------------
+
+    /// Revisions that contain a file blob, via `processed_files`.
+    ///
+    /// `git_file_hash` is the blob id stored on each row. Reading
+    /// `processed_files` costs ~0.08s for the whole table versus 0.36s for
+    /// `git ls-tree`; this helper reads only the rows for one hash.
+    pub async fn revisions_for_file_hash(&self, git_file_hash: &str) -> Result<Vec<String>> {
+        self.processed_file_store
+            .get_revisions_for_file_hash(git_file_hash)
+            .await
+    }
+
+    /// Branches that contain a file blob, via `revisions_for_file_hash`
+    /// plus the indexed branch tips. Sorted by branch name for stable output.
+    pub async fn branches_for_file_hash(
+        &self,
+        git_file_hash: &str,
+    ) -> Result<Vec<crate::database::branches::IndexedBranchInfo>> {
+        let revisions = self.revisions_for_file_hash(git_file_hash).await?;
+        let mut seen = std::collections::HashSet::new();
+        let mut out = Vec::new();
+        for rev in revisions {
+            for branch in self.branch_store.get_branches_at_commit(&rev).await? {
+                if seen.insert(branch.branch_name.clone()) {
+                    out.push(branch);
+                }
+            }
+        }
+        out.sort_by(|a, b| a.branch_name.cmp(&b.branch_name));
+        Ok(out)
+    }
+
+    /// Where a symbol of a given name was found: distinct revisions and
+    /// branches that hold at least one row for it. Reads `functions` for the
+    /// name, then `processed_files` for each distinct hash. No caller uses
+    /// this yet; it is the read side of "not at this revision, present on
+    /// ...".
+    pub async fn symbol_revisions(
+        &self,
+        name: &str,
+    ) -> Result<(
+        Vec<String>,
+        Vec<crate::database::branches::IndexedBranchInfo>,
+    )> {
+        let rows = self
+            .function_store
+            .find_all_by_name_unfiltered(name)
+            .await?;
+        let mut hashes: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for row in &rows {
+            hashes.insert(row.git_file_hash.clone());
+        }
+        let mut rev_set = std::collections::HashSet::new();
+        for hash in hashes {
+            for rev in self.revisions_for_file_hash(&hash).await? {
+                rev_set.insert(rev);
+            }
+        }
+        let mut revisions: Vec<String> = rev_set.into_iter().collect();
+        revisions.sort();
+        let mut branches = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for rev in &revisions {
+            for b in self.branch_store.get_branches_at_commit(rev).await? {
+                if seen.insert(b.branch_name.clone()) {
+                    branches.push(b);
+                }
+            }
+        }
+        branches.sort_by(|a, b| a.branch_name.cmp(&b.branch_name));
+        Ok((revisions, branches))
+    }
+
     pub async fn get_existing_function_names(&self) -> Result<std::collections::HashSet<String>> {
         use futures::TryStreamExt;
 

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -29,7 +29,7 @@ use crate::workdir::WorkdirIndex;
 use crate::worktree::{WorkingCopy, WorkingCopyHashes};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 
 // Optimal batch size for LanceDB operations
@@ -171,6 +171,19 @@ pub struct DatabaseManager {
     /// per-candidate stat entirely and trust every row, the way `--git-only`
     /// always has.
     git_only: AtomicBool,
+    /// Bumped by a long-lived caller (the REPL) once per top-level command,
+    /// so `ensure_workdir_index_built` can tell "asked again within the
+    /// command that just built this" (several `_git_aware` calls in one
+    /// `func` — cheap, must stay a no-op) from "asked again in a later
+    /// command" (a REPL user had a chance to edit a file in between — must
+    /// refresh). A caller that never calls `note_repl_command` (MCP, LSP,
+    /// `-q`) leaves this at 0 forever, which builds the overlay once and
+    /// reuses it — right for a caller with no prompt to edit a file at.
+    workdir_command_generation: AtomicU64,
+    /// The command generation the current `workdir_index` was last built or
+    /// refreshed for. `u64::MAX` means "never built", so the first build on
+    /// generation 0 is not mistaken for already-current.
+    workdir_index_generation: AtomicU64,
 }
 
 impl DatabaseManager {
@@ -207,7 +220,23 @@ impl DatabaseManager {
             attribute_names: std::sync::OnceLock::new(),
             working_copy: WorkingCopyHashes::new(),
             git_only: AtomicBool::new(false),
+            workdir_command_generation: AtomicU64::new(0),
+            workdir_index_generation: AtomicU64::new(u64::MAX),
         })
+    }
+
+    /// Mark the start of a new top-level command, so the next lookup that
+    /// needs the working-copy overlay treats it as due for a freshness
+    /// check instead of reusing whatever the previous command already built
+    /// or refreshed — an edit made between two REPL commands becomes visible
+    /// to the first overlay-consuming call in the next one. Call once per
+    /// command read from the prompt, before dispatching it; calling it more
+    /// than once for the same command only costs one extra refresh, calling
+    /// it not at all builds the overlay once and reuses it (see
+    /// `workdir_command_generation`'s doc comment).
+    pub fn note_repl_command(&self) {
+        self.workdir_command_generation
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     /// Say the caller will not be editing: candidate files are trusted
@@ -1348,25 +1377,61 @@ impl DatabaseManager {
     // on-miss fallback (a symbol with no row at all). `ensure_workdir_index_built`
     // is what makes that walk lazy: the first of these helpers actually
     // consulted in a process builds it, once, instead of every command
-    // building it whether asked for or not.
+    // building it whether asked for or not — and keeps it current across
+    // the top-level commands of one REPL session rather than
+    // freezing it at whatever the working tree held on that first build.
 
     /// Build the working-copy overlay for `git_sha` if nothing has this
-    /// process, unless it is unusable for it (see `workdir_overlay_usable`).
-    /// One walk of the tracked files, done at most once — on the first
-    /// regex, grep, caller/callee, or on-miss lookup that needs it, not
-    /// before every query.
+    /// process yet, unless it is unusable for it (see
+    /// `workdir_overlay_usable`); refresh it, at most once per top-level
+    /// command (see `workdir_command_generation`'s doc comment), if it
+    /// already exists.
+    ///
+    /// A naive "refresh whenever asked" is wrong here: a single `func`
+    /// command calls both `get_function_callees_git_aware` and
+    /// `get_function_callers_git_aware`, each of which reaches this through
+    /// its own `workdir_find_*` helper, so an unconditional refresh would
+    /// walk the tracked-file set twice for one command instead of once —
+    /// measured while building this patch: 266,533 statx for `help; func
+    /// alloc_super; help` against ~131,489 for a single build, because the
+    /// second call inside the same `func` command refreshed instead of
+    /// reusing. Gating on the command generation fixes that: every call
+    /// within one command sees the same generation and reuses; the first
+    /// call in the *next* command sees a new one and refreshes through
+    /// `build_incremental`'s own cache (HEAD SHA plus per-file mtime/size,
+    /// the mechanism `test_incremental_reuses_cache` in workdir.rs covers
+    /// directly) — a stat of each tracked file, not a re-read or a re-parse
+    /// of the ones that have not changed. A command that never touches this
+    /// path (`help` on its own) still never pays either cost.
     fn ensure_workdir_index_built(&self, git_sha: &str) {
         if !self.workdir_overlay_usable(git_sha) {
             return;
         }
-        if self.workdir_index.read().unwrap().is_some() {
+        let current_generation = self.workdir_command_generation.load(Ordering::Relaxed);
+        let built_for_generation = self
+            .workdir_index_generation
+            .swap(current_generation, Ordering::Relaxed);
+        if built_for_generation == current_generation && self.has_workdir_index() {
             return;
         }
         let repo_path = Path::new(&self.git_repo_path);
-        match WorkdirIndex::build(repo_path) {
+        let (built, refreshing) = {
+            let guard = self.workdir_index.read().unwrap();
+            let refreshing = guard.is_some();
+            (
+                WorkdirIndex::build_incremental(repo_path, guard.as_ref()),
+                refreshing,
+            )
+        };
+        match built {
             Ok(workdir) => {
                 tracing::info!(
-                    "workdir: built overlay on demand: {} dirty, {} deleted, {} functions, {} types",
+                    "workdir: {} overlay: {} dirty, {} deleted, {} functions, {} types",
+                    if refreshing {
+                        "refreshed"
+                    } else {
+                        "built on demand"
+                    },
                     workdir.dirty_file_count(),
                     workdir.deleted_file_count(),
                     workdir.function_count(),
@@ -1374,7 +1439,14 @@ impl DatabaseManager {
                 );
                 self.set_workdir_index(workdir);
             }
-            Err(e) => tracing::info!("workdir: could not build overlay on demand: {e}"),
+            Err(e) => tracing::info!(
+                "workdir: could not {} overlay: {e}",
+                if refreshing {
+                    "refresh"
+                } else {
+                    "build on demand"
+                }
+            ),
         }
     }
 
@@ -7666,6 +7738,95 @@ mod tests {
             .unwrap();
         assert_eq!(function_counts["target"], 2);
         assert_eq!(type_counts["duplicate"], 3);
+    }
+
+    #[tokio::test]
+    async fn a_later_repl_command_sees_an_edit_the_current_one_did_not() {
+        // The on-miss overlay is built once, lazily, and reused within one
+        // call, so `func alloc_super; help` walks the tree once rather than
+        // twice. What that alone does not do is notice a file
+        // changed *after* that first build: `ensure_workdir_index_built`
+        // used to return immediately whenever an overlay already existed,
+        // for the rest of the process. This test pins both halves of a
+        // trade-off that pulls in opposite directions: refreshing on every
+        // call re-walks the tree
+        // twice for one `func` command (it calls both
+        // `get_function_callees_git_aware` and
+        // `get_function_callers_git_aware`); never refreshing leaves an
+        // edit invisible for the rest of the session. `note_repl_command`
+        // is the line between the two: calls before it share one overlay,
+        // calls after it get a freshness check.
+        //
+        // (workdir.rs's own `test_incremental_reuses_cache` already covers
+        // `build_incremental`'s cache primitive directly; this test is
+        // about `ensure_workdir_index_built` deciding *when* to call it.)
+        let repo_dir = tempfile::tempdir().unwrap();
+        let repo_path = repo_dir.path();
+        git(repo_path, &["init", "-q"]);
+        std::fs::write(repo_path.join("a.c"), "/* placeholder */\n").unwrap();
+        git(repo_path, &["add", "a.c"]);
+        git(repo_path, &["commit", "-q", "-m", "initial"]);
+
+        let git_sha = crate::git::get_git_sha(repo_path).unwrap().unwrap();
+
+        let db_path = repo_path.join(".semcode.db");
+        let db = DatabaseManager::new(
+            db_path.to_str().unwrap(),
+            repo_path.to_string_lossy().into_owned(),
+        )
+        .await
+        .unwrap();
+        db.create_tables().await.unwrap();
+
+        // No row anywhere names this function — symbol_filename is empty —
+        // so only the on-miss path (the workdir overlay) can ever answer
+        // it. The first call builds the overlay from a clean tree and finds
+        // nothing.
+        let before = db
+            .find_all_functions_git_aware("brand_new_func", &git_sha)
+            .await
+            .unwrap();
+        assert!(before.is_empty(), "found before it was written: {before:?}");
+        assert!(db.has_workdir_index(), "overlay was not built on first use");
+
+        // Edit the file after the overlay already exists in this process —
+        // what happens between two commands in one REPL session.
+        // (Body has to clear `filter_implementations_only`'s 50-byte
+        // "substantial body" floor, or a real function reads as a bare
+        // declaration and this test would fail for a reason that has
+        // nothing to do with the overlay.)
+        std::fs::write(
+            repo_path.join("a.c"),
+            "int brand_new_func(void)\n{\n    int result = 42;\n    return result;\n}\n",
+        )
+        .unwrap();
+
+        // Still the same command as the first call (nothing told the
+        // database a new one started): the edit must not appear yet, or a
+        // `func` command that checks callees and then callers would walk
+        // the tracked-file set twice instead of once.
+        let still_this_command = db
+            .find_all_functions_git_aware("brand_new_func", &git_sha)
+            .await
+            .unwrap();
+        assert!(
+            still_this_command.is_empty(),
+            "a second lookup in the same command re-walked the tree instead of reusing: {still_this_command:?}"
+        );
+
+        // A new command starts — the REPL calls this once per line read from
+        // the prompt, before dispatching it.
+        db.note_repl_command();
+
+        let next_command = db
+            .find_all_functions_git_aware("brand_new_func", &git_sha)
+            .await
+            .unwrap();
+        assert_eq!(
+            next_command.len(),
+            1,
+            "edit made before the next command is still invisible: {next_command:?}"
+        );
     }
 }
 

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -1274,6 +1274,7 @@ impl DatabaseManager {
     }
 
     /// Merge a HEAD manifest with workdir dirty/deleted state.
+    #[allow(dead_code)]
     fn workdir_merged_manifest(
         &self,
         head_manifest: std::collections::HashMap<String, String>,
@@ -1395,7 +1396,7 @@ impl DatabaseManager {
         let mut resolved_hashes = Vec::new();
         for file_path in &unique_file_paths {
             if let Some(hash) = git_manifest.hash_of(file_path) {
-                resolved_hashes.push((file_path.clone(), hash.to_string()));
+                resolved_hashes.push((file_path.clone(), hash));
             }
         }
 
@@ -2420,7 +2421,7 @@ impl DatabaseManager {
                     if self.workdir_is_dirty(path) || self.workdir_is_deleted(path) {
                         continue;
                     }
-                    if git_manifest.hash_of(path) != Some(hashes.value(row)) {
+                    if git_manifest.hash_of(path).as_deref() != Some(hashes.value(row)) {
                         continue;
                     }
                     let identity = format!(
@@ -2484,7 +2485,7 @@ impl DatabaseManager {
                         if self.workdir_is_dirty(path) || self.workdir_is_deleted(path) {
                             continue;
                         }
-                        if git_manifest.hash_of(path) != Some(hashes.value(row)) {
+                        if git_manifest.hash_of(path).as_deref() != Some(hashes.value(row)) {
                             continue;
                         }
                         if types.is_null(row) {
@@ -4261,23 +4262,26 @@ impl DatabaseManager {
         &self,
         git_sha: &str,
     ) -> Result<crate::database::resolution::RevisionPaths> {
-        let mut manifest = std::collections::HashMap::new();
-
-        // Use shared tree traversal utility
-        crate::git::walk_tree_at_commit(
-            &self.git_repo_path,
-            git_sha,
-            |relative_path, object_id| {
-                // Normalize path by removing any double slashes
-                let normalized_path = relative_path.replace("//", "/");
-                manifest.insert(normalized_path, object_id.to_string());
-                Ok(())
-            },
-        )?;
-
-        // Merge with workdir overlay (adds dirty files, removes deleted files)
-        Ok(crate::database::resolution::RevisionPaths::from_map(
-            self.workdir_merged_manifest(manifest),
+        let (dirty, deleted) = {
+            let guard = self.workdir_index.read().unwrap();
+            match guard.as_ref() {
+                Some(w) => (w.dirty_file_paths().clone(), w.deleted_file_paths().clone()),
+                None => (
+                    std::collections::HashMap::new(),
+                    std::collections::HashSet::new(),
+                ),
+            }
+        };
+        let valid = match gix::discover(&self.git_repo_path) {
+            Ok(repo) => crate::git::resolve_to_commit(&repo, git_sha).is_ok(),
+            Err(_) => false,
+        };
+        Ok(crate::database::resolution::RevisionPaths::new_lazy(
+            std::path::PathBuf::from(&self.git_repo_path),
+            git_sha.to_string(),
+            dirty,
+            deleted,
+            valid,
         ))
     }
 

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -342,6 +342,14 @@ impl DatabaseManager {
             .await
     }
 
+    pub async fn record_tree_sha(&self, sha: &str) -> Result<()> {
+        self.schema_manager.set_tree_sha(sha).await
+    }
+
+    pub async fn recorded_tree_sha(&self) -> Result<Option<String>> {
+        self.schema_manager.meta_value("index:tree_sha").await
+    }
+
     /// How the index was built: the extensions indexed, and whether macros
     /// were skipped. `None` when the index does not say, which is every index
     /// written before this was recorded.

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -22,10 +22,14 @@ use crate::database::types::{TypeStore, TypedefStore};
 use crate::database::content::{ContentInfo, ContentStore};
 use crate::database::processed_files::{ProcessedFileRecord, ProcessedFileStore};
 use crate::database::vectors::VectorStore;
+use crate::treesitter_analyzer::TreeSitterAnalyzer;
 use crate::types::{FunctionInfo, TypeInfo, TypedefInfo};
 use crate::vectorizer::CodeVectorizer;
 use crate::workdir::WorkdirIndex;
+use crate::worktree::{WorkingCopy, WorkingCopyHashes};
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 // Optimal batch size for LanceDB operations
@@ -57,6 +61,20 @@ impl Absent {
             Absent::ContentNotIndexed => "no indexed row holds the content that tree has",
         }
     }
+}
+
+/// What a candidate file holds against the blob hash a query is checking it
+/// against — the row's, or the tree's at the revision asked about. Answering
+/// `Indexed` costs a stat; the other two cost a stat and a hash, of one file,
+/// never a walk of files the query did not name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CandidateFile {
+    /// The disk holds exactly the expected hash: the indexed row is current.
+    Indexed,
+    /// The disk holds something else: an uncommitted edit on top of it.
+    Edited,
+    /// There is no file here any more.
+    Deleted,
 }
 
 /// Where a name's rows do live, for the line that reports it absent.
@@ -145,6 +163,14 @@ pub struct DatabaseManager {
     manifest_cache: std::sync::RwLock<Option<(String, GitManifest)>>,
     /// Identifiers that are compiler attributes, read once per process.
     attribute_names: std::sync::OnceLock<Arc<HashSet<String>>>,
+    /// Hashes of working-copy files a query has already looked at, memoised
+    /// on (size, mtime) so a name asked about twice reads its file once.
+    /// This is what a query stats instead of the working tree.
+    working_copy: WorkingCopyHashes,
+    /// Set when the caller has said it will not be editing: skip the
+    /// per-candidate stat entirely and trust every row, the way `--git-only`
+    /// always has.
+    git_only: AtomicBool,
 }
 
 impl DatabaseManager {
@@ -179,7 +205,50 @@ impl DatabaseManager {
             workdir_index: std::sync::RwLock::new(None),
             manifest_cache: std::sync::RwLock::new(None),
             attribute_names: std::sync::OnceLock::new(),
+            working_copy: WorkingCopyHashes::new(),
+            git_only: AtomicBool::new(false),
         })
+    }
+
+    /// Say the caller will not be editing: candidate files are trusted
+    /// without a stat, and the working-tree overlay is never built, on-miss
+    /// or otherwise. Matches the REPL's `--git-only`.
+    pub fn set_git_only(&self, git_only: bool) {
+        self.git_only.store(git_only, Ordering::Relaxed);
+    }
+
+    fn is_git_only(&self) -> bool {
+        self.git_only.load(Ordering::Relaxed)
+    }
+
+    /// Whether `git_sha` is the commit currently checked out — the only
+    /// relationship in which the working copy can answer for it. A query
+    /// naming an explicit SHA or branch other than what is checked out has
+    /// no such relationship: the file on disk is some other, unrelated
+    /// version, and comparing it against a blob from that revision would
+    /// manufacture an edit out of an unrelated diff — the wrong-branch
+    /// answer this code exists to prevent, reappearing through the
+    /// working-copy overlay instead of the index. A ref read, not a walk of
+    /// anything, and cheap enough to ask every time rather than trust a
+    /// caller to remember to say so.
+    fn is_checked_out(&self, git_sha: &str) -> bool {
+        if git_sha.is_empty() {
+            return false;
+        }
+        match gix::discover(&self.git_repo_path) {
+            Ok(repo) => repo
+                .head_commit()
+                .map(|c| c.id().to_string() == git_sha)
+                .unwrap_or(false),
+            Err(_) => false,
+        }
+    }
+
+    /// Whether the working-copy overlay may be consulted for a query naming
+    /// `git_sha`: the caller has not opted out (`git_only`), and the working
+    /// copy actually represents that revision.
+    fn workdir_overlay_usable(&self, git_sha: &str) -> bool {
+        !self.is_git_only() && self.is_checked_out(git_sha)
     }
 
     pub async fn list_tables(&self) -> Result<Vec<String>> {
@@ -1270,15 +1339,55 @@ impl DatabaseManager {
     }
 
     // --- Workdir overlay helpers ---
+    //
+    // Two mechanisms, not one. `candidate_state` answers for a single named
+    // file with a stat and, on a mismatch, a hash, which is what a
+    // name-keyed answer runs on. The `workdir_*` helpers below it still consult a full
+    // `WorkdirIndex`, built by walking every tracked file, for the queries a
+    // name cannot bound in advance (regex, grep, callers) and for the
+    // on-miss fallback (a symbol with no row at all). `ensure_workdir_index_built`
+    // is what makes that walk lazy: the first of these helpers actually
+    // consulted in a process builds it, once, instead of every command
+    // building it whether asked for or not.
+
+    /// Build the working-copy overlay for `git_sha` if nothing has this
+    /// process, unless it is unusable for it (see `workdir_overlay_usable`).
+    /// One walk of the tracked files, done at most once — on the first
+    /// regex, grep, caller/callee, or on-miss lookup that needs it, not
+    /// before every query.
+    fn ensure_workdir_index_built(&self, git_sha: &str) {
+        if !self.workdir_overlay_usable(git_sha) {
+            return;
+        }
+        if self.workdir_index.read().unwrap().is_some() {
+            return;
+        }
+        let repo_path = Path::new(&self.git_repo_path);
+        match WorkdirIndex::build(repo_path) {
+            Ok(workdir) => {
+                tracing::info!(
+                    "workdir: built overlay on demand: {} dirty, {} deleted, {} functions, {} types",
+                    workdir.dirty_file_count(),
+                    workdir.deleted_file_count(),
+                    workdir.function_count(),
+                    workdir.type_count(),
+                );
+                self.set_workdir_index(workdir);
+            }
+            Err(e) => tracing::info!("workdir: could not build overlay on demand: {e}"),
+        }
+    }
 
     /// Look up a function in the workdir overlay (if set).
-    fn workdir_find_function(&self, name: &str) -> Option<FunctionInfo> {
+    fn workdir_find_function(&self, name: &str, git_sha: &str) -> Option<FunctionInfo> {
+        self.ensure_workdir_index_built(git_sha);
         let guard = self.workdir_index.read().unwrap();
         guard.as_ref().and_then(|w| w.find_function(name).cloned())
     }
 
     /// Look up all functions matching a name in the workdir overlay.
-    fn workdir_find_all_functions(&self, name: &str) -> Vec<FunctionInfo> {
+    fn workdir_find_all_functions(&self, name: &str, git_sha: &str) -> Vec<FunctionInfo> {
+        self.ensure_workdir_index_built(git_sha);
         let guard = self.workdir_index.read().unwrap();
         guard
             .as_ref()
@@ -1287,7 +1396,8 @@ impl DatabaseManager {
     }
 
     /// Look up all types matching a name in the workdir overlay.
-    fn workdir_find_all_types(&self, name: &str) -> Vec<TypeInfo> {
+    fn workdir_find_all_types(&self, name: &str, git_sha: &str) -> Vec<TypeInfo> {
+        self.ensure_workdir_index_built(git_sha);
         let guard = self.workdir_index.read().unwrap();
         guard
             .as_ref()
@@ -1296,7 +1406,8 @@ impl DatabaseManager {
     }
 
     /// Find callers in the workdir overlay.
-    fn workdir_find_callers(&self, name: &str) -> Vec<FunctionInfo> {
+    fn workdir_find_callers(&self, name: &str, git_sha: &str) -> Vec<FunctionInfo> {
+        self.ensure_workdir_index_built(git_sha);
         let guard = self.workdir_index.read().unwrap();
         guard
             .as_ref()
@@ -1305,7 +1416,8 @@ impl DatabaseManager {
     }
 
     /// Find callees in the workdir overlay.
-    fn workdir_find_callees(&self, name: &str) -> Option<Vec<String>> {
+    fn workdir_find_callees(&self, name: &str, git_sha: &str) -> Option<Vec<String>> {
+        self.ensure_workdir_index_built(git_sha);
         let guard = self.workdir_index.read().unwrap();
         guard.as_ref().and_then(|w| w.find_callees(name))
     }
@@ -1315,7 +1427,9 @@ impl DatabaseManager {
         &self,
         pattern: &str,
         path_pattern: Option<&str>,
+        git_sha: &str,
     ) -> Vec<FunctionInfo> {
+        self.ensure_workdir_index_built(git_sha);
         let guard = self.workdir_index.read().unwrap();
         guard
             .as_ref()
@@ -1329,7 +1443,8 @@ impl DatabaseManager {
     }
 
     /// Regex search for functions in the workdir overlay.
-    fn workdir_find_functions_regex(&self, pattern: &str) -> Vec<FunctionInfo> {
+    fn workdir_find_functions_regex(&self, pattern: &str, git_sha: &str) -> Vec<FunctionInfo> {
+        self.ensure_workdir_index_built(git_sha);
         let guard = self.workdir_index.read().unwrap();
         guard
             .as_ref()
@@ -1343,7 +1458,8 @@ impl DatabaseManager {
     }
 
     /// Regex search for types in the workdir overlay.
-    fn workdir_find_types_regex(&self, pattern: &str) -> Vec<TypeInfo> {
+    fn workdir_find_types_regex(&self, pattern: &str, git_sha: &str) -> Vec<TypeInfo> {
+        self.ensure_workdir_index_built(git_sha);
         let guard = self.workdir_index.read().unwrap();
         guard
             .as_ref()
@@ -1352,19 +1468,106 @@ impl DatabaseManager {
     }
 
     /// Check if a file is deleted in the workdir overlay.
-    fn workdir_is_deleted(&self, file_path: &str) -> bool {
+    fn workdir_is_deleted(&self, file_path: &str, git_sha: &str) -> bool {
+        self.ensure_workdir_index_built(git_sha);
         let guard = self.workdir_index.read().unwrap();
         guard.as_ref().is_some_and(|w| w.is_deleted(file_path))
     }
 
-    fn workdir_is_dirty(&self, file_path: &str) -> bool {
+    fn workdir_is_dirty(&self, file_path: &str, git_sha: &str) -> bool {
+        self.ensure_workdir_index_built(git_sha);
         let guard = self.workdir_index.read().unwrap();
         guard.as_ref().is_some_and(|w| w.is_dirty(file_path))
     }
 
-    fn workdir_dirty_count(&self) -> usize {
+    fn workdir_dirty_count(&self, git_sha: &str) -> usize {
+        self.ensure_workdir_index_built(git_sha);
         let guard = self.workdir_index.read().unwrap();
         guard.as_ref().map_or(0, |w| w.dirty_file_count())
+    }
+
+    /// What one candidate file — a path a query already named, with the blob
+    /// hash its row (or the tree) says belongs there — currently holds. The
+    /// primitive a common query runs on: a stat, and only on a
+    /// mismatch a hash, of the handful of files a name-keyed lookup touches,
+    /// never a walk of the tree the query did not ask about. `git_sha` gates
+    /// it on `is_checked_out`: comparing the working copy against a blob
+    /// from a revision it does not represent would answer for the wrong one.
+    fn candidate_state(
+        &self,
+        file_path: &str,
+        expected_hash: &str,
+        git_sha: &str,
+    ) -> CandidateFile {
+        if !self.workdir_overlay_usable(git_sha) {
+            return CandidateFile::Indexed;
+        }
+        let abs_path = Path::new(&self.git_repo_path).join(file_path);
+        match self.working_copy.compare(&abs_path, expected_hash) {
+            Ok(WorkingCopy::Same) => CandidateFile::Indexed,
+            Ok(WorkingCopy::Different) => CandidateFile::Edited,
+            Ok(WorkingCopy::Absent) => CandidateFile::Deleted,
+            Err(e) => {
+                // A stat that fails for a reason other than "not found" (a
+                // permission error, say) is not evidence the file changed;
+                // trust the row rather than manufacture an edit or a
+                // deletion from an I/O error.
+                tracing::debug!("workdir: could not stat {file_path}: {e}");
+                CandidateFile::Indexed
+            }
+        }
+    }
+
+    /// Read and parse one file from the working copy, hashed the same way a
+    /// row's `git_file_hash` is — a git blob id, not the workdir index's
+    /// internal blake3 — so the result is indistinguishable from a row to
+    /// whatever compares it against one.
+    fn reparse_file(&self, file_path: &str) -> Option<crate::treesitter_analyzer::FileAnalysis> {
+        let abs_path = Path::new(&self.git_repo_path).join(file_path);
+        let content = std::fs::read_to_string(&abs_path).ok()?;
+        let hash = self.working_copy.blob_id_of(&abs_path).ok().flatten()?;
+        let mut analyzer = TreeSitterAnalyzer::new().ok()?;
+        let source_root = Some(Path::new(&self.git_repo_path));
+        match analyzer.analyze_source_with_metadata(
+            &content,
+            Path::new(file_path),
+            &hash,
+            source_root,
+        ) {
+            Ok(analysis) => Some(analysis),
+            Err(e) => {
+                tracing::info!("workdir: failed to re-parse {file_path}: {e}");
+                None
+            }
+        }
+    }
+
+    /// The functions and macros named `name` in one edited candidate file —
+    /// the answer for `CandidateFile::Edited`, without building an index over
+    /// anything the query did not name.
+    fn reparse_functions(&self, file_path: &str, name: &str) -> Vec<FunctionInfo> {
+        let Some(analysis) = self.reparse_file(file_path) else {
+            return Vec::new();
+        };
+        analysis
+            .functions
+            .into_iter()
+            .chain(analysis.macros)
+            .filter(|f| f.name.eq_ignore_ascii_case(name))
+            .collect()
+    }
+
+    /// The same, for a type or typedef name (typedefs are extracted into
+    /// `types` with `kind = "typedef"`, the way the indexer stores them).
+    fn reparse_types(&self, file_path: &str, name: &str) -> Vec<TypeInfo> {
+        let Some(analysis) = self.reparse_file(file_path) else {
+            return Vec::new();
+        };
+        analysis
+            .types
+            .into_iter()
+            .filter(|t| t.name.eq_ignore_ascii_case(name))
+            .collect()
     }
 
     /// Merge a HEAD manifest with workdir dirty/deleted state.
@@ -1402,8 +1605,8 @@ impl DatabaseManager {
         // would be invisible once the overlay is no longer built eagerly. Scan the overlay here — 197,179 stat calls become a
         // lookup in a HashMap that is already in memory, ~0.01ms for the four
         // files a typical query touches against 1.10s for the scan it replaces.
-        if let Some(func) = self.workdir_find_function(name) {
-            let dirty = self.workdir_dirty_count();
+        if let Some(func) = self.workdir_find_function(name, git_sha) {
+            let dirty = self.workdir_dirty_count(git_sha);
             tracing::info!(
                 "function '{name}' is not in the index at {git_sha}: {}; but {dirty} dirty file(s) have it — answering from the working tree",
                 why.reason()
@@ -1421,9 +1624,9 @@ impl DatabaseManager {
         git_sha: &str,
         why: Absent,
     ) -> Result<Vec<FunctionInfo>> {
-        let workdir_matches = self.workdir_find_all_functions(name);
+        let workdir_matches = self.workdir_find_all_functions(name, git_sha);
         if !workdir_matches.is_empty() {
-            let dirty = self.workdir_dirty_count();
+            let dirty = self.workdir_dirty_count(git_sha);
             tracing::info!(
                 "function '{name}' is not in the index at {git_sha}: {}; but {dirty} dirty file(s) have {} match(es) — answering from the working tree",
                 why.reason(),
@@ -1438,28 +1641,20 @@ impl DatabaseManager {
     /// The same, for types. A dirty file is part of the revision the caller
     /// asked about — the tree plus what is on disk — so a match from one is an
     /// answer for that revision, not a borrowed answer from another.
+    ///
+    /// The candidate-level check in `find_types_git_aware` already answers a
+    /// dirty *known* candidate; this is reached only when no candidate
+    /// existed at all, or none of them held the content indexed — so a match
+    /// here can only come from the on-miss scan, built lazily, once.
     async fn types_not_at_revision(
         &self,
         name: &str,
         git_sha: &str,
         why: Absent,
-        workdir_matches: Vec<TypeInfo>,
     ) -> Result<Vec<TypeInfo>> {
-        if !workdir_matches.is_empty() {
-            let dirty = self.workdir_dirty_count();
-            tracing::info!(
-                "type '{name}' is not in the index at {git_sha}: {}; but {dirty} dirty file(s) have {} match(es) — answering from the working tree",
-                why.reason(),
-                workdir_matches.len()
-            );
-            return Ok(workdir_matches);
-        }
-        // On-miss scan for the case the caller did not pass workdir_matches
-        // (e.g. the manifest was empty). The eager overlay would have answered
-        // before patch 8, and this keeps the answer after it.
-        let on_miss = self.workdir_find_all_types(name);
+        let on_miss = self.workdir_find_all_types(name, git_sha);
         if !on_miss.is_empty() {
-            let dirty = self.workdir_dirty_count();
+            let dirty = self.workdir_dirty_count(git_sha);
             tracing::info!(
                 "type '{name}' is not in the index at {git_sha}: {}; but {dirty} dirty file(s) have {} match(es) — answering from the working tree (on-miss)",
                 why.reason(),
@@ -1486,9 +1681,9 @@ impl DatabaseManager {
         // On-miss scan: typedefs are stored as types in the workdir overlay.
         // If a dirty file defines a type of the same name, surface that it
         // exists in the working tree rather than silently returning absence.
-        let on_miss = self.workdir_find_all_types(name);
+        let on_miss = self.workdir_find_all_types(name, git_sha);
         if !on_miss.is_empty() {
-            let dirty = self.workdir_dirty_count();
+            let dirty = self.workdir_dirty_count(git_sha);
             tracing::info!(
                 "typedef '{name}' is not in the index at {git_sha}: {}; but {dirty} dirty file(s) have a type of the same name — answering from the working tree (on-miss)",
                 why.reason()
@@ -1617,10 +1812,6 @@ impl DatabaseManager {
         name: &str,
         git_sha: &str,
     ) -> Result<Option<FunctionInfo>> {
-        // Check workdir overlay first — if the function is in a dirty file, return it
-        if let Some(func) = self.workdir_find_function(name) {
-            return Ok(Some(func));
-        }
         let git_manifest = self.git_manifest_cached(git_sha).await?;
         if git_manifest.is_empty() {
             let why = self.why_nothing_resolved(git_sha);
@@ -1635,13 +1826,23 @@ impl DatabaseManager {
         name: &str,
         git_manifest: &crate::database::resolution::RevisionPaths,
     ) -> Result<Option<FunctionInfo>> {
+        let revision = match git_manifest.revision() {
+            "" => "the revision asked about",
+            sha => sha,
+        };
+
         // Step 1: Get candidate file paths from symbol_filename table
         let unique_file_paths = self
             .symbol_filename_store
             .get_filenames_for_symbol(name)
             .await?;
         if unique_file_paths.is_empty() {
-            return Ok(None);
+            // No row has ever named this function: the on-miss path is the
+            // only one that can still find it, in an edit the index has
+            // never seen.
+            return self
+                .function_not_at_revision(name, revision, Absent::PathsNotInTree)
+                .await;
         }
 
         // Step 2: Use manifest to get hashes for candidate files (fast HashMap lookups)
@@ -1652,25 +1853,30 @@ impl DatabaseManager {
             }
         }
 
-        let revision = match git_manifest.revision() {
-            "" => "the revision asked about",
-            sha => sha,
-        };
         if resolved_hashes.is_empty() {
             return self
                 .function_not_at_revision(name, revision, Absent::PathsNotInTree)
                 .await;
         }
 
-        // Step 3: Direct targeted search for each (filename, git_hash) combination
+        // Step 3: stat (and, on a mismatch, hash) each candidate against the
+        // blob it has at this revision. A match answers the indexed row with
+        // no further git call; a difference is an edit, answered by parsing
+        // that one file; a deletion answers nothing for that candidate.
         let mut matches = Vec::new();
         for (file_path, git_hash) in &resolved_hashes {
-            if let Some(func) = self
-                .function_store
-                .find_by_name_file_and_hash(name, file_path, git_hash)
-                .await?
-            {
-                matches.push(func);
+            match self.candidate_state(file_path, git_hash, revision) {
+                CandidateFile::Indexed => {
+                    if let Some(func) = self
+                        .function_store
+                        .find_by_name_file_and_hash(name, file_path, git_hash)
+                        .await?
+                    {
+                        matches.push(func);
+                    }
+                }
+                CandidateFile::Edited => matches.extend(self.reparse_functions(file_path, name)),
+                CandidateFile::Deleted => {}
             }
         }
 
@@ -1793,23 +1999,17 @@ impl DatabaseManager {
         name: &str,
         git_sha: &str,
     ) -> Result<Vec<FunctionInfo>> {
-        // Get workdir overlay matches first
-        let workdir_matches = self.workdir_find_all_functions(name);
-        let workdir_files: HashSet<String> = workdir_matches
-            .iter()
-            .map(|f| f.file_path.clone())
-            .collect();
-
         // Step 1: Get candidate file paths from symbol_filename table (optimized - no need to load full function records)
         let unique_file_paths = self
             .symbol_filename_store
             .get_filenames_for_symbol(name)
             .await?;
-        if unique_file_paths.is_empty() && workdir_matches.is_empty() {
-            return Ok(Vec::new());
-        }
         if unique_file_paths.is_empty() {
-            return Ok(self.filter_implementations_only(workdir_matches));
+            // No row has ever named this function: only the on-miss path can
+            // still find it, in an edit the index has never seen.
+            return self
+                .functions_not_at_revision(name, git_sha, Absent::PathsNotInTree)
+                .await;
         }
 
         tracing::debug!(
@@ -1828,27 +2028,25 @@ impl DatabaseManager {
                 .await;
         }
 
-        // Step 3: Direct targeted search for each (filename, git_hash) combination
+        // Step 3: stat (and, on a mismatch, hash) each candidate against the
+        // blob it has at this revision — a handful of files, not the working
+        // tree. A match answers the indexed row with no further git call; a
+        // difference is an edit, answered by parsing that one file; a
+        // deletion answers nothing for that candidate.
         let mut matches = Vec::new();
         for (file_path, git_hash) in &resolved_hashes {
-            tracing::debug!(
-                "Searching for: name='{}' file='{}' hash='{}'",
-                name,
-                file_path,
-                git_hash
-            );
-            if let Some(func) = self
-                .function_store
-                .find_by_name_file_and_hash(name, file_path, git_hash)
-                .await?
-            {
-                tracing::debug!(
-                    "Found match: {} in {} (hash: {})",
-                    name,
-                    file_path,
-                    git_hash
-                );
-                matches.push(func);
+            match self.candidate_state(file_path, git_hash, git_sha) {
+                CandidateFile::Indexed => {
+                    if let Some(func) = self
+                        .function_store
+                        .find_by_name_file_and_hash(name, file_path, git_hash)
+                        .await?
+                    {
+                        matches.push(func);
+                    }
+                }
+                CandidateFile::Edited => matches.extend(self.reparse_functions(file_path, name)),
+                CandidateFile::Deleted => {}
             }
         }
 
@@ -1861,16 +2059,7 @@ impl DatabaseManager {
                 .await;
         }
 
-        // Filter out DB results from dirty/deleted files, then merge with workdir results
-        let mut merged: Vec<FunctionInfo> = workdir_matches;
-        for func in matches {
-            if !workdir_files.contains(&func.file_path) && !self.workdir_is_deleted(&func.file_path)
-            {
-                merged.push(func);
-            }
-        }
-
-        let implementations = self.filter_implementations_only(merged);
+        let implementations = self.filter_implementations_only(matches);
         tracing::info!(
             "Git-aware lookup succeeded: found {} implementations of '{}' at commit '{}'",
             implementations.len(),
@@ -2214,22 +2403,17 @@ impl DatabaseManager {
 
     /// Find all type definitions with an exact name at a specific git commit.
     pub async fn find_types_git_aware(&self, name: &str, git_sha: &str) -> Result<Vec<TypeInfo>> {
-        let workdir_matches = self.workdir_find_all_types(name);
-        let workdir_files: HashSet<String> = workdir_matches
-            .iter()
-            .map(|ty| ty.file_path.clone())
-            .collect();
-
         // Step 1: Get candidate file paths from symbol_filename table (optimized - no need to load full type records)
         let unique_file_paths = self
             .symbol_filename_store
             .get_filenames_for_symbol(name)
             .await?;
-        if unique_file_paths.is_empty() && workdir_matches.is_empty() {
-            return Ok(Vec::new());
-        }
         if unique_file_paths.is_empty() {
-            return Ok(workdir_matches);
+            // No row has ever named this type: only the on-miss path can
+            // still find it, in an edit the index has never seen.
+            return self
+                .types_not_at_revision(name, git_sha, Absent::PathsNotInTree)
+                .await;
         }
 
         // Step 2: Resolve file paths to git hashes at target commit
@@ -2238,40 +2422,45 @@ impl DatabaseManager {
             .await?;
         if resolved_hashes.is_empty() {
             let why = self.why_nothing_resolved(git_sha);
-            return self
-                .types_not_at_revision(name, git_sha, why, workdir_matches)
-                .await;
+            return self.types_not_at_revision(name, git_sha, why).await;
         }
 
-        // Step 3: Direct targeted search using git hashes
-        let hash_values: Vec<String> = resolved_hashes.values().cloned().collect();
-        let types = self
-            .type_store
-            .find_by_git_hashes(&hash_values, Some(name), None)
-            .await?;
-
-        if types.is_empty() {
-            return self
-                .types_not_at_revision(name, git_sha, Absent::ContentNotIndexed, workdir_matches)
-                .await;
-        }
-
-        // Replace committed definitions from dirty files with their overlay versions,
-        // and omit definitions from files deleted in the worktree.
-        let mut merged = workdir_matches;
-        for ty in types {
-            if !workdir_files.contains(&ty.file_path) && !self.workdir_is_deleted(&ty.file_path) {
-                merged.push(ty);
+        // Step 3: stat (and, on a mismatch, hash) each candidate against the
+        // blob it has at this revision. A match keeps its hash for one batched
+        // DB query — the common case pays for a stat and nothing else; a
+        // difference is an edit, answered by parsing that one file; a
+        // deletion answers nothing for that candidate.
+        let mut trusted_hashes: Vec<String> = Vec::new();
+        let mut matches: Vec<TypeInfo> = Vec::new();
+        for (file_path, git_hash) in &resolved_hashes {
+            match self.candidate_state(file_path, git_hash, git_sha) {
+                CandidateFile::Indexed => trusted_hashes.push(git_hash.clone()),
+                CandidateFile::Edited => matches.extend(self.reparse_types(file_path, name)),
+                CandidateFile::Deleted => {}
             }
         }
-        merged.sort_by(|a, b| {
+        if !trusted_hashes.is_empty() {
+            matches.extend(
+                self.type_store
+                    .find_by_git_hashes(&trusted_hashes, Some(name), None)
+                    .await?,
+            );
+        }
+
+        if matches.is_empty() {
+            return self
+                .types_not_at_revision(name, git_sha, Absent::ContentNotIndexed)
+                .await;
+        }
+
+        matches.sort_by(|a, b| {
             a.file_path
                 .cmp(&b.file_path)
                 .then(a.line_start.cmp(&b.line_start))
         });
         let attributes = self.attribute_names().await?;
-        Self::flatten_anonymous_members(&mut merged, &attributes);
-        Ok(merged)
+        Self::flatten_anonymous_members(&mut matches, &attributes);
+        Ok(matches)
     }
 
     pub async fn get_all_types(&self) -> Result<Vec<TypeInfo>> {
@@ -2498,7 +2687,7 @@ impl DatabaseManager {
         pattern: &str,
         git_sha: &str,
     ) -> Result<Vec<TypeInfo>> {
-        let workdir_matches = self.workdir_find_types_regex(pattern);
+        let workdir_matches = self.workdir_find_types_regex(pattern, git_sha);
         let workdir_files: HashSet<String> = workdir_matches
             .iter()
             .map(|t| t.file_path.clone())
@@ -2511,7 +2700,7 @@ impl DatabaseManager {
 
         // Filter out DB results from dirty/deleted files, then prepend workdir matches
         db_results.retain(|t| {
-            !workdir_files.contains(&t.file_path) && !self.workdir_is_deleted(&t.file_path)
+            !workdir_files.contains(&t.file_path) && !self.workdir_is_deleted(&t.file_path, git_sha)
         });
 
         let mut merged = workdir_matches;
@@ -2581,7 +2770,7 @@ impl DatabaseManager {
         pattern: &str,
         git_sha: &str,
     ) -> Result<Vec<FunctionInfo>> {
-        let workdir_matches = self.workdir_find_functions_regex(pattern);
+        let workdir_matches = self.workdir_find_functions_regex(pattern, git_sha);
         let workdir_files: HashSet<String> = workdir_matches
             .iter()
             .map(|f| f.file_path.clone())
@@ -2593,7 +2782,7 @@ impl DatabaseManager {
             .await?;
 
         db_results.retain(|f| {
-            !workdir_files.contains(&f.file_path) && !self.workdir_is_deleted(&f.file_path)
+            !workdir_files.contains(&f.file_path) && !self.workdir_is_deleted(&f.file_path, git_sha)
         });
 
         let mut merged = workdir_matches;
@@ -2658,7 +2847,9 @@ impl DatabaseManager {
 
                 for row in 0..batch.num_rows() {
                     let path = paths.value(row);
-                    if self.workdir_is_dirty(path) || self.workdir_is_deleted(path) {
+                    if self.workdir_is_dirty(path, git_sha)
+                        || self.workdir_is_deleted(path, git_sha)
+                    {
                         continue;
                     }
                     if git_manifest.hash_of(path).as_deref() != Some(hashes.value(row)) {
@@ -2722,7 +2913,9 @@ impl DatabaseManager {
 
                     for row in 0..batch.num_rows() {
                         let path = paths.value(row);
-                        if self.workdir_is_dirty(path) || self.workdir_is_deleted(path) {
+                        if self.workdir_is_dirty(path, git_sha)
+                            || self.workdir_is_deleted(path, git_sha)
+                        {
                             continue;
                         }
                         if git_manifest.hash_of(path).as_deref() != Some(hashes.value(row)) {
@@ -2868,7 +3061,7 @@ impl DatabaseManager {
         git_sha: &str,
     ) -> Result<Vec<String>> {
         // Collect callers from workdir overlay
-        let workdir_callers = self.workdir_find_callers(function_name);
+        let workdir_callers = self.workdir_find_callers(function_name, git_sha);
         let mut caller_names: Vec<String> =
             workdir_callers.iter().map(|f| f.name.clone()).collect();
 
@@ -3145,7 +3338,7 @@ impl DatabaseManager {
         git_sha: &str,
     ) -> Result<Vec<String>> {
         // Check workdir overlay first — if the function is in a dirty file, use its callees
-        if let Some(callees) = self.workdir_find_callees(function_name) {
+        if let Some(callees) = self.workdir_find_callees(function_name, git_sha) {
             return Ok(callees);
         }
         let git_manifest = self.git_manifest_cached(git_sha).await?;
@@ -4288,7 +4481,7 @@ impl DatabaseManager {
         git_sha: &str,
     ) -> Result<(Vec<FunctionInfo>, bool)> {
         // Get workdir overlay matches first
-        let workdir_matches = self.workdir_grep_functions(pattern, path_pattern);
+        let workdir_matches = self.workdir_grep_functions(pattern, path_pattern, git_sha);
         let workdir_files: HashSet<String> = workdir_matches
             .iter()
             .map(|f| f.file_path.clone())
@@ -4371,7 +4564,8 @@ impl DatabaseManager {
         // Merge workdir results with DB results, excluding dirty/deleted files from DB
         let mut merged = workdir_matches;
         for func in git_filtered_functions {
-            if !workdir_files.contains(&func.file_path) && !self.workdir_is_deleted(&func.file_path)
+            if !workdir_files.contains(&func.file_path)
+                && !self.workdir_is_deleted(&func.file_path, git_sha)
             {
                 merged.push(func);
             }

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -35,6 +35,95 @@ pub const OPTIMAL_BATCH_SIZE: usize = 65536;
 /// walks the whole tree.
 type GitManifest = std::sync::Arc<crate::database::resolution::RevisionPaths>;
 
+/// Why a revision cannot account for a symbol. The answer is the same in all
+/// three cases; the reason is what tells an index that does not have the tree
+/// apart from a symbol that is not in it.
+#[derive(Copy, Clone)]
+enum Absent {
+    /// The revision itself did not resolve, so no path could be looked up in
+    /// it. Either the repository does not have that commit or git failed.
+    RevisionUnknown,
+    /// The files the symbol lives in are not in that tree.
+    PathsNotInTree,
+    /// The files are in the tree, holding content no indexed row has.
+    ContentNotIndexed,
+}
+
+impl Absent {
+    fn reason(self) -> &'static str {
+        match self {
+            Absent::RevisionUnknown => "the revision did not resolve",
+            Absent::PathsNotInTree => "its files are not in that tree",
+            Absent::ContentNotIndexed => "no indexed row holds the content that tree has",
+        }
+    }
+}
+
+/// Where a name's rows do live, for the line that reports it absent.
+///
+/// A revision with no branch is normal: the index records commits it read,
+/// and only some of them were branch tips.
+fn describe_revisions(
+    revisions: &[String],
+    branches: &[crate::database::branches::IndexedBranchInfo],
+) -> String {
+    let revs: Vec<&str> = revisions
+        .iter()
+        .map(|r| &r[..r.len().min(12)])
+        .take(4)
+        .collect();
+    let more = revisions.len().saturating_sub(revs.len());
+    let at = if more > 0 {
+        format!("{} and {} more", revs.join(", "), more)
+    } else {
+        revs.join(", ")
+    };
+    if branches.is_empty() {
+        return format!("its rows are at {at}, on no indexed branch");
+    }
+    let names: Vec<&str> = branches.iter().map(|b| b.branch_name.as_str()).collect();
+    format!("its rows are at {at}, on {}", names.join(", "))
+}
+
+/// The same, for an index that cannot name a revision: the files the rows
+/// came from and the content they carry. `processed_files` holds a revision
+/// only when the indexer was given one, so this is what most indexes can
+/// say, and it is enough to tell a caller which tree to look in.
+fn describe_files(places: &[(String, String)]) -> String {
+    let mut seen = HashSet::new();
+    let mut described = Vec::new();
+    for (path, hash) in places {
+        if !seen.insert(path) {
+            continue;
+        }
+        if described.len() < 3 {
+            described.push(format!("{path} (blob {})", &hash[..hash.len().min(12)]));
+        }
+    }
+    if described.is_empty() {
+        return "the index has no row for it".to_string();
+    }
+    let more = seen.len().saturating_sub(described.len());
+    if more > 0 {
+        format!("its rows are in {}, and {more} more", described.join(", "))
+    } else {
+        format!("its rows are in {}", described.join(", "))
+    }
+}
+
+/// One line per absence, because an answer that is missing says nothing. An
+/// unresolvable revision is the operator's problem and warns; a symbol that
+/// is simply not in the tree is an answer and informs.
+fn log_absence(kind: &str, name: &str, git_sha: &str, why: Absent, elsewhere: &str) {
+    let reason = why.reason();
+    match why {
+        Absent::RevisionUnknown => {
+            tracing::warn!("{kind} '{name}' is not answered for {git_sha}: {reason}; {elsewhere}")
+        }
+        _ => tracing::info!("{kind} '{name}' is not at {git_sha}: {reason}; {elsewhere}"),
+    }
+}
+
 pub struct DatabaseManager {
     connection: Connection,
     git_repo_path: String,
@@ -1286,6 +1375,154 @@ impl DatabaseManager {
         }
     }
 
+    /// The answer when the requested revision cannot be mapped onto the files
+    /// a symbol lives in: the paths do not exist at that revision, the
+    /// revision itself does not resolve, or no row carries the content the
+    /// revision holds.
+    ///
+    /// All three say the same thing — the index cannot show the symbol is in
+    /// the tree that was named — so all three answer that it is not there.
+    /// Where its rows do live is logged, from the revisions the index recorded
+    /// for their content.
+    async fn function_not_at_revision(
+        &self,
+        name: &str,
+        git_sha: &str,
+        why: Absent,
+    ) -> Result<Option<FunctionInfo>> {
+        self.log_absent_function(name, git_sha, why).await;
+        Ok(None)
+    }
+
+    /// The same, for a lookup that returns every match rather than one.
+    async fn functions_not_at_revision(
+        &self,
+        name: &str,
+        git_sha: &str,
+        why: Absent,
+    ) -> Result<Vec<FunctionInfo>> {
+        self.log_absent_function(name, git_sha, why).await;
+        Ok(Vec::new())
+    }
+
+    /// The same, for types. A dirty file is part of the revision the caller
+    /// asked about — the tree plus what is on disk — so a match from one is an
+    /// answer for that revision, not a borrowed answer from another.
+    async fn types_not_at_revision(
+        &self,
+        name: &str,
+        git_sha: &str,
+        why: Absent,
+        workdir_matches: Vec<TypeInfo>,
+    ) -> Result<Vec<TypeInfo>> {
+        if !workdir_matches.is_empty() {
+            return Ok(workdir_matches);
+        }
+        let place = self
+            .find_type(name)
+            .await?
+            .map(|ty| (ty.file_path, ty.git_file_hash));
+        self.log_absent_symbol("type", name, git_sha, why, place)
+            .await;
+        Ok(Vec::new())
+    }
+
+    /// The same, for typedefs.
+    async fn typedef_not_at_revision(
+        &self,
+        name: &str,
+        git_sha: &str,
+        why: Absent,
+    ) -> Result<Option<TypedefInfo>> {
+        let place = self
+            .find_typedef(name)
+            .await?
+            .map(|td| (td.file_path, td.git_file_hash));
+        self.log_absent_symbol("typedef", name, git_sha, why, place)
+            .await;
+        Ok(None)
+    }
+
+    /// Report a function absent at a revision, naming the revisions its rows
+    /// were indexed at, or the files they came from when the index recorded no
+    /// revision for their content.
+    async fn log_absent_function(&self, name: &str, git_sha: &str, why: Absent) {
+        let elsewhere = match self.symbol_revisions(name).await {
+            Ok((revisions, branches)) if !revisions.is_empty() => {
+                describe_revisions(&revisions, &branches)
+            }
+            Ok(_) => match self.function_store.find_all_by_name_unfiltered(name).await {
+                Ok(rows) => describe_files(
+                    &rows
+                        .into_iter()
+                        .map(|r| (r.file_path, r.git_file_hash))
+                        .collect::<Vec<_>>(),
+                ),
+                Err(e) => format!("the index could not say where it is: {e}"),
+            },
+            Err(e) => format!("the index could not say where it is: {e}"),
+        };
+        log_absence("function", name, git_sha, why, &elsewhere);
+    }
+
+    /// The same for a symbol whose rows are not in the functions table. The
+    /// row is read to describe where its content lives, never to answer with.
+    async fn log_absent_symbol(
+        &self,
+        kind: &str,
+        name: &str,
+        git_sha: &str,
+        why: Absent,
+        place: Option<(String, String)>,
+    ) {
+        let Some((path, hash)) = place else {
+            log_absence(kind, name, git_sha, why, "the index has no row for it");
+            return;
+        };
+        let elsewhere = match self.where_hash_lives(&hash).await {
+            Ok((revisions, branches)) if !revisions.is_empty() => {
+                describe_revisions(&revisions, &branches)
+            }
+            Ok(_) => describe_files(&[(path, hash)]),
+            Err(e) => format!("the index could not say where it is: {e}"),
+        };
+        log_absence(kind, name, git_sha, why, &elsewhere);
+    }
+
+    /// Whether the repository can resolve a revision at all.
+    fn revision_resolves(&self, git_sha: &str) -> bool {
+        match gix::discover(&self.git_repo_path) {
+            Ok(repo) => crate::git::resolve_to_commit(&repo, git_sha).is_ok(),
+            Err(_) => false,
+        }
+    }
+
+    /// Which absence it is when no path resolved. `resolve_git_file_hashes`
+    /// answers with an empty map both for a path that is not in the tree and
+    /// for a git failure, so ask the repository which one happened. Only
+    /// reached on the absence path, so the extra `gix::discover` is not on any
+    /// answer's way.
+    fn why_nothing_resolved(&self, git_sha: &str) -> Absent {
+        if self.revision_resolves(git_sha) {
+            Absent::PathsNotInTree
+        } else {
+            Absent::RevisionUnknown
+        }
+    }
+
+    /// The revisions and branches that hold one file blob.
+    async fn where_hash_lives(
+        &self,
+        hash: &str,
+    ) -> Result<(
+        Vec<String>,
+        Vec<crate::database::branches::IndexedBranchInfo>,
+    )> {
+        let revisions = self.revisions_for_file_hash(hash).await?;
+        let branches = self.branches_for_file_hash(hash).await?;
+        Ok((revisions, branches))
+    }
+
     /// Find a function by name without git awareness (non-git-aware)
     ///
     /// **WARNING**: This method does NOT filter by git commit and may return outdated versions.
@@ -1300,47 +1537,6 @@ impl DatabaseManager {
     /// Returns the "best match" from all indexed versions without considering git history.
     /// Prefers .c over .h files, implementations over declarations, but may not match
     /// the version currently in your working directory.
-    /// An answer given without establishing the revision.
-    ///
-    /// Every lookup below reaches this when the requested revision cannot be
-    /// mapped onto the files a symbol lives in: the paths do not exist at that
-    /// revision, the manifest is empty, or no row carries the content the
-    /// revision holds. Each case has the same meaning — the index cannot show
-    /// that the symbol is in that tree — and the same behaviour today, which
-    /// is to answer from every revision it has.
-    ///
-    /// Collected here so that behaviour has one name, one changelog entry, and
-    /// one place to change. Nothing about it changes in this patch.
-    async fn function_without_revision(&self, name: &str) -> Result<Option<FunctionInfo>> {
-        self.find_function(name).await
-    }
-
-    /// The same, for a lookup that returns every match rather than one.
-    async fn functions_without_revision(&self, name: &str) -> Result<Vec<FunctionInfo>> {
-        let all_functions = self
-            .function_store
-            .find_all_by_name_unfiltered(name)
-            .await?;
-        Ok(self.filter_implementations_only(all_functions))
-    }
-
-    /// The same, for types, which prefer a dirty-file match if there is one.
-    async fn types_without_revision(
-        &self,
-        name: &str,
-        workdir_matches: Vec<TypeInfo>,
-    ) -> Result<Vec<TypeInfo>> {
-        if !workdir_matches.is_empty() {
-            return Ok(workdir_matches);
-        }
-        Ok(self.find_type(name).await?.into_iter().collect())
-    }
-
-    /// The same, for typedefs.
-    async fn typedef_without_revision(&self, name: &str) -> Result<Option<TypedefInfo>> {
-        self.find_typedef(name).await
-    }
-
     pub async fn find_function(&self, name: &str) -> Result<Option<FunctionInfo>> {
         // Get all functions with this name and select the best one (prefers .c over .h, implementations over declarations)
         let all_matches = self
@@ -1367,12 +1563,8 @@ impl DatabaseManager {
         }
         let git_manifest = self.git_manifest_cached(git_sha).await?;
         if git_manifest.is_empty() {
-            tracing::info!(
-                "No files resolved for '{}' at commit '{}' - falling back to non-git lookup",
-                name,
-                git_sha
-            );
-            return self.function_without_revision(name).await;
+            let why = self.why_nothing_resolved(git_sha);
+            return self.function_not_at_revision(name, git_sha, why).await;
         }
         self.find_function_with_manifest(name, &git_manifest).await
     }
@@ -1400,8 +1592,14 @@ impl DatabaseManager {
             }
         }
 
+        let revision = match git_manifest.revision() {
+            "" => "the revision asked about",
+            sha => sha,
+        };
         if resolved_hashes.is_empty() {
-            return self.function_without_revision(name).await;
+            return self
+                .function_not_at_revision(name, revision, Absent::PathsNotInTree)
+                .await;
         }
 
         // Step 3: Direct targeted search for each (filename, git_hash) combination
@@ -1418,8 +1616,9 @@ impl DatabaseManager {
 
         // Step 4: Pick the best result (prefer implementation over declaration)
         if matches.is_empty() {
-            // Fallback: do a regular find to get any available function
-            return self.find_function(name).await;
+            return self
+                .function_not_at_revision(name, revision, Absent::ContentNotIndexed)
+                .await;
         }
 
         let best_match = self.select_best_function_match(matches);
@@ -1564,8 +1763,9 @@ impl DatabaseManager {
             .resolve_git_file_hashes(&unique_file_paths, git_sha)
             .await?;
         if resolved_hashes.is_empty() {
-            tracing::warn!("No files resolved for '{}' at commit '{}'", name, git_sha);
-            return self.functions_without_revision(name).await;
+            return self
+                .functions_not_at_revision(name, git_sha, self.why_nothing_resolved(git_sha))
+                .await;
         }
 
         // Step 3: Direct targeted search for each (filename, git_hash) combination
@@ -1595,13 +1795,10 @@ impl DatabaseManager {
         // Step 4: Filter out declarations but keep all implementations
         if matches.is_empty() {
             // Not a resolution failure: the revision is known and no row holds
-            // the content it has. The answer given is the same one.
-            tracing::warn!(
-                "No exact matches found for '{}' at commit '{}', falling back",
-                name,
-                git_sha
-            );
-            return self.functions_without_revision(name).await;
+            // the content it has. Either way the symbol is not in that tree.
+            return self
+                .functions_not_at_revision(name, git_sha, Absent::ContentNotIndexed)
+                .await;
         }
 
         // Filter out DB results from dirty/deleted files, then merge with workdir results
@@ -1980,12 +2177,10 @@ impl DatabaseManager {
             .resolve_git_file_hashes(&unique_file_paths, git_sha)
             .await?;
         if resolved_hashes.is_empty() {
-            tracing::info!(
-                "No files resolved for type '{}' at commit '{}' - falling back to non-git lookup",
-                name,
-                git_sha
-            );
-            return self.types_without_revision(name, workdir_matches).await;
+            let why = self.why_nothing_resolved(git_sha);
+            return self
+                .types_not_at_revision(name, git_sha, why, workdir_matches)
+                .await;
         }
 
         // Step 3: Direct targeted search using git hashes
@@ -1996,16 +2191,9 @@ impl DatabaseManager {
             .await?;
 
         if types.is_empty() {
-            tracing::info!(
-                "No exact matches found for type '{}' at commit '{}', falling back to non-git lookup",
-                name,
-                git_sha
-            );
-            if !workdir_matches.is_empty() {
-                return Ok(workdir_matches);
-            }
-            // Fallback: do a regular find to get any available type
-            return Ok(self.find_type(name).await?.into_iter().collect());
+            return self
+                .types_not_at_revision(name, git_sha, Absent::ContentNotIndexed, workdir_matches)
+                .await;
         }
 
         // Replace committed definitions from dirty files with their overlay versions,
@@ -2171,12 +2359,8 @@ impl DatabaseManager {
             .resolve_git_file_hashes(&unique_file_paths, git_sha)
             .await?;
         if resolved_hashes.is_empty() {
-            tracing::info!(
-                "No files resolved for typedef '{}' at commit '{}' - falling back to non-git lookup",
-                name,
-                git_sha
-            );
-            return self.typedef_without_revision(name).await;
+            let why = self.why_nothing_resolved(git_sha);
+            return self.typedef_not_at_revision(name, git_sha, why).await;
         }
 
         // Step 3: Direct targeted search using git hashes
@@ -2187,13 +2371,9 @@ impl DatabaseManager {
             .await?;
 
         if typedefs.is_empty() {
-            tracing::info!(
-                "No exact matches found for typedef '{}' at commit '{}', falling back to non-git lookup",
-                name,
-                git_sha
-            );
-            // Fallback: do a regular find to get any available typedef
-            return self.find_typedef(name).await;
+            return self
+                .typedef_not_at_revision(name, git_sha, Absent::ContentNotIndexed)
+                .await;
         }
 
         // Return the first match
@@ -4346,10 +4526,7 @@ impl DatabaseManager {
                 ),
             }
         };
-        let valid = match gix::discover(&self.git_repo_path) {
-            Ok(repo) => crate::git::resolve_to_commit(&repo, git_sha).is_ok(),
-            Err(_) => false,
-        };
+        let valid = self.revision_resolves(git_sha);
         Ok(crate::database::resolution::RevisionPaths::new_lazy(
             std::path::PathBuf::from(&self.git_repo_path),
             git_sha.to_string(),

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -33,7 +33,7 @@ pub const OPTIMAL_BATCH_SIZE: usize = 65536;
 
 /// A revision's file manifest: path to blob id, shared because building one
 /// walks the whole tree.
-type GitManifest = std::sync::Arc<std::collections::HashMap<String, String>>;
+type GitManifest = std::sync::Arc<crate::database::resolution::RevisionPaths>;
 
 pub struct DatabaseManager {
     connection: Connection,
@@ -887,7 +887,7 @@ impl DatabaseManager {
     async fn resolve_chained_registrations(
         &self,
         registrations: &mut [crate::types::Registration],
-        manifest: &std::collections::HashMap<String, String>,
+        manifest: &crate::database::resolution::RevisionPaths,
     ) -> Result<()> {
         let mut resolved: std::collections::HashMap<(String, String), Option<String>> =
             std::collections::HashMap::new();
@@ -939,7 +939,7 @@ impl DatabaseManager {
         &self,
         container_name: &str,
         field: &str,
-        manifest: &std::collections::HashMap<String, String>,
+        manifest: &crate::database::resolution::RevisionPaths,
     ) -> Result<Option<String>> {
         use crate::database::resolution::{aggregate_of, at_revision};
 
@@ -1103,7 +1103,7 @@ impl DatabaseManager {
     async fn type_chained_receivers(
         &self,
         sites: &mut [crate::types::DispatchSite],
-        manifest: &std::collections::HashMap<String, String>,
+        manifest: &crate::database::resolution::RevisionPaths,
     ) -> Result<()> {
         let mut resolved: std::collections::HashMap<(String, String), Option<String>> =
             std::collections::HashMap::new();
@@ -1380,7 +1380,7 @@ impl DatabaseManager {
     pub async fn find_function_with_manifest(
         &self,
         name: &str,
-        git_manifest: &std::collections::HashMap<String, String>,
+        git_manifest: &crate::database::resolution::RevisionPaths,
     ) -> Result<Option<FunctionInfo>> {
         // Step 1: Get candidate file paths from symbol_filename table
         let unique_file_paths = self
@@ -1394,8 +1394,8 @@ impl DatabaseManager {
         // Step 2: Use manifest to get hashes for candidate files (fast HashMap lookups)
         let mut resolved_hashes = Vec::new();
         for file_path in &unique_file_paths {
-            if let Some(hash) = git_manifest.get(file_path) {
-                resolved_hashes.push((file_path.clone(), hash.clone()));
+            if let Some(hash) = git_manifest.hash_of(file_path) {
+                resolved_hashes.push((file_path.clone(), hash.to_string()));
             }
         }
 
@@ -1429,7 +1429,7 @@ impl DatabaseManager {
     pub async fn get_function_types_with_manifest(
         &self,
         name: &str,
-        git_manifest: &std::collections::HashMap<String, String>,
+        git_manifest: &crate::database::resolution::RevisionPaths,
     ) -> Result<Vec<String>> {
         // Query functions table directly - only read the columns we need
         let escaped_name = name.replace("'", "''");
@@ -1487,7 +1487,7 @@ impl DatabaseManager {
                     let git_file_hash = git_file_hash_array.value(i);
 
                     // Check if this function exists at the target git SHA
-                    if let Some(expected_hash) = git_manifest.get(file_path) {
+                    if let Some(expected_hash) = git_manifest.hash_of(file_path) {
                         if git_file_hash == expected_hash {
                             // Parse the types JSON
                             let types = if types_array.is_null(i) {
@@ -2420,7 +2420,7 @@ impl DatabaseManager {
                     if self.workdir_is_dirty(path) || self.workdir_is_deleted(path) {
                         continue;
                     }
-                    if git_manifest.get(path).map(String::as_str) != Some(hashes.value(row)) {
+                    if git_manifest.hash_of(path) != Some(hashes.value(row)) {
                         continue;
                     }
                     let identity = format!(
@@ -2484,7 +2484,7 @@ impl DatabaseManager {
                         if self.workdir_is_dirty(path) || self.workdir_is_deleted(path) {
                             continue;
                         }
-                        if git_manifest.get(path).map(String::as_str) != Some(hashes.value(row)) {
+                        if git_manifest.hash_of(path) != Some(hashes.value(row)) {
                             continue;
                         }
                         if types.is_null(row) {
@@ -4023,7 +4023,7 @@ impl DatabaseManager {
         for func in &all_matching_functions {
             // Check if this function's file SHA matches the git manifest
             if let Some(expected_hash) = resolved_hashes.get(&func.file_path) {
-                if &func.git_file_hash == expected_hash {
+                if func.git_file_hash == *expected_hash {
                     if limit > 0 && git_filtered_functions.len() >= limit {
                         limit_hit = true;
                         break;
@@ -4183,8 +4183,8 @@ impl DatabaseManager {
         for caller_name in &all_callers {
             if let Some(func) = caller_functions.get(caller_name).and_then(|f| f.first()) {
                 // Check if this function's file SHA matches the git manifest
-                if let Some(expected_hash) = git_manifest.get(&func.file_path) {
-                    if &func.git_file_hash == expected_hash {
+                if let Some(expected_hash) = git_manifest.hash_of(&func.file_path) {
+                    if func.git_file_hash == expected_hash {
                         valid_callers.push(func.clone());
                         tracing::debug!(
                             "Valid caller: {} in {} (hash: {})",
@@ -4260,7 +4260,7 @@ impl DatabaseManager {
     pub async fn generate_git_manifest(
         &self,
         git_sha: &str,
-    ) -> Result<std::collections::HashMap<String, String>> {
+    ) -> Result<crate::database::resolution::RevisionPaths> {
         let mut manifest = std::collections::HashMap::new();
 
         // Use shared tree traversal utility
@@ -4276,7 +4276,9 @@ impl DatabaseManager {
         )?;
 
         // Merge with workdir overlay (adds dirty files, removes deleted files)
-        Ok(self.workdir_merged_manifest(manifest))
+        Ok(crate::database::resolution::RevisionPaths::from_map(
+            self.workdir_merged_manifest(manifest),
+        ))
     }
 
     /// Fallback callers search when not in git repository
@@ -4371,7 +4373,7 @@ impl DatabaseManager {
     async fn function_exists_in_manifest(
         &self,
         function_name: &str,
-        git_manifest: &std::collections::HashMap<String, String>,
+        git_manifest: &crate::database::resolution::RevisionPaths,
     ) -> Result<bool> {
         // Get all functions with this name (non-git-aware, fast database query)
         let all_functions = self
@@ -4381,8 +4383,8 @@ impl DatabaseManager {
 
         // Check if any function exists in the git manifest (fast HashMap lookup)
         for func in &all_functions {
-            if let Some(expected_hash) = git_manifest.get(&func.file_path) {
-                if &func.git_file_hash == expected_hash {
+            if let Some(expected_hash) = git_manifest.hash_of(&func.file_path) {
+                if func.git_file_hash == expected_hash {
                     return Ok(true);
                 }
             }
@@ -4395,7 +4397,7 @@ impl DatabaseManager {
     pub async fn get_function_callees_with_manifest(
         &self,
         function_name: &str,
-        git_manifest: &std::collections::HashMap<String, String>,
+        git_manifest: &crate::database::resolution::RevisionPaths,
     ) -> Result<Vec<String>> {
         // Query functions table directly - efficient, doesn't fetch bodies
         let escaped_name = function_name.replace("'", "''");
@@ -4453,7 +4455,7 @@ impl DatabaseManager {
                     let git_file_hash = git_file_hash_array.value(i);
 
                     // Fast manifest lookup
-                    if let Some(expected_hash) = git_manifest.get(file_path) {
+                    if let Some(expected_hash) = git_manifest.hash_of(file_path) {
                         if git_file_hash == expected_hash {
                             // Parse the calls JSON
                             let calls = if calls_array.is_null(i) {
@@ -4499,7 +4501,7 @@ impl DatabaseManager {
     /// This is much faster than doing N separate LIKE queries for N functions.
     pub async fn build_caller_index_with_manifest(
         &self,
-        git_manifest: &std::collections::HashMap<String, String>,
+        git_manifest: &crate::database::resolution::RevisionPaths,
     ) -> Result<std::collections::HashMap<String, Vec<String>>> {
         let start = std::time::Instant::now();
         let table = self.connection.open_table("functions").execute().await?;
@@ -4551,7 +4553,7 @@ impl DatabaseManager {
                     let git_file_hash = git_file_hash_array.value(i);
 
                     // Only include functions that exist at the current git commit
-                    if let Some(expected_hash) = git_manifest.get(file_path) {
+                    if let Some(expected_hash) = git_manifest.hash_of(file_path) {
                         if git_file_hash == expected_hash {
                             let caller_name = name_array.value(i);
                             if !calls_array.is_null(i) {
@@ -4582,7 +4584,7 @@ impl DatabaseManager {
     pub async fn get_function_callers_with_manifest(
         &self,
         function_name: &str,
-        git_manifest: &std::collections::HashMap<String, String>,
+        git_manifest: &crate::database::resolution::RevisionPaths,
     ) -> Result<Vec<String>> {
         // Use efficient filtering: find functions whose calls JSON contains the target function name
         let escaped_name = function_name.replace("'", "''"); // SQL escape
@@ -4637,8 +4639,8 @@ impl DatabaseManager {
                     let git_file_hash = git_file_hash_array.value(i).to_string();
 
                     // Fast manifest lookup instead of expensive git resolution
-                    if let Some(expected_hash) = git_manifest.get(file_path) {
-                        if &git_file_hash == expected_hash {
+                    if let Some(expected_hash) = git_manifest.hash_of(file_path) {
+                        if git_file_hash == expected_hash {
                             // This function exists at the git SHA, verify it actually calls our target
                             if !calls_array.is_null(i) {
                                 let calls_json = calls_array.value(i);

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -1362,6 +1362,11 @@ impl DatabaseManager {
         guard.as_ref().is_some_and(|w| w.is_dirty(file_path))
     }
 
+    fn workdir_dirty_count(&self) -> usize {
+        let guard = self.workdir_index.read().unwrap();
+        guard.as_ref().map_or(0, |w| w.dirty_file_count())
+    }
+
     /// Merge a HEAD manifest with workdir dirty/deleted state.
     #[allow(dead_code)]
     fn workdir_merged_manifest(
@@ -1390,6 +1395,21 @@ impl DatabaseManager {
         git_sha: &str,
         why: Absent,
     ) -> Result<Option<FunctionInfo>> {
+        // On-miss scan: a symbol that exists only in an edited file has no
+        // row in the index and no candidate path from symbol_filename. The
+        // eager overlay already answers this before the manifest is built, but
+        // an absence after the manifest has to answer it too, or an edit
+        // would be invisible once the overlay is no longer built eagerly. Scan the overlay here — 197,179 stat calls become a
+        // lookup in a HashMap that is already in memory, ~0.01ms for the four
+        // files a typical query touches against 1.10s for the scan it replaces.
+        if let Some(func) = self.workdir_find_function(name) {
+            let dirty = self.workdir_dirty_count();
+            tracing::info!(
+                "function '{name}' is not in the index at {git_sha}: {}; but {dirty} dirty file(s) have it — answering from the working tree",
+                why.reason()
+            );
+            return Ok(Some(func));
+        }
         self.log_absent_function(name, git_sha, why).await;
         Ok(None)
     }
@@ -1401,6 +1421,16 @@ impl DatabaseManager {
         git_sha: &str,
         why: Absent,
     ) -> Result<Vec<FunctionInfo>> {
+        let workdir_matches = self.workdir_find_all_functions(name);
+        if !workdir_matches.is_empty() {
+            let dirty = self.workdir_dirty_count();
+            tracing::info!(
+                "function '{name}' is not in the index at {git_sha}: {}; but {dirty} dirty file(s) have {} match(es) — answering from the working tree",
+                why.reason(),
+                workdir_matches.len()
+            );
+            return Ok(self.filter_implementations_only(workdir_matches));
+        }
         self.log_absent_function(name, git_sha, why).await;
         Ok(Vec::new())
     }
@@ -1416,7 +1446,26 @@ impl DatabaseManager {
         workdir_matches: Vec<TypeInfo>,
     ) -> Result<Vec<TypeInfo>> {
         if !workdir_matches.is_empty() {
+            let dirty = self.workdir_dirty_count();
+            tracing::info!(
+                "type '{name}' is not in the index at {git_sha}: {}; but {dirty} dirty file(s) have {} match(es) — answering from the working tree",
+                why.reason(),
+                workdir_matches.len()
+            );
             return Ok(workdir_matches);
+        }
+        // On-miss scan for the case the caller did not pass workdir_matches
+        // (e.g. the manifest was empty). The eager overlay would have answered
+        // before patch 8, and this keeps the answer after it.
+        let on_miss = self.workdir_find_all_types(name);
+        if !on_miss.is_empty() {
+            let dirty = self.workdir_dirty_count();
+            tracing::info!(
+                "type '{name}' is not in the index at {git_sha}: {}; but {dirty} dirty file(s) have {} match(es) — answering from the working tree (on-miss)",
+                why.reason(),
+                on_miss.len()
+            );
+            return Ok(on_miss);
         }
         let place = self
             .find_type(name)
@@ -1434,6 +1483,17 @@ impl DatabaseManager {
         git_sha: &str,
         why: Absent,
     ) -> Result<Option<TypedefInfo>> {
+        // On-miss scan: typedefs are stored as types in the workdir overlay.
+        // If a dirty file defines a type of the same name, surface that it
+        // exists in the working tree rather than silently returning absence.
+        let on_miss = self.workdir_find_all_types(name);
+        if !on_miss.is_empty() {
+            let dirty = self.workdir_dirty_count();
+            tracing::info!(
+                "typedef '{name}' is not in the index at {git_sha}: {}; but {dirty} dirty file(s) have a type of the same name — answering from the working tree (on-miss)",
+                why.reason()
+            );
+        }
         let place = self
             .find_typedef(name)
             .await?

--- a/src/database/processed_files.rs
+++ b/src/database/processed_files.rs
@@ -457,6 +457,43 @@ impl ProcessedFileStore {
         Ok(pair_set)
     }
 
+    /// Revisions that contain a given file content (by its blob hash).
+    ///
+    /// Reads `processed_files` where `git_file_sha` matches, so a caller can
+    /// say where a row's content lives without walking git. Returns distinct
+    /// `git_sha` values, sorted for deterministic output.
+    pub async fn get_revisions_for_file_hash(&self, git_file_sha: &str) -> Result<Vec<String>> {
+        let table = self
+            .connection
+            .open_table("processed_files")
+            .execute()
+            .await?;
+        let escaped = git_file_sha.replace('\'', "''");
+        let filter = format!("git_file_sha = '{escaped}'");
+        let results = table
+            .query()
+            .only_if(filter)
+            .execute()
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+        let mut revs = std::collections::HashSet::new();
+        for batch in &results {
+            let git_sha_array = batch
+                .column_by_name("git_sha")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+                .ok_or_else(|| anyhow::anyhow!("Missing git_sha column"))?;
+            for i in 0..batch.num_rows() {
+                if !git_sha_array.is_null(i) {
+                    revs.insert(git_sha_array.value(i).to_string());
+                }
+            }
+        }
+        let mut out: Vec<String> = revs.into_iter().collect();
+        out.sort();
+        Ok(out)
+    }
+
     /// Extract a ProcessedFileRecord from a batch at the given row index
     fn extract_record_from_batch(
         &self,

--- a/src/database/resolution.rs
+++ b/src/database/resolution.rs
@@ -285,14 +285,55 @@ pub fn group_by_member(sites: Vec<DispatchSite>) -> HashMap<String, Vec<Dispatch
 
 /// Keep only rows whose file is at the revision being queried, the same way
 /// function lookups do.
-pub fn at_revision<T, F>(rows: Vec<T>, manifest: &HashMap<String, String>, key: F) -> Vec<T>
+/// The content each path holds at a revision, as the working tree shows it.
+///
+/// A revision is not a filter a query may apply and may skip: it decides
+/// which rows are answers at all. Giving it a type means a lookup cannot be
+/// written without one, and means how the paths are obtained — a whole-tree
+/// walk, a lookup per path, or the index itself — is a property of this value
+/// rather than of every caller.
+#[derive(Debug, Default, Clone)]
+pub struct RevisionPaths {
+    paths: HashMap<String, String>,
+}
+
+impl RevisionPaths {
+    /// Paths already resolved, with the working tree's answer preferred.
+    pub fn from_map(paths: HashMap<String, String>) -> Self {
+        Self { paths }
+    }
+
+    /// The content this path holds, or None when the revision does not have
+    /// it. None is an answer: the row that named this path is not in this
+    /// tree.
+    pub fn hash_of(&self, path: &str) -> Option<&str> {
+        self.paths.get(path).map(String::as_str)
+    }
+
+    /// Whether nothing at all resolved, which says the revision could not be
+    /// established rather than that the tree is empty.
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.paths.len()
+    }
+
+    /// The paths as a map, for the callers that still hand one to git.
+    pub fn as_map(&self) -> &HashMap<String, String> {
+        &self.paths
+    }
+}
+
+pub fn at_revision<T, F>(rows: Vec<T>, paths: &RevisionPaths, key: F) -> Vec<T>
 where
     F: Fn(&T) -> (&str, &str),
 {
     rows.into_iter()
         .filter(|row| {
             let (file, hash) = key(row);
-            manifest.get(file).map(|h| h == hash).unwrap_or(false)
+            paths.hash_of(file).map(|h| h == hash).unwrap_or(false)
         })
         .collect()
 }

--- a/src/database/resolution.rs
+++ b/src/database/resolution.rs
@@ -4,7 +4,9 @@
 // dispatch through. Neither side knows the answer alone: a site names a
 // member, a registration names a target, and the join is what turns them
 // into "this call can reach that function".
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::RwLock;
 
 use crate::types::{DispatchSite, Registration};
 
@@ -292,37 +294,215 @@ pub fn group_by_member(sites: Vec<DispatchSite>) -> HashMap<String, Vec<Dispatch
 /// written without one, and means how the paths are obtained — a whole-tree
 /// walk, a lookup per path, or the index itself — is a property of this value
 /// rather than of every caller.
-#[derive(Debug, Default, Clone)]
+const LAZY_THRESHOLD: usize = 64;
+
+#[derive(Debug, Clone, Default)]
+struct Inner {
+    cache: HashMap<String, Option<String>>,
+    fallback: Option<HashMap<String, String>>,
+    lookups: usize,
+}
+
+#[derive(Debug)]
 pub struct RevisionPaths {
-    paths: HashMap<String, String>,
+    repo_path: PathBuf,
+    git_sha: String,
+    dirty: HashMap<String, String>,
+    deleted: HashSet<String>,
+    inner: RwLock<Inner>,
+    threshold: usize,
+    valid: bool,
+}
+
+impl Default for RevisionPaths {
+    fn default() -> Self {
+        Self {
+            repo_path: PathBuf::new(),
+            git_sha: String::new(),
+            dirty: HashMap::new(),
+            deleted: HashSet::new(),
+            inner: RwLock::new(Inner::default()),
+            threshold: LAZY_THRESHOLD,
+            valid: true,
+        }
+    }
+}
+
+impl Clone for RevisionPaths {
+    fn clone(&self) -> Self {
+        let inner = self.inner.read().unwrap().clone();
+        Self {
+            repo_path: self.repo_path.clone(),
+            git_sha: self.git_sha.clone(),
+            dirty: self.dirty.clone(),
+            deleted: self.deleted.clone(),
+            inner: RwLock::new(inner),
+            threshold: self.threshold,
+            valid: self.valid,
+        }
+    }
 }
 
 impl RevisionPaths {
     /// Paths already resolved, with the working tree's answer preferred.
     pub fn from_map(paths: HashMap<String, String>) -> Self {
-        Self { paths }
+        let valid = true;
+        Self {
+            repo_path: PathBuf::new(),
+            git_sha: String::new(),
+            dirty: HashMap::new(),
+            deleted: HashSet::new(),
+            inner: RwLock::new(Inner {
+                cache: HashMap::new(),
+                fallback: Some(paths),
+                lookups: 0,
+            }),
+            threshold: LAZY_THRESHOLD,
+            valid,
+        }
+    }
+
+    /// Lazily-resolved revision paths: dirty/deleted overlay plus per-path git
+    /// lookups with a fallback to a whole-tree walk past a threshold.
+    pub fn new_lazy(
+        repo_path: PathBuf,
+        git_sha: String,
+        dirty: HashMap<String, String>,
+        deleted: HashSet<String>,
+        valid: bool,
+    ) -> Self {
+        Self {
+            repo_path,
+            git_sha,
+            dirty,
+            deleted,
+            inner: RwLock::new(Inner::default()),
+            threshold: LAZY_THRESHOLD,
+            valid,
+        }
     }
 
     /// The content this path holds, or None when the revision does not have
     /// it. None is an answer: the row that named this path is not in this
     /// tree.
-    pub fn hash_of(&self, path: &str) -> Option<&str> {
-        self.paths.get(path).map(String::as_str)
+    pub fn hash_of(&self, path: &str) -> Option<String> {
+        if self.deleted.contains(path) {
+            return None;
+        }
+        if let Some(h) = self.dirty.get(path) {
+            return Some(h.clone());
+        }
+        if !self.valid {
+            return None;
+        }
+        // Fast path under read lock: fallback or cached.
+        {
+            let inner = self.inner.read().unwrap();
+            if let Some(fb) = &inner.fallback {
+                return fb.get(path).cloned();
+            }
+            if let Some(cached) = inner.cache.get(path) {
+                return cached.clone();
+            }
+            if inner.lookups < self.threshold {
+                // need per-path resolve; drop lock before IO
+            } else {
+                // need fallback walk; drop lock before IO
+            }
+        }
+        // Decide whether to fallback based on lookup count.
+        let needs_fallback = {
+            let inner = self.inner.read().unwrap();
+            inner.fallback.is_none() && inner.lookups >= self.threshold
+        };
+        if needs_fallback {
+            // Build fallback manifest once.
+            let mut manifest = HashMap::new();
+            let walk_ok = crate::git::walk_tree_at_commit(
+                &self.repo_path,
+                &self.git_sha,
+                |relative_path, object_id| {
+                    let normalized_path = relative_path.replace("//", "/");
+                    manifest.insert(normalized_path, object_id.to_string());
+                    Ok(())
+                },
+            )
+            .is_ok();
+            let mut inner = self.inner.write().unwrap();
+            // Another thread may have populated fallback while we walked.
+            if inner.fallback.is_none() {
+                if walk_ok {
+                    inner.fallback = Some(manifest);
+                } else {
+                    // Walk failed: treat as empty fallback rather than caching per-path misses forever.
+                    inner.fallback = Some(HashMap::new());
+                }
+            }
+            if let Some(fb) = &inner.fallback {
+                return fb.get(path).cloned();
+            }
+            return None;
+        }
+        // Per-path resolve.
+        let resolved = crate::git::resolve_files_at_commit(
+            &self.repo_path,
+            &self.git_sha,
+            &[path.to_string()],
+        )
+        .ok()
+        .and_then(|m| m.get(path).cloned());
+        let mut inner = self.inner.write().unwrap();
+        // If fallback was populated concurrently, prefer it.
+        if let Some(fb) = &inner.fallback {
+            return fb.get(path).cloned();
+        }
+        // Deduplicate: if another thread already cached this path, use it.
+        if let Some(cached) = inner.cache.get(path) {
+            return cached.clone();
+        }
+        inner.lookups += 1;
+        inner.cache.insert(path.to_string(), resolved.clone());
+        resolved
     }
 
     /// Whether nothing at all resolved, which says the revision could not be
     /// established rather than that the tree is empty.
     pub fn is_empty(&self) -> bool {
-        self.paths.is_empty()
+        if !self.valid {
+            return true;
+        }
+        let inner = self.inner.read().unwrap();
+        if let Some(fb) = &inner.fallback {
+            return fb.is_empty() && self.dirty.is_empty();
+        }
+        // Lazy without fallback: we have not proven the tree is empty; treat
+        // as non-empty so callers do not take the empty-revision fast path
+        // before any lookup has happened.
+        false
     }
 
     pub fn len(&self) -> usize {
-        self.paths.len()
+        let inner = self.inner.read().unwrap();
+        if let Some(fb) = &inner.fallback {
+            return fb.len();
+        }
+        inner.cache.len()
     }
 
     /// The paths as a map, for the callers that still hand one to git.
-    pub fn as_map(&self) -> &HashMap<String, String> {
-        &self.paths
+    /// Cloned because the lazy variant may need to materialise the fallback.
+    pub fn as_map(&self) -> HashMap<String, String> {
+        let inner = self.inner.read().unwrap();
+        if let Some(fb) = &inner.fallback {
+            return fb.clone();
+        }
+        // Materialise what we have cached (dirty is handled separately, so
+        // this is just the resolved subset).
+        inner
+            .cache
+            .iter()
+            .filter_map(|(k, v)| v.as_ref().map(|h| (k.clone(), h.clone())))
+            .collect()
     }
 }
 
@@ -333,7 +513,7 @@ where
     rows.into_iter()
         .filter(|row| {
             let (file, hash) = key(row);
-            paths.hash_of(file).map(|h| h == hash).unwrap_or(false)
+            paths.hash_of(file).as_deref() == Some(hash)
         })
         .collect()
 }

--- a/src/database/resolution.rs
+++ b/src/database/resolution.rs
@@ -465,6 +465,12 @@ impl RevisionPaths {
         resolved
     }
 
+    /// The revision these paths are for. Empty when the paths were handed in
+    /// already resolved, which is the only case that cannot name one.
+    pub fn revision(&self) -> &str {
+        &self.git_sha
+    }
+
     /// Whether nothing at all resolved, which says the revision could not be
     /// established rather than that the tree is empty.
     pub fn is_empty(&self) -> bool {

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -306,6 +306,32 @@ impl SchemaManager {
         Ok(())
     }
 
+    /// Record the commit whose tree was read in full. Written last at
+    /// the end of a full tree read, so an interrupted run cannot claim it.
+    /// A new key in `schema_meta`, not a new column, so no migration.
+    pub async fn set_tree_sha(&self, sha: &str) -> Result<()> {
+        let table = self.connection.open_table("schema_meta").execute().await?;
+        table
+            .delete("key = 'index:tree_sha'")
+            .await
+            .context("clearing index:tree_sha")?;
+        let schema = std::sync::Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("key", arrow::datatypes::DataType::Utf8, false),
+            arrow::datatypes::Field::new("value", arrow::datatypes::DataType::Utf8, false),
+        ]));
+        let batch = arrow::record_batch::RecordBatch::try_new(
+            schema,
+            vec![
+                std::sync::Arc::new(arrow::array::StringArray::from(vec!["index:tree_sha"]))
+                    as arrow::array::ArrayRef,
+                std::sync::Arc::new(arrow::array::StringArray::from(vec![sha]))
+                    as arrow::array::ArrayRef,
+            ],
+        )?;
+        table.add(vec![batch]).execute().await?;
+        Ok(())
+    }
+
     /// The value recorded under a key, absent when the index does not say.
     pub async fn meta_value(&self, key: &str) -> Result<Option<String>> {
         let names = self.connection.table_names().execute().await?;

--- a/src/git_range.rs
+++ b/src/git_range.rs
@@ -22,6 +22,10 @@ struct GitFileTuple {
     file_path: PathBuf,
     file_sha: String,
     object_id: gix::ObjectId,
+    /// The commit this file was read from. Recorded with the file, because it
+    /// is the only place that knows: a range run reads many commits, and a
+    /// row cannot say which tree it belongs to afterwards.
+    commit_sha: String,
 }
 
 /// Results from processing git file tuples (for database insertion batches)
@@ -172,6 +176,7 @@ fn stream_git_file_tuples_batch(
                 file_path: manifest_entry.relative_path.clone(),
                 file_sha: file_sha.clone(),
                 object_id: manifest_entry.object_id,
+                commit_sha: commit_sha.to_string(),
             };
 
             // Send tuple to channel - if channel is closed, workers are done
@@ -269,7 +274,7 @@ fn process_git_file_tuple_with_repo(
     // Track this file as processed
     let processed_file_record = ProcessedFileRecord {
         file: tuple.file_path.to_string_lossy().to_string(),
-        git_sha: None, // Will be set by caller if available
+        git_sha: Some(tuple.commit_sha.clone()),
         git_file_sha: tuple.file_sha.clone(),
         extractor_version: Some(crate::SCHEMA_VERSION),
     };
@@ -809,6 +814,7 @@ fn stream_tree_file_tuples(
             file_path: PathBuf::from(relative_path),
             file_sha,
             object_id: *object_id,
+            commit_sha: commit_sha.clone(),
         };
 
         // Send tuple to channel - if channel is closed, workers are done

--- a/src/git_range.rs
+++ b/src/git_range.rs
@@ -1201,6 +1201,21 @@ pub async fn process_git_tree(
     // in place and is re-read next time.
     db_manager.record_index_build(extensions, no_macros).await?;
 
+    // The whole tree at this commit has been read, so record which commit it
+    // was. Written last, after record_index_build, so an interrupted run
+    // cannot claim coverage it did not finish.
+    let tree_sha = gix::discover(repo_path)
+        .ok()
+        .and_then(|repo| {
+            crate::git::resolve_to_commit(&repo, commit_sha)
+                .ok()
+                .map(|c| c.id().to_string())
+        })
+        .unwrap_or_else(|| commit_sha.to_string());
+    if let Err(e) = db_manager.record_tree_sha(&tree_sha).await {
+        tracing::warn!("Failed to record index:tree_sha {}: {}", tree_sha, e);
+    }
+
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod treesitter_analyzer;
 mod types;
 mod vectorizer;
 pub mod workdir;
+pub mod worktree;
 
 // Query functionality modules
 pub mod callchain;

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// What the file on disk holds, against what the index recorded for it.
+//
+// A row carries the hash of the file it was extracted from, so the question
+// "is this row still what the file says" is one hash of one file. Asked per
+// file a query names, it replaces asking it of every file in the repository
+// before any query runs.
+use anyhow::Result;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::RwLock;
+
+/// The file on disk, relative to a hash the index holds for it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkingCopy {
+    /// The file holds exactly the content that hash describes.
+    Same,
+    /// The file exists and holds something else: an edit, or a row from
+    /// another revision. Which one it is takes a question to git.
+    Different,
+    /// There is no such file.
+    Absent,
+}
+
+/// The object id git would give this content.
+///
+/// A blob id is taken over `blob <len>\0` and then the bytes; hashing the
+/// bytes alone produces something that is not comparable with anything git or
+/// the index stores.
+pub fn blob_id(content: &[u8]) -> String {
+    use sha1::{Digest, Sha1};
+
+    let mut hasher = Sha1::new();
+    hasher.update(format!("blob {}\0", content.len()).as_bytes());
+    hasher.update(content);
+    hex::encode(hasher.finalize())
+}
+
+/// Hashes of files already read, so a query that names the same file twice —
+/// or a second query in the same process — reads it once.
+///
+/// Keyed on the size and modification time the file had when it was hashed,
+/// which is what git's own index does. A change that leaves both identical is
+/// missed, the same way git misses it; hashing costs 0.05ms for a 67KB source
+/// file, so a caller with reason to doubt can ask for a fresh read.
+#[derive(Default)]
+pub struct WorkingCopyHashes {
+    seen: RwLock<HashMap<String, (u64, i64, String)>>,
+}
+
+impl WorkingCopyHashes {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The blob id of a file on disk, or None if it is not there.
+    pub fn blob_id_of(&self, path: &Path) -> Result<Option<String>> {
+        let key = path.to_string_lossy().into_owned();
+        let Some(stat) = stat_of(path)? else {
+            self.seen.write().unwrap().remove(&key);
+            return Ok(None);
+        };
+
+        if let Some((size, mtime, hash)) = self.seen.read().unwrap().get(&key) {
+            if (*size, *mtime) == stat {
+                return Ok(Some(hash.clone()));
+            }
+        }
+
+        let hash = blob_id(&std::fs::read(path)?);
+        self.seen
+            .write()
+            .unwrap()
+            .insert(key, (stat.0, stat.1, hash.clone()));
+        Ok(Some(hash))
+    }
+
+    /// What the file holds, against a hash the index recorded.
+    pub fn compare(&self, path: &Path, indexed_hash: &str) -> Result<WorkingCopy> {
+        match self.blob_id_of(path)? {
+            None => Ok(WorkingCopy::Absent),
+            Some(hash) if hash == indexed_hash => Ok(WorkingCopy::Same),
+            Some(_) => Ok(WorkingCopy::Different),
+        }
+    }
+
+    /// Forget what is known about a path.
+    pub fn forget(&self, path: &Path) {
+        self.seen
+            .write()
+            .unwrap()
+            .remove(&path.to_string_lossy().into_owned());
+    }
+}
+
+fn stat_of(path: &Path) -> Result<Option<(u64, i64)>> {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) => {
+            let mtime = meta
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_nanos() as i64)
+                .unwrap_or(0);
+            Ok(Some((meta.len(), mtime)))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn git_hash_object(path: &Path) -> String {
+        let out = std::process::Command::new("git")
+            .args(["hash-object", path.to_str().unwrap()])
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "git hash-object failed");
+        String::from_utf8(out.stdout).unwrap().trim().to_string()
+    }
+
+    #[test]
+    fn a_blob_id_is_the_one_git_gives() {
+        // The authority for this is git, so ask git.
+        let dir = tempfile::tempdir().unwrap();
+        for content in ["", "int f(void)\n{\n\treturn 1;\n}\n", "\0\0binary\n"] {
+            let path = dir.path().join("file.c");
+            std::fs::write(&path, content).unwrap();
+            assert_eq!(
+                blob_id(content.as_bytes()),
+                git_hash_object(&path),
+                "content {content:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_file_matching_its_recorded_hash_is_the_same() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shared.c");
+        let content = "int shared(void)\n{\n\treturn 1;\n}\n";
+        std::fs::write(&path, content).unwrap();
+
+        let hashes = WorkingCopyHashes::new();
+        let recorded = blob_id(content.as_bytes());
+        assert_eq!(hashes.compare(&path, &recorded).unwrap(), WorkingCopy::Same);
+    }
+
+    #[test]
+    fn an_edited_file_differs_from_its_recorded_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shared.c");
+        std::fs::write(&path, "int shared(void)\n{\n\treturn 1;\n}\n").unwrap();
+        let hashes = WorkingCopyHashes::new();
+        let recorded = hashes.blob_id_of(&path).unwrap().unwrap();
+
+        // A different length, so the change is visible to stat as well.
+        std::fs::write(&path, "int shared(void)\n{\n\treturn 2; /* edited */\n}\n").unwrap();
+        assert_eq!(
+            hashes.compare(&path, &recorded).unwrap(),
+            WorkingCopy::Different
+        );
+    }
+
+    #[test]
+    fn a_missing_file_is_absent_and_forgotten() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gone.c");
+        std::fs::write(&path, "int gone(void)\n{\n\treturn 1;\n}\n").unwrap();
+        let hashes = WorkingCopyHashes::new();
+        let recorded = hashes.blob_id_of(&path).unwrap().unwrap();
+
+        std::fs::remove_file(&path).unwrap();
+        assert_eq!(
+            hashes.compare(&path, &recorded).unwrap(),
+            WorkingCopy::Absent
+        );
+        // A deleted file must not answer from what it used to hold.
+        assert_eq!(hashes.blob_id_of(&path).unwrap(), None);
+    }
+
+    #[test]
+    fn a_second_look_at_an_unchanged_file_reuses_the_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shared.c");
+        std::fs::write(&path, "int shared(void)\n{\n\treturn 1;\n}\n").unwrap();
+
+        let hashes = WorkingCopyHashes::new();
+        let first = hashes.blob_id_of(&path).unwrap().unwrap();
+
+        // Same size and mtime, different bytes: the memo answers, and this is
+        // the documented limit of it rather than a defect to fix.
+        let stat = std::fs::metadata(&path).unwrap();
+        std::fs::write(&path, "int shared(void)\n{\n\treturn 9;\n}\n").unwrap();
+        let file = std::fs::File::open(&path).unwrap();
+        file.set_times(
+            std::fs::FileTimes::new()
+                .set_modified(stat.modified().unwrap())
+                .set_accessed(stat.accessed().unwrap()),
+        )
+        .unwrap();
+
+        assert_eq!(hashes.blob_id_of(&path).unwrap().unwrap(), first);
+        hashes.forget(&path);
+        assert_ne!(hashes.blob_id_of(&path).unwrap().unwrap(), first);
+    }
+}

--- a/tests/revision_scoping.rs
+++ b/tests/revision_scoping.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// What a query answers when the index holds more revisions than the caller
+// asked about.
+use semcode::{git, DatabaseManager};
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+fn git_run(repo: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .env("GIT_AUTHOR_NAME", "Semcode Test")
+        .env("GIT_AUTHOR_EMAIL", "semcode@example.com")
+        .env("GIT_COMMITTER_NAME", "Semcode Test")
+        .env("GIT_COMMITTER_EMAIL", "semcode@example.com")
+        .status()
+        .unwrap();
+    assert!(status.success(), "git {args:?} failed");
+}
+
+fn head_of(repo: &Path) -> String {
+    git::get_git_sha(repo).unwrap().unwrap()
+}
+
+/// A repository with two branches, and an index holding both.
+///
+/// `shared.c` is on both branches. `only_on_topic.c` is on `topic` alone, so
+/// a query that says it wants `main` is asking about a tree that never
+/// contained `topic_only`.
+async fn two_branches() -> (tempfile::TempDir, Arc<DatabaseManager>, String, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path();
+
+    git_run(repo, &["init", "-q"]);
+    std::fs::write(
+        repo.join("shared.c"),
+        "int shared_function(void)\n{\n\
+\tint a = 1;\n\
+\tint b = 2;\n\
+\tint c = a + b + 42;\n\
+\tchar buf[64];\n\
+\tsnprintf(buf, sizeof(buf), \"%d\", c);\n\
+\treturn c + (int)strlen(buf);\n}\n",
+    )
+    .unwrap();
+    git_run(repo, &["add", "."]);
+    git_run(repo, &["commit", "-q", "-m", "shared"]);
+    git_run(repo, &["branch", "-M", "main"]);
+    let main_sha = head_of(repo);
+
+    git_run(repo, &["checkout", "-q", "-b", "topic"]);
+    std::fs::write(
+        repo.join("only_on_topic.c"),
+        "int topic_only(void)\n{\n\
+\tint x = 10;\n\
+\tint y = 20;\n\
+\tint z = x * y + 7;\n\
+\tchar tmp[64];\n\
+\tsnprintf(tmp, sizeof(tmp), \"topic %d\", z);\n\
+\treturn z + (int)strlen(tmp);\n}\n",
+    )
+    .unwrap();
+    git_run(repo, &["add", "."]);
+    git_run(repo, &["commit", "-q", "-m", "topic"]);
+    let topic_sha = head_of(repo);
+
+    let db = Arc::new(
+        DatabaseManager::new(
+            repo.join(".semcode.db").to_str().unwrap(),
+            repo.to_string_lossy().into_owned(),
+        )
+        .await
+        .unwrap(),
+    );
+    db.create_tables().await.unwrap();
+
+    let extensions = ["c".to_string(), "h".to_string()];
+    for sha in [&main_sha, &topic_sha] {
+        semcode::git_range::process_git_tree(repo, sha, &extensions, db.clone(), false, 1)
+            .await
+            .unwrap();
+    }
+
+    // Leave the checkout on main: the caller asks about main, and main is
+    // what is on disk.
+    git_run(repo, &["checkout", "-q", "main"]);
+
+    (dir, db, main_sha, topic_sha)
+}
+
+#[tokio::test]
+async fn a_function_from_another_branch_is_answered_for_this_one() {
+    // Pinned, not endorsed.
+    //
+    // `topic_only` exists only on `topic`. Asked for at `main`, the file it
+    // lives in does not exist, so no path resolves, and the lookup falls back
+    // to every revision in the index rather than reporting an absence:
+    //
+    //     if resolved_hashes.is_empty() {
+    //         tracing::warn!("No files resolved for '{}' at commit '{}'", name, git_sha);
+    //         // Fallback: get all functions and filter implementations
+    //
+    // The warning goes to a log, and the caller is told about a function that
+    // is not in the tree it named. This test records that, and is flipped by
+    // the patch that makes the revision decide.
+    let (_dir, db, main_sha, _topic_sha) = two_branches().await;
+
+    let found = db
+        .find_all_functions_git_aware("topic_only", &main_sha)
+        .await
+        .unwrap();
+
+    assert!(
+        !found.is_empty(),
+        "the fallback is gone; flip this test to assert the absence"
+    );
+    assert_eq!(found[0].name, "topic_only");
+}
+
+#[tokio::test]
+async fn a_function_on_this_branch_is_answered_for_it() {
+    // The control: whatever the patch does to the case above, this one has to
+    // keep working, at either revision.
+    let (_dir, db, main_sha, topic_sha) = two_branches().await;
+
+    for sha in [&main_sha, &topic_sha] {
+        let found = db
+            .find_all_functions_git_aware("shared_function", sha)
+            .await
+            .unwrap();
+        assert_eq!(found.len(), 1, "at {sha}: {found:?}");
+        assert_eq!(found[0].file_path, "shared.c");
+    }
+}
+
+#[tokio::test]
+async fn a_function_added_on_a_branch_is_answered_for_that_branch() {
+    let (_dir, db, _main_sha, topic_sha) = two_branches().await;
+
+    let found = db
+        .find_all_functions_git_aware("topic_only", &topic_sha)
+        .await
+        .unwrap();
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].file_path, "only_on_topic.c");
+}

--- a/tests/revision_scoping.rs
+++ b/tests/revision_scoping.rs
@@ -24,12 +24,28 @@ fn head_of(repo: &Path) -> String {
     git::get_git_sha(repo).unwrap().unwrap()
 }
 
-/// A repository with two branches, and an index holding both.
-///
-/// `shared.c` is on both branches. `only_on_topic.c` is on `topic` alone, so
-/// a query that says it wants `main` is asking about a tree that never
-/// contained `topic_only`.
+/// Which revisions the index was built from.
+#[derive(Copy, Clone, PartialEq)]
+enum Indexed {
+    /// Both branches, so every revision the tests ask about is in the index.
+    Both,
+    /// `main` alone, so `topic` is a revision the index has files for and
+    /// content for only at another revision.
+    MainOnly,
+}
+
 async fn two_branches() -> (tempfile::TempDir, Arc<DatabaseManager>, String, String) {
+    two_branches_indexing(Indexed::Both).await
+}
+
+/// A repository with two branches.
+///
+/// `shared.c` is on both, with different contents. `only_on_topic.c` is on
+/// `topic` alone, so a query that says it wants `main` is asking about a tree
+/// that never contained `topic_only`.
+async fn two_branches_indexing(
+    indexed: Indexed,
+) -> (tempfile::TempDir, Arc<DatabaseManager>, String, String) {
     let dir = tempfile::tempdir().unwrap();
     let repo = dir.path();
 
@@ -53,13 +69,30 @@ async fn two_branches() -> (tempfile::TempDir, Arc<DatabaseManager>, String, Str
     git_run(repo, &["checkout", "-q", "-b", "topic"]);
     std::fs::write(
         repo.join("only_on_topic.c"),
-        "int topic_only(void)\n{\n\
+        "struct topic_only_state {\n\
+\tint counter;\n\
+\tchar label[32];\n};\n\n\
+typedef struct topic_only_state topic_only_state_t;\n\n\
+int topic_only(void)\n{\n\
 \tint x = 10;\n\
 \tint y = 20;\n\
 \tint z = x * y + 7;\n\
 \tchar tmp[64];\n\
 \tsnprintf(tmp, sizeof(tmp), \"topic %d\", z);\n\
 \treturn z + (int)strlen(tmp);\n}\n",
+    )
+    .unwrap();
+    // shared.c differs between the branches, so `topic` holds content that an
+    // index built from `main` alone has never seen.
+    std::fs::write(
+        repo.join("shared.c"),
+        "int shared_function(void)\n{\n\
+\tint a = 3;\n\
+\tint b = 4;\n\
+\tint c = a * b + 42;\n\
+\tchar buf[64];\n\
+\tsnprintf(buf, sizeof(buf), \"topic %d\", c);\n\
+\treturn c + (int)strlen(buf);\n}\n",
     )
     .unwrap();
     git_run(repo, &["add", "."]);
@@ -77,7 +110,11 @@ async fn two_branches() -> (tempfile::TempDir, Arc<DatabaseManager>, String, Str
     db.create_tables().await.unwrap();
 
     let extensions = ["c".to_string(), "h".to_string()];
-    for sha in [&main_sha, &topic_sha] {
+    let revisions: Vec<&String> = match indexed {
+        Indexed::Both => vec![&main_sha, &topic_sha],
+        Indexed::MainOnly => vec![&main_sha],
+    };
+    for sha in revisions {
         semcode::git_range::process_git_tree(repo, sha, &extensions, db.clone(), false, 1)
             .await
             .unwrap();
@@ -91,32 +128,118 @@ async fn two_branches() -> (tempfile::TempDir, Arc<DatabaseManager>, String, Str
 }
 
 #[tokio::test]
-async fn a_function_from_another_branch_is_answered_for_this_one() {
-    // Pinned, not endorsed.
-    //
+async fn a_function_from_another_branch_is_not_answered_for_this_one() {
     // `topic_only` exists only on `topic`. Asked for at `main`, the file it
-    // lives in does not exist, so no path resolves, and the lookup falls back
-    // to every revision in the index rather than reporting an absence:
-    //
-    //     if resolved_hashes.is_empty() {
-    //         tracing::warn!("No files resolved for '{}' at commit '{}'", name, git_sha);
-    //         // Fallback: get all functions and filter implementations
-    //
-    // The warning goes to a log, and the caller is told about a function that
-    // is not in the tree it named. This test records that, and is flipped by
-    // the patch that makes the revision decide.
-    let (_dir, db, main_sha, _topic_sha) = two_branches().await;
+    // lives in is not in that tree, so the answer is that it is not there —
+    // where it does live is a separate question, which the index can answer.
+    let (_dir, db, main_sha, topic_sha) = two_branches().await;
 
     let found = db
         .find_all_functions_git_aware("topic_only", &main_sha)
         .await
         .unwrap();
+    assert!(
+        found.is_empty(),
+        "answered from another revision: {found:?}"
+    );
+
+    // The absence belongs to the revision, not to a missing row: the index
+    // holds the function, and answers for it where it does exist.
+    let row = db.find_function("topic_only").await.unwrap().unwrap();
+    assert_eq!(row.file_path, "only_on_topic.c");
+    assert_eq!(
+        db.find_all_functions_git_aware("topic_only", &topic_sha)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn a_single_function_lookup_is_not_answered_from_another_branch() {
+    // The same, through the lookup that returns one match and reaches the
+    // absence with a manifest rather than with a commit.
+    let (_dir, db, main_sha, topic_sha) = two_branches().await;
 
     assert!(
-        !found.is_empty(),
-        "the fallback is gone; flip this test to assert the absence"
+        db.find_function_git_aware("topic_only", &main_sha)
+            .await
+            .unwrap()
+            .is_none(),
+        "answered from another revision"
     );
-    assert_eq!(found[0].name, "topic_only");
+    assert!(
+        db.find_function_git_aware("topic_only", &topic_sha)
+            .await
+            .unwrap()
+            .is_some(),
+        "not answered at its own revision"
+    );
+}
+
+#[tokio::test]
+async fn a_type_from_another_branch_is_not_answered_for_this_one() {
+    // Types and typedefs have their own lookups, and had their own fallbacks.
+    let (_dir, db, main_sha, topic_sha) = two_branches().await;
+
+    let types = db
+        .find_types_git_aware("topic_only_state", &main_sha)
+        .await
+        .unwrap();
+    assert!(
+        types.is_empty(),
+        "answered from another revision: {types:?}"
+    );
+    assert_eq!(
+        db.find_types_git_aware("topic_only_state", &topic_sha)
+            .await
+            .unwrap()
+            .len(),
+        1,
+        "not answered at its own revision"
+    );
+
+    assert!(
+        db.find_typedef_git_aware("topic_only_state_t", &main_sha)
+            .await
+            .unwrap()
+            .is_none(),
+        "typedef answered from another revision"
+    );
+    assert!(
+        db.find_typedef_git_aware("topic_only_state_t", &topic_sha)
+            .await
+            .unwrap()
+            .is_some(),
+        "typedef not answered at its own revision"
+    );
+}
+
+#[tokio::test]
+async fn content_the_index_never_read_is_not_answered_from_the_revision_it_did() {
+    // The second leak, which is not a resolution failure: `shared.c` is in
+    // both trees with different contents, and the index holds only `main`.
+    // Asked at `topic` the path resolves, no row carries the blob it resolves
+    // to, and the answer used to be `main`'s row.
+    let (_dir, db, main_sha, topic_sha) = two_branches_indexing(Indexed::MainOnly).await;
+
+    let found = db
+        .find_all_functions_git_aware("shared_function", &topic_sha)
+        .await
+        .unwrap();
+    assert!(
+        found.is_empty(),
+        "answered with content from another revision: {found:?}"
+    );
+
+    // Same name, same path, and the revision that was indexed still answers.
+    let found = db
+        .find_all_functions_git_aware("shared_function", &main_sha)
+        .await
+        .unwrap();
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].file_path, "shared.c");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Instead of scanning the entire git repository and kernel tree every time semcode starts up, compare the file against the git hash when we first serve a query from that file.

This allows us to start up quickly, and in the common case, also serve requests quickly, because verifying a handful of files is much faster than verifying the entire tree.

Checking git hash of a file in the tree before serving a query about that file also makes it possible to determine that some content we might have otherwise served is not present on the current branch of the git tree, but only on a different branch.

Closes #49 