### PR TITLE
db: keep an object-like macro's expansion beside its name

### DIFF
--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -155,6 +155,7 @@ pub struct DatabaseManager {
     content_store: ContentStore,
     dispatch_site_store: crate::database::dispatch_sites::DispatchSiteStore,
     registration_store: crate::database::registrations::RegistrationStore,
+    object_macro_store: crate::database::object_macros::ObjectMacroStore,
     symbol_filename_store: SymbolFilenameStore,
     branch_store: IndexedBranchStore,
     workdir_index: std::sync::RwLock<Option<WorkdirIndex>>,
@@ -214,6 +215,9 @@ impl DatabaseManager {
                 connection.clone(),
             ),
             symbol_filename_store: SymbolFilenameStore::new(connection.clone()),
+            object_macro_store: crate::database::object_macros::ObjectMacroStore::new(
+                connection.clone(),
+            ),
             branch_store: IndexedBranchStore::new(connection.clone()),
             workdir_index: std::sync::RwLock::new(None),
             manifest_cache: std::sync::RwLock::new(None),
@@ -922,7 +926,10 @@ impl DatabaseManager {
             symbol_filename_pairs.push((type_info.name.clone(), type_info.file_path.clone()));
         }
 
-        // Note: Macros are now in functions, so no separate loop needed
+        // An object-like macro is stored twice on purpose: as a function,
+        // which is where a caller looks it up by name, and here with its
+        // expansion beside it, which is what reading a declaration needs.
+        let object_macros = Self::object_macros_among(&functions);
 
         // Step 3: Insert content and metadata in parallel
         let (content_result, func_result, type_result, symbol_filename_result) = tokio::join!(
@@ -962,6 +969,7 @@ impl DatabaseManager {
         func_result?;
         type_result?;
         symbol_filename_result?;
+        self.object_macro_store.insert_batch(object_macros).await?;
 
         Ok(())
     }
@@ -1357,15 +1365,45 @@ impl DatabaseManager {
         self.dispatch_site_store.find_by_caller(caller_name).await
     }
 
+    /// The object-like macros in a batch of extracted functions.
+    ///
+    /// A macro reaches the database as a function with no return type; an
+    /// object-like one also has no parameters, and its body is the whole
+    /// `#define`. The expansion is what follows the name — the alias or the
+    /// attribute — and is the only part a declaration needs.
+    fn object_macros_among(
+        functions: &[FunctionInfo],
+    ) -> Vec<crate::database::object_macros::ObjectMacro> {
+        functions
+            .iter()
+            .filter(|f| f.return_type.is_empty() && f.parameters.is_empty())
+            .filter_map(|f| {
+                let directive = f.body.trim_start().strip_prefix('#')?.trim_start();
+                if !directive.starts_with("define") {
+                    return None;
+                }
+                let expansion = f.body.split_once(&f.name).map(|(_, rest)| rest.trim())?;
+                Some(crate::database::object_macros::ObjectMacro {
+                    name: f.name.clone(),
+                    expansion: expansion.to_string(),
+                    file_path: f.file_path.clone(),
+                    git_file_hash: f.git_file_hash.clone(),
+                })
+            })
+            .collect()
+    }
+
     pub async fn insert_functions(&self, functions: Vec<FunctionInfo>) -> Result<()> {
         // Extract (symbol_name, filename) pairs for symbol_filename table
         let symbol_filename_pairs: Vec<(String, String)> = functions
             .iter()
             .map(|f| (f.name.clone(), f.file_path.clone()))
             .collect();
+        let object_macros = Self::object_macros_among(&functions);
 
         // Insert functions
         self.function_store.insert_batch(functions).await?;
+        self.object_macro_store.insert_batch(object_macros).await?;
 
         // Insert into symbol_filename table
         self.symbol_filename_store
@@ -2421,10 +2459,10 @@ impl DatabaseManager {
             return Ok(known.clone());
         }
 
-        let macros = self.function_store.object_like_macros().await?;
+        let macros = self.object_macro_store.all().await?;
         let bodies: HashMap<&str, &str> = macros
             .iter()
-            .map(|(name, body)| (name.as_str(), body.as_str()))
+            .map(|(name, expansion)| (name.as_str(), expansion.as_str()))
             .collect();
 
         let mut attributes = HashSet::new();

--- a/src/database/functions.rs
+++ b/src/database/functions.rs
@@ -329,68 +329,6 @@ impl FunctionStore {
         Ok(())
     }
 
-    /// Object-like macros and what they expand to.
-    ///
-    /// Stored so a declaration can be read: an identifier where a member name
-    /// would be may be an attribute, and only the expansion says which.
-    pub async fn object_like_macros(&self) -> Result<Vec<(String, String)>> {
-        let table = self.connection.open_table("functions").execute().await?;
-        let batches: Vec<RecordBatch> = table
-            .query()
-            .only_if("return_type = ''")
-            .select(lancedb::query::Select::columns(&["name", "body_hash"]))
-            .execute()
-            .await?
-            .try_collect()
-            .await?;
-
-        let mut named_hashes: Vec<(String, String)> = Vec::new();
-        for batch in &batches {
-            let column = |i: usize| {
-                batch
-                    .column(i)
-                    .as_any()
-                    .downcast_ref::<StringArray>()
-                    .expect("string column")
-            };
-            let (names, hashes) = (column(0), column(1));
-            for row in 0..batch.num_rows() {
-                if !hashes.is_null(row) {
-                    named_hashes
-                        .push((names.value(row).to_string(), hashes.value(row).to_string()));
-                }
-            }
-        }
-
-        let hashes: Vec<String> = named_hashes.iter().map(|(_, h)| h.clone()).collect();
-        let bodies = self.bulk_get_content(&hashes).await?;
-
-        let mut macros = Vec::new();
-        for (name, hash) in named_hashes {
-            let Some(definition) = bodies.get(&hash) else {
-                continue;
-            };
-            // `#define` and `# define` are both written, the second inside
-            // conditionals, which is exactly where an attribute macro lives.
-            let directive = definition
-                .trim_start()
-                .strip_prefix('#')
-                .map(str::trim_start);
-            if !directive.is_some_and(|d| d.starts_with("define")) {
-                continue;
-            }
-            // `#define NAME value` -> value, which is what an alias points at
-            // and what carries the attribute.
-            let expansion = definition
-                .split_once(&name)
-                .map(|(_, rest)| rest.trim())
-                .unwrap_or("");
-            macros.push((name, expansion.to_string()));
-        }
-
-        Ok(macros)
-    }
-
     pub async fn find_all_by_name(&self, name: &str) -> Result<Vec<FunctionInfo>> {
         let table = self.connection.open_table("functions").execute().await?;
         let escaped_name = name.replace("'", "''");

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -5,6 +5,7 @@ mod connection;
 pub mod content;
 pub mod dispatch_sites;
 mod functions;
+pub mod object_macros;
 pub mod processed_files;
 pub mod registrations;
 pub mod resolution;

--- a/src/database/object_macros.rs
+++ b/src/database/object_macros.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Object-like macros, kept with what they expand to.
+//
+// A declaration cannot be read without them: `struct { ... } __packed;` and
+// `struct { ... } lru_gen;` are the same shape to the grammar, and only the
+// expansion says that the first names no member. The expansion lives in
+// another file, so the question is asked of the whole set at once, here.
+use anyhow::Result;
+use arrow::array::{Array, ArrayRef, RecordBatch, RecordBatchIterator, StringArray, StringBuilder};
+use futures::TryStreamExt;
+use lancedb::connection::Connection;
+use lancedb::query::ExecutableQuery;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub struct ObjectMacroStore {
+    connection: Connection,
+}
+
+/// A macro and what it stands for.
+#[derive(Debug, Clone)]
+pub struct ObjectMacro {
+    pub name: String,
+    pub expansion: String,
+    pub file_path: String,
+    pub git_file_hash: String,
+}
+
+impl ObjectMacroStore {
+    pub fn new(connection: Connection) -> Self {
+        Self { connection }
+    }
+
+    pub async fn insert_batch(&self, macros: Vec<ObjectMacro>) -> Result<()> {
+        if macros.is_empty() {
+            return Ok(());
+        }
+
+        let mut names = StringBuilder::new();
+        let mut expansions = StringBuilder::new();
+        let mut files = StringBuilder::new();
+        let mut hashes = StringBuilder::new();
+        for entry in &macros {
+            names.append_value(&entry.name);
+            expansions.append_value(&entry.expansion);
+            files.append_value(&entry.file_path);
+            hashes.append_value(&entry.git_file_hash);
+        }
+
+        let batch = RecordBatch::try_from_iter(vec![
+            ("name", Arc::new(names.finish()) as ArrayRef),
+            ("expansion", Arc::new(expansions.finish()) as ArrayRef),
+            ("file_path", Arc::new(files.finish()) as ArrayRef),
+            ("git_file_hash", Arc::new(hashes.finish()) as ArrayRef),
+        ])?;
+
+        let table = self
+            .connection
+            .open_table("object_macros")
+            .execute()
+            .await?;
+        // One row per definition: re-reading a file it already holds stores
+        // the same row rather than a second copy.
+        let mut merge_insert = table.merge_insert(&["name", "file_path", "git_file_hash"]);
+        merge_insert
+            .when_matched_update_all(None)
+            .when_not_matched_insert_all();
+        let schema = batch.schema();
+        merge_insert
+            .execute(Box::new(RecordBatchIterator::new(vec![Ok(batch)], schema)))
+            .await?;
+
+        Ok(())
+    }
+
+    /// Every macro, by name, with what it expands to.
+    ///
+    /// The whole table is read: the caller needs the closure over aliases, and
+    /// the set is small — a Linux tree has some tens of thousands, against
+    /// six million `#define`s that cannot lead to an attribute and are not
+    /// stored.
+    pub async fn all(&self) -> Result<HashMap<String, String>> {
+        let table = match self.connection.open_table("object_macros").execute().await {
+            Ok(table) => table,
+            // An index written before this table existed. The version check
+            // asks for a re-index; until then there is nothing to read, and
+            // saying so is better than reading 159,455 bodies to find out.
+            Err(_) => return Ok(HashMap::new()),
+        };
+
+        let batches: Vec<RecordBatch> = table.query().execute().await?.try_collect().await?;
+
+        let mut macros = HashMap::new();
+        for batch in &batches {
+            let column = |i: usize| {
+                batch
+                    .column(i)
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("string column")
+            };
+            let (names, expansions) = (column(0), column(1));
+            for row in 0..batch.num_rows() {
+                // A macro defined in several files under one name: the first
+                // wins, and a disagreement between them is not a question a
+                // declaration can answer anyway.
+                macros
+                    .entry(names.value(row).to_string())
+                    .or_insert_with(|| expansions.value(row).to_string());
+            }
+        }
+
+        Ok(macros)
+    }
+}

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -33,7 +33,7 @@ pub enum OptimizeOutcome {
 /// 4: a registration can be recorded before its container type is known,
 ///    carrying the base and field path instead. A version 3 index has no
 ///    such rows at all: it dropped those registrations.
-pub const SCHEMA_VERSION: u32 = 4;
+pub const SCHEMA_VERSION: u32 = 5;
 
 pub struct SchemaManager {
     connection: Connection,
@@ -87,6 +87,10 @@ impl SchemaManager {
                 &["container_base_type", "container_field"],
             )
             .await?;
+        }
+
+        if !table_names.iter().any(|n| n == "object_macros") {
+            self.create_object_macros_table().await?;
         }
 
         if !table_names.iter().any(|n| n == "schema_meta") {
@@ -208,6 +212,32 @@ impl SchemaManager {
 
     /// Functions installed in struct members: `.read = my_read`. Resolution
     /// joins these against the members dispatch sites go through.
+    /// Object-like macros that can stand where a member name would.
+    ///
+    /// `struct { ... } __packed;` parses the same as `struct { ... } lru_gen;`,
+    /// so reading a declaration means knowing what the identifier expands to,
+    /// and the expansion is written in another file. Kept with the expansion
+    /// beside the name: the question is asked of the whole set at once, and
+    /// answering it from the functions table means fetching 159,455 macro
+    /// bodies out of the content store — 118,218 file opens for one `type`.
+    async fn create_object_macros_table(&self) -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            // What the macro stands for: an attribute outright, or the name of
+            // another macro that leads to one.
+            Field::new("expansion", DataType::Utf8, false),
+            Field::new("file_path", DataType::Utf8, false),
+            Field::new("git_file_hash", DataType::Utf8, false),
+        ]));
+
+        self.connection
+            .create_table("object_macros", vec![RecordBatch::new_empty(schema)])
+            .execute()
+            .await?;
+
+        Ok(())
+    }
+
     pub async fn create_registrations_table(&self) -> Result<()> {
         let schema = Arc::new(Schema::new(vec![
             Field::new("container_type", DataType::Utf8, false),


### PR DESCRIPTION
Reading a declaration needs to know what an identifier expands to — `struct { ... } __packed;` and `struct { ... } lru_gen;` are one shape to the grammar — and the answer was obtained by reading macro bodies out of the content store:

    type mm_struct          9.40s
    func try_to_free_pages  1.70s

    openat  118,218
    read    161,561

for one `type`. Finding the macros is cheap: 0.11s over 1,059,378 rows. What costs is fetching the 159,455 bodies that scan matches, one content lookup each — and 137,000 of them are function-like macros the question never concerned, because the only thing marking a macro in the functions table is an empty return type.

Store an object-like macro's expansion next to its name, where the question can be answered by reading it:

    type mm_struct          1.30s

Same answers: mm_struct still reads `mm_count` and `mm_mt` rather than `__randomize_layout.mm_mt`.

Only macros that can lead to an attribute are stored, as before — one stating an attribute outright, or one whose body is a single identifier that may lead to another that does. A Linux tree holds six million `#define`s and this table holds tens of thousands.

The index now holds something it did not, so SCHEMA_VERSION goes to 5 and an older index is asked to be read again. A build finding no such table reads an empty set rather than falling back to the scan this patch removes.

Assisted-by: claw:claude-opus-5