### PR TITLE
index more functions from arrays, typedefs, and tables

### DIFF
--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -1087,6 +1087,54 @@ impl DatabaseManager {
     /// whole tree's types are available. A row whose path cannot be resolved
     /// keeps an empty container and joins nothing, which is what it did
     /// before it was recorded at all.
+    /// Drop table rows whose claim the typedef does not support.
+    ///
+    /// `static bfa_isr_func_t bfa_isrs[N] = { ... }` is a table only because
+    /// `bfa_isr_func_t` is a typedef for a function pointer, and the file that
+    /// declares the table does not say so. The extractor records the claim and
+    /// the name; this is where it is checked, against the typedef the index
+    /// holds. An array of enum constants declared the same way keeps no rows.
+    async fn keep_verified_tables(
+        &self,
+        registrations: &mut Vec<crate::types::Registration>,
+        git_sha: &str,
+    ) -> Result<()> {
+        let claimed: HashSet<String> = registrations
+            .iter()
+            .filter(|r| r.member == crate::types::ARRAY_ELEMENT_MEMBER)
+            .filter_map(|r| r.container_base_type.clone())
+            .collect();
+        if claimed.is_empty() {
+            return Ok(());
+        }
+
+        let mut points_at_a_function = HashMap::new();
+        for name in claimed {
+            // A typedef the index does not hold cannot support the claim.
+            // Saying so costs a table; keeping it would invent one.
+            let verdict = match self.find_typedef_git_aware(&name, git_sha).await? {
+                Some(typedef) => {
+                    let underlying = typedef.underlying_type;
+                    underlying.contains("(*)") || underlying.contains("(*")
+                }
+                None => false,
+            };
+            points_at_a_function.insert(name, verdict);
+        }
+
+        registrations.retain(|r| {
+            let Some(claim) = r.container_base_type.as_deref() else {
+                return true;
+            };
+            if r.member != crate::types::ARRAY_ELEMENT_MEMBER {
+                return true;
+            }
+            points_at_a_function.get(claim).copied().unwrap_or(false)
+        });
+
+        Ok(())
+    }
+
     async fn resolve_chained_registrations(
         &self,
         registrations: &mut [crate::types::Registration],
@@ -1193,6 +1241,8 @@ impl DatabaseManager {
         );
         self.resolve_chained_registrations(&mut registrations, &manifest)
             .await?;
+        self.keep_verified_tables(&mut registrations, git_sha)
+            .await?;
         registrations.retain(|r| r.container_type == container_type);
 
         Ok(registrations)
@@ -1211,6 +1261,8 @@ impl DatabaseManager {
             |r| (r.file_path.as_str(), r.git_file_hash.as_str()),
         );
         self.resolve_chained_registrations(&mut registrations, &manifest)
+            .await?;
+        self.keep_verified_tables(&mut registrations, git_sha)
             .await?;
 
         Ok(registrations)
@@ -1265,6 +1317,8 @@ impl DatabaseManager {
             |r| (r.file_path.as_str(), r.git_file_hash.as_str()),
         );
         self.resolve_chained_registrations(&mut registrations, &manifest)
+            .await?;
+        self.keep_verified_tables(&mut registrations, git_sha)
             .await?;
         let stated = at_revision(
             self.dispatch_site_store.find_by_target(target).await?,

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -382,6 +382,16 @@ impl TreeSitterAnalyzer {
                 type: (_) @underlying_type
                 declarator: (type_identifier) @typedef_name
             ) @typedef
+
+            (type_definition
+                type: (_) @underlying_type
+                declarator: (function_declarator
+                    declarator: (parenthesized_declarator
+                        (pointer_declarator declarator: (type_identifier) @typedef_name)
+                    )
+                    parameters: (parameter_list) @pointer_params
+                )
+            ) @typedef
         "#,
         )?;
 
@@ -2385,6 +2395,7 @@ impl TreeSitterAnalyzer {
             let mut line_start = 0;
             let mut typedef_start_byte = 0;
             let mut typedef_end_byte = 0;
+            let mut pointer_params: Option<String> = None;
 
             for capture in m.captures {
                 let node = capture.node;
@@ -2398,6 +2409,12 @@ impl TreeSitterAnalyzer {
                     }
                     "underlying_type" => {
                         underlying_type = Some(text.to_string());
+                    }
+                    // `typedef void (*bfa_isr_func_t)(struct bfa_s *)` aliases
+                    // a function pointer, and the return type alone would read
+                    // as an alias for `void`. Spell what it points at.
+                    "pointer_params" => {
+                        pointer_params = Some(collapse_whitespace(text));
                     }
                     "typedef" => {
                         typedef_start_byte = node.start_byte();
@@ -2413,6 +2430,15 @@ impl TreeSitterAnalyzer {
             if let Some(name) = typedef_name {
                 // Get the complete typedef definition
                 let definition = &source[typedef_start_byte..typedef_end_byte];
+
+                // What a function-pointer typedef aliases is a pointer to a
+                // function, not the return type the grammar puts in `type`.
+                let underlying_type = match pointer_params {
+                    Some(params) => underlying_type
+                        .map(|returns| format!("{returns} (*){params}"))
+                        .or(Some(format!("(*){params}"))),
+                    None => underlying_type,
+                };
 
                 // Create TypeInfo with kind="typedef"
                 // Store underlying type info in the definition field
@@ -4972,6 +4998,43 @@ mod tests {
 
         let run = found.iter().find(|r| r.member == "run").unwrap();
         assert_eq!(run.container_type, "outer");
+    }
+
+    #[test]
+    fn a_typedef_for_a_function_pointer_is_recorded() {
+        // `typedef void (*bfa_isr_func_t)(struct bfa_s *)` puts the name
+        // inside a function declarator, so a query wanting a bare
+        // type_identifier matches nothing and the typedef is not recorded at
+        // all. Every table declared through one is then unrecognisable.
+        let mut analyzer = TreeSitterAnalyzer::new().unwrap();
+        let analysis = analyzer
+            .analyze_source_with_metadata(
+                "typedef void (*bfa_isr_func_t)(struct bfa_s *bfa);\n\
+                 typedef unsigned long sector_t;\n",
+                Path::new("bfa.h"),
+                "testhash",
+                None,
+            )
+            .unwrap();
+
+        let typedefs: Vec<&TypeInfo> = analysis
+            .types
+            .iter()
+            .filter(|t| t.kind == "typedef")
+            .collect();
+        let names: Vec<&str> = typedefs.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"bfa_isr_func_t"), "{names:?}");
+        assert!(names.contains(&"sector_t"), "{names:?}");
+
+        let pointer = typedefs
+            .iter()
+            .find(|t| t.name == "bfa_isr_func_t")
+            .unwrap();
+        assert!(
+            pointer.definition.contains("(*)"),
+            "a reader cannot tell it is a function pointer: {:?}",
+            pointer.definition
+        );
     }
 
     #[test]

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -2853,14 +2853,9 @@ impl TreeSitterAnalyzer {
                         // A macro's own parameter is not a function.
                         // `#define hypercall_update(hc) static_call_update(hv_hypercall, hc)`
                         // installs whatever a caller passes, and `hc` names
-                        // that nowhere. Scoped to static calls: a macro that
-                        // declares an ops table records its parameter on
-                        // purpose, which is a separate decision with its own
-                        // test.
+                        // that nowhere.
                         if let Some(names) = parameters.as_ref() {
-                            facts.registrations.retain(|r| {
-                                r.member != STATIC_CALL_MEMBER || !names.contains(&r.target)
-                            });
+                            facts.registrations.retain(|r| !names.contains(&r.target));
                         }
                         for registration in &mut facts.registrations {
                             registration.byte_start += body_start;
@@ -4915,24 +4910,25 @@ mod tests {
     }
 
     #[test]
-    fn a_macro_that_declares_an_ops_table_registers_it() {
-        // ACPI and the error-injection macros build tables this way: the
-        // macro declares the thing it initialises, so its type is stated.
+    fn a_macro_that_declares_a_table_records_no_function() {
+        // A macro that declares what it initialises does state the type, so
+        // this used to be recorded as `ops::run = fn`. But `fn` is the
+        // macro's own parameter: it names whatever a caller passes, which is
+        // to say nothing, and a row claiming a function called `fn` was
+        // installed is a claim about a function that does not exist.
+        //
+        // Over a Linux tree this shape recorded 16 rows across 12 macros, and
+        // none of them installed a function: `TNUM(_v, _m)` fills
+        // `tnum::value` with an integer, `XA_LIMIT(_min, _max)` fills
+        // `xa_limit::min`, `UVC_INFO_QUIRK(q)` fills a bitmask. They are value
+        // constructors, and what they fill is not callable.
         let found = registrations_of(
             "struct ops { int (*run)(void); };\n\
              #define DEFINE_OPS(name, fn) struct ops name = { .run = fn }\n",
             "test.c",
         );
 
-        assert_eq!(
-            found,
-            vec![(
-                "ops".to_string(),
-                "run".to_string(),
-                "fn".to_string(),
-                "DEFINE_OPS".to_string()
-            )]
-        );
+        assert!(found.is_empty(), "{found:?}");
     }
 
     #[test]

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -8,7 +8,7 @@ use tree_sitter::{Parser, Query, QueryCursor, Tree};
 
 use crate::types::{
     DispatchKind, DispatchSite, FieldInfo, FunctionInfo, GlobalTypeRegistry, MacroParams,
-    ParameterInfo, Registration, RegistrationKind, TypeInfo,
+    ParameterInfo, Registration, RegistrationKind, TypeInfo, ARRAY_ELEMENT_MEMBER,
 };
 // TemporaryCallRelationship import removed - call relationships are now embedded in function JSON columns
 use crate::hash::compute_file_hash;
@@ -428,6 +428,13 @@ impl TreeSitterAnalyzer {
                 function: (identifier) @macro_name
                 arguments: (argument_list) @macro_args
             ) @macro_call
+
+            (call_expression
+                function: (subscript_expression
+                    argument: (_) @array_name
+                    index: (_) @array_index
+                )
+            ) @array_call
         "#,
         )?;
 
@@ -855,6 +862,7 @@ impl TreeSitterAnalyzer {
             let mut receiver: Option<tree_sitter::Node> = None;
             let mut macro_name: Option<tree_sitter::Node> = None;
             let mut macro_args: Option<tree_sitter::Node> = None;
+            let mut array_name: Option<tree_sitter::Node> = None;
 
             for capture in call_match.captures {
                 match queries.call_query.capture_names()[capture.index as usize] {
@@ -868,6 +876,7 @@ impl TreeSitterAnalyzer {
                     "receiver" => receiver = Some(capture.node),
                     "macro_name" => macro_name = Some(capture.node),
                     "macro_args" => macro_args = Some(capture.node),
+                    "array_name" => array_name = Some(capture.node),
                     "pointer_expr" => {
                         // `(*fp)(...)`: a call through a pointer value, which
                         // the plain call pattern does not match at all.
@@ -887,6 +896,43 @@ impl TreeSitterAnalyzer {
                         }
                     }
                     _ => {}
+                }
+            }
+
+            // `table[i](...)`: the call names no function and no member, and
+            // the table it indexes is the only thing that says what it can
+            // reach. Record the table as the container, with every element a
+            // candidate — which is what a runtime index leaves open, and what
+            // the kernel's exit-handler and syscall tables are.
+            if let Some(array) = array_name {
+                // The thing indexed has to be nameable, or there is nothing
+                // to join a table against. A bare name is the table itself;
+                // a field is a table held in a struct, which receiver typing
+                // can still say something about. Anything else names no
+                // container — a macro body can parse as a subscripted call —
+                // and recording one would invent a table out of whatever text
+                // sat between the brackets.
+                let container = match array.kind() {
+                    "identifier" => Some(collapse_whitespace(&source_code[array.byte_range()])),
+                    "field_expression" => None,
+                    _ => continue,
+                };
+                let name = collapse_whitespace(&source_code[array.byte_range()]);
+                if !name.is_empty() {
+                    extraction.member_sites.push(RawDispatchSite {
+                        member: ARRAY_ELEMENT_MEMBER.to_string(),
+                        receiver_expr: Some(name),
+                        // A table is named, not typed: the array variable is
+                        // the container, and no struct declares a member of
+                        // this name, so the two cannot collide.
+                        receiver_type: container,
+                        receiver_base_type: None,
+                        receiver_field: None,
+                        kind: DispatchKind::ArrayElement,
+                        byte_start: array.start_byte(),
+                        line: array.start_position().row as u32 + 1,
+                        target: None,
+                    });
                 }
             }
 
@@ -1008,6 +1054,14 @@ impl TreeSitterAnalyzer {
         }
 
         for site in sites.iter_mut() {
+            // A table that named itself already has its container: asking
+            // the declaration what `kvm_vmx_exit_handlers` is answers `int`,
+            // which would replace the answer with a wrong one. A table held
+            // in a struct field has not, and typing its base is what would
+            // let it be resolved later.
+            if site.kind == DispatchKind::ArrayElement && site.receiver_type.is_some() {
+                continue;
+            }
             let Some(receiver) = site.receiver_expr.as_deref() else {
                 continue;
             };
@@ -1207,6 +1261,14 @@ impl TreeSitterAnalyzer {
             }
 
             if node.kind() != "initializer_list" {
+                continue;
+            }
+
+            // A table of function pointers names no type to fill and no
+            // member to fill it with. The table itself is the container, and
+            // every element is a way in.
+            if let Some(table) = Self::function_pointer_table(node, source) {
+                found.extend(Self::table_elements(node, source, &table));
                 continue;
             }
 
@@ -1469,6 +1531,102 @@ impl TreeSitterAnalyzer {
     /// outer type and the path `ops` are what this file proves; resolution
     /// turns them into the container, exactly as it does for a receiver that
     /// reads through a field.
+    /// The name of the array of function pointers this list initialises.
+    ///
+    /// ```text
+    /// static int (*kvm_vmx_exit_handlers[])(struct kvm_vcpu *vcpu) = {
+    ///         [EXIT_REASON_CPUID] = kvm_emulate_cpuid,
+    /// ```
+    ///
+    /// The declaration states `int`, which says nothing, and the elements
+    /// name an index rather than a member — so neither the type walk nor the
+    /// member walk can see this, and everything reached through such a table
+    /// looks uncalled. What identifies the slot is the table's own name.
+    ///
+    /// Recognised by shape: a declarator that is a function returning through
+    /// a parenthesised pointer to an array, which is how C spells an array of
+    /// function pointers and is not how it spells anything else.
+    fn function_pointer_table(list: tree_sitter::Node, source: &str) -> Option<String> {
+        let parent = list.parent()?;
+        if parent.kind() != "init_declarator" {
+            return None;
+        }
+
+        let mut node = parent.child_by_field_name("declarator")?;
+        let (mut saw_function, mut saw_pointer, mut saw_array) = (false, false, false);
+        loop {
+            match node.kind() {
+                "function_declarator" => saw_function = true,
+                "pointer_declarator" => saw_pointer = true,
+                "array_declarator" => saw_array = true,
+                "identifier" => break,
+                _ => {}
+            }
+            node = node
+                .child_by_field_name("declarator")
+                .or_else(|| node.named_child(0))?;
+        }
+
+        if !(saw_function && saw_pointer && saw_array) {
+            return None;
+        }
+
+        let name = source[node.byte_range()].to_string();
+        (!name.is_empty()).then_some(name)
+    }
+
+    /// The functions a table of function pointers holds.
+    ///
+    /// Both designated elements, `[EXIT_REASON_CPUID] = kvm_emulate_cpuid`,
+    /// and positional ones. The index is not recorded as the member: a call
+    /// through the table computes it at run time, so every element is a
+    /// candidate and recording which one would suggest a precision the join
+    /// does not have.
+    fn table_elements(list: tree_sitter::Node, source: &str, table: &str) -> Vec<RawRegistration> {
+        let mut found = Vec::new();
+        let mut cursor = list.walk();
+
+        for child in list.named_children(&mut cursor) {
+            let value = match child.kind() {
+                "initializer_pair" => match child.child_by_field_name("value") {
+                    Some(value) => value,
+                    None => continue,
+                },
+                "identifier" => child,
+                _ => continue,
+            };
+
+            let target_node = match value.kind() {
+                "identifier" => Some(value),
+                "pointer_expression" => value
+                    .child_by_field_name("argument")
+                    .filter(|a| a.kind() == "identifier"),
+                _ => None,
+            };
+            let Some(target_node) = target_node else {
+                continue;
+            };
+
+            let target = source[target_node.byte_range()].to_string();
+            if target.is_empty() {
+                continue;
+            }
+
+            found.push(RawRegistration {
+                container_type: table.to_string(),
+                container_base_type: None,
+                container_field: None,
+                member: ARRAY_ELEMENT_MEMBER.to_string(),
+                target,
+                byte_start: target_node.start_byte(),
+                line: target_node.start_position().row as u32 + 1,
+                kind: RegistrationKind::DesignatedInit,
+            });
+        }
+
+        found
+    }
+
     fn initializer_container(
         list: tree_sitter::Node,
         source: &str,
@@ -4814,6 +4972,105 @@ mod tests {
 
         let run = found.iter().find(|r| r.member == "run").unwrap();
         assert_eq!(run.container_type, "outer");
+    }
+
+    #[test]
+    fn a_table_of_function_pointers_records_its_elements() {
+        // kvm_vmx_exit_handlers is this shape. The declaration's type is
+        // `int`, and the elements name an exit reason rather than a member,
+        // so nothing else in the extractor sees these installations.
+        let found = registration_rows(
+            "int handle_cpuid(struct kvm_vcpu *vcpu);\n\
+             int handle_vmx_instruction(struct kvm_vcpu *vcpu);\n\
+             static int (*kvm_vmx_exit_handlers[])(struct kvm_vcpu *vcpu) = {\n\
+             \t[EXIT_REASON_CPUID] = handle_cpuid,\n\
+             \t[EXIT_REASON_VMCALL] = handle_vmx_instruction,\n\
+             };\n",
+            "vmx.c",
+        );
+
+        let targets: Vec<&str> = found.iter().map(|r| r.target.as_str()).collect();
+        assert!(targets.contains(&"handle_cpuid"), "{found:?}");
+        assert!(targets.contains(&"handle_vmx_instruction"), "{found:?}");
+        for row in &found {
+            assert_eq!(row.container_type, "kvm_vmx_exit_handlers");
+            assert_eq!(row.member, "[]");
+        }
+    }
+
+    #[test]
+    fn a_positional_table_records_its_elements() {
+        let found = registration_rows(
+            "int first(void);\n\
+             int second(void);\n\
+             static int (*table[])(void) = { first, second };\n",
+            "t.c",
+        );
+
+        let targets: Vec<&str> = found.iter().map(|r| r.target.as_str()).collect();
+        assert_eq!(targets, vec!["first", "second"], "{found:?}");
+    }
+
+    #[test]
+    fn an_array_of_structs_is_not_a_table_of_function_pointers() {
+        // `.read = f` inside an array of ops structs still records the member
+        // and the struct, not the array.
+        let found = registration_rows(
+            "struct ops { int (*read)(void); };\n\
+             int impl(void);\n\
+             static struct ops table[] = { [0] = { .read = impl } };\n",
+            "t.c",
+        );
+
+        let read = found.iter().find(|r| r.target == "impl").expect("dropped");
+        assert_eq!(read.member, "read");
+        assert_eq!(read.container_type, "ops");
+    }
+
+    #[test]
+    fn a_table_held_in_a_field_is_recorded_without_inventing_a_container() {
+        // `chip->get_delay[i]()` dispatches through an array a struct holds.
+        // The site is worth recording; the container is not knowable from
+        // the array name, because there is not one.
+        let (_functions, sites) = analyze(
+            "int azx_get_position(struct azx *chip, int i)\n\
+             {\n\
+             \treturn chip->get_delay[i](chip);\n\
+             }\n",
+            "hda.c",
+        );
+
+        let site = sites
+            .iter()
+            .find(|s| s.kind == DispatchKind::ArrayElement)
+            .expect("no array dispatch site");
+        assert_eq!(site.receiver_expr.as_deref(), Some("chip->get_delay"));
+        assert_eq!(
+            site.receiver_type, None,
+            "a field is not a table name: {site:?}"
+        );
+    }
+
+    #[test]
+    fn a_call_through_a_table_is_a_dispatch_site() {
+        let (_functions, sites) = analyze(
+            "int __vmx_handle_exit(struct kvm_vcpu *vcpu, int r)\n\
+             {\n\
+             \tint i = exit_reason.basic;\n\
+             \tif (!kvm_vmx_exit_handlers[i])\n\
+             \t\treturn 0;\n\
+             \treturn kvm_vmx_exit_handlers[i](vcpu);\n\
+             }\n",
+            "vmx.c",
+        );
+
+        let site = sites
+            .iter()
+            .find(|s| s.kind == DispatchKind::ArrayElement)
+            .expect("no array dispatch site");
+        assert_eq!(site.member, "[]");
+        assert_eq!(site.receiver_type.as_deref(), Some("kvm_vmx_exit_handlers"));
+        assert_eq!(site.caller_name, "__vmx_handle_exit");
     }
 
     #[test]

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -9,6 +9,7 @@ use tree_sitter::{Parser, Query, QueryCursor, Tree};
 use crate::types::{
     DispatchKind, DispatchSite, FieldInfo, FunctionInfo, GlobalTypeRegistry, MacroParams,
     ParameterInfo, Registration, RegistrationKind, TypeInfo, ARRAY_ELEMENT_MEMBER,
+    STATIC_CALL_MEMBER,
 };
 // TemporaryCallRelationship import removed - call relationships are now embedded in function JSON columns
 use crate::hash::compute_file_hash;
@@ -454,6 +455,13 @@ impl TreeSitterAnalyzer {
                     index: (_) @array_index
                 )
             ) @array_call
+
+            (call_expression
+                function: (call_expression
+                    function: (identifier) @static_call_name
+                    arguments: (argument_list (identifier) @static_call_key)
+                )
+            ) @static_call_site
         "#,
         )?;
 
@@ -882,6 +890,9 @@ impl TreeSitterAnalyzer {
             let mut macro_name: Option<tree_sitter::Node> = None;
             let mut macro_args: Option<tree_sitter::Node> = None;
             let mut array_name: Option<tree_sitter::Node> = None;
+            let mut static_call_name: Option<tree_sitter::Node> = None;
+            let mut static_call_key: Option<tree_sitter::Node> = None;
+            let mut static_call_site: Option<tree_sitter::Node> = None;
 
             for capture in call_match.captures {
                 match queries.call_query.capture_names()[capture.index as usize] {
@@ -896,6 +907,9 @@ impl TreeSitterAnalyzer {
                     "macro_name" => macro_name = Some(capture.node),
                     "macro_args" => macro_args = Some(capture.node),
                     "array_name" => array_name = Some(capture.node),
+                    "static_call_name" => static_call_name = Some(capture.node),
+                    "static_call_key" => static_call_key = Some(capture.node),
+                    "static_call_site" => static_call_site = Some(capture.node),
                     "pointer_expr" => {
                         // `(*fp)(...)`: a call through a pointer value, which
                         // the plain call pattern does not match at all.
@@ -923,6 +937,40 @@ impl TreeSitterAnalyzer {
             // reach. Record the table as the container, with every element a
             // candidate — which is what a runtime index leaves open, and what
             // the kernel's exit-handler and syscall tables are.
+            // `static_call(key)(vcpu)`: the callee is itself a call, naming
+            // the key that holds the function. The branch is patched at run
+            // time, so nothing here dispatches through a pointer.
+            if let (Some(name), Some(key), Some(call)) =
+                (static_call_name, static_call_key, static_call_site)
+            {
+                if source_code[name.byte_range()].trim() != "static_call" {
+                    continue;
+                }
+                // `kvm_x86_call(op)` writes `static_call(kvm_x86_##op)`,
+                // which parses as an identifier and the rest of the paste
+                // beside it. The name it means does not exist until the
+                // preprocessor makes it, and half of one joins to nothing, so
+                // the key has to be the only thing in there.
+                if key
+                    .parent()
+                    .is_some_and(|args| args.named_child_count() != 1)
+                {
+                    continue;
+                }
+                let key = source_code[key.byte_range()].to_string();
+                extraction.member_sites.push(RawDispatchSite {
+                    member: STATIC_CALL_MEMBER.to_string(),
+                    receiver_expr: Some(key.clone()),
+                    receiver_type: Some(key),
+                    receiver_base_type: None,
+                    receiver_field: None,
+                    kind: DispatchKind::StaticCall,
+                    byte_start: call.start_byte(),
+                    line: call.start_position().row as u32 + 1,
+                    target: None,
+                });
+            }
+
             if let Some(array) = array_name {
                 // The thing indexed has to be nameable, or there is nothing
                 // to join a table against. A bare name is the table itself;
@@ -1078,7 +1126,11 @@ impl TreeSitterAnalyzer {
             // which would replace the answer with a wrong one. A table held
             // in a struct field has not, and typing its base is what would
             // let it be resolved later.
-            if site.kind == DispatchKind::ArrayElement && site.receiver_type.is_some() {
+            if matches!(
+                site.kind,
+                DispatchKind::ArrayElement | DispatchKind::StaticCall
+            ) && site.receiver_type.is_some()
+            {
                 continue;
             }
             let Some(receiver) = site.receiver_expr.as_deref() else {
@@ -1280,6 +1332,11 @@ impl TreeSitterAnalyzer {
             }
 
             if let Some(registration) = Self::initcall(node, source) {
+                found.push(registration);
+                continue;
+            }
+
+            if let Some(registration) = Self::static_call_install(node, source) {
                 found.push(registration);
                 continue;
             }
@@ -1536,6 +1593,75 @@ impl TreeSitterAnalyzer {
         }
 
         members
+    }
+
+    /// A function installed in a static-call key.
+    ///
+    /// ```text
+    /// DEFINE_STATIC_CALL(kvm_x86_run, vmx_vcpu_run);
+    /// static_call_update(kvm_x86_run, svm_vcpu_run);
+    /// ```
+    ///
+    /// The key is a slot holding one function, and a call through it is
+    /// patched into a direct branch at run time. Nothing dispatches through a
+    /// pointer and nothing assigns one, so neither the member walk nor the
+    /// table walk sees this.
+    ///
+    /// A key built by pasting — the kernel writes `static_call(kvm_x86_##op)`
+    /// behind `kvm_x86_call(op)` — is not recorded, because the name does not
+    /// exist until the preprocessor makes it.
+    fn static_call_install(node: tree_sitter::Node, source: &str) -> Option<RawRegistration> {
+        let call = match node.kind() {
+            "expression_statement" => node.named_child(0)?,
+            "call_expression" => node,
+            _ => return None,
+        };
+        if call.kind() != "call_expression" {
+            return None;
+        }
+
+        let name = call.child_by_field_name("function")?;
+        if name.kind() != "identifier" {
+            return None;
+        }
+        let name = &source[name.byte_range()];
+        // Only these two install the function they name.
+        // `DEFINE_STATIC_CALL_NULL` and `DEFINE_STATIC_CALL_RET0` take a
+        // prototype in that position and install nothing or a stub:
+        // `DEFINE_STATIC_CALL_NULL(amd_pmu_branch_reset,
+        // amd_pmu_branch_reset_t)` names a type, and the key starts out NULL.
+        if !matches!(name, "DEFINE_STATIC_CALL" | "static_call_update") {
+            return None;
+        }
+
+        let arguments = call.child_by_field_name("arguments")?;
+        let mut cursor = arguments.walk();
+        let named: Vec<tree_sitter::Node> = arguments.named_children(&mut cursor).collect();
+        let [key, target] = named[..] else {
+            return None;
+        };
+        if key.kind() != "identifier" || target.kind() != "identifier" {
+            return None;
+        }
+
+        let (key, target) = (
+            source[key.byte_range()].to_string(),
+            source[target.byte_range()].to_string(),
+        );
+        if key.is_empty() || target.is_empty() {
+            return None;
+        }
+
+        Some(RawRegistration {
+            container_type: key,
+            container_base_type: None,
+            container_field: None,
+            member: STATIC_CALL_MEMBER.to_string(),
+            target,
+            byte_start: call.start_byte(),
+            line: call.start_position().row as u32 + 1,
+            kind: RegistrationKind::Assignment,
+        })
     }
 
     /// A function the kernel runs at boot, named by the macro that files it.
@@ -2723,6 +2849,18 @@ impl TreeSitterAnalyzer {
                         for site in &mut facts.sites {
                             site.byte_start += body_start;
                             site.line = body_line + site.line.saturating_sub(1);
+                        }
+                        // A macro's own parameter is not a function.
+                        // `#define hypercall_update(hc) static_call_update(hv_hypercall, hc)`
+                        // installs whatever a caller passes, and `hc` names
+                        // that nowhere. Scoped to static calls: a macro that
+                        // declares an ops table records its parameter on
+                        // purpose, which is a separate decision with its own
+                        // test.
+                        if let Some(names) = parameters.as_ref() {
+                            facts.registrations.retain(|r| {
+                                r.member != STATIC_CALL_MEMBER || !names.contains(&r.target)
+                            });
                         }
                         for registration in &mut facts.registrations {
                             registration.byte_start += body_start;
@@ -5171,6 +5309,94 @@ mod tests {
             pointer.definition.contains("(*)"),
             "a reader cannot tell it is a function pointer: {:?}",
             pointer.definition
+        );
+    }
+
+    #[test]
+    fn a_static_call_that_installs_nothing_records_nothing() {
+        // `DEFINE_STATIC_CALL_NULL(name, type)` takes a prototype in the
+        // second position and leaves the key NULL, so the name there is a
+        // type and nothing is installed.
+        let found = registration_rows(
+            "typedef void (*amd_pmu_branch_reset_t)(void);\n\
+             DEFINE_STATIC_CALL_NULL(amd_pmu_branch_reset, amd_pmu_branch_reset_t);\n",
+            "core.c",
+        );
+
+        assert!(
+            found.iter().all(|r| r.member != "()"),
+            "a prototype was recorded as an installed function: {found:?}"
+        );
+    }
+
+    #[test]
+    fn a_macro_parameter_is_not_an_installed_function() {
+        // `#define hypercall_update(hc) static_call_update(hv_hypercall, hc)`
+        // installs whatever a caller passes; `hc` names that nowhere.
+        let found = registration_rows(
+            "#define hypercall_update(hc) static_call_update(hv_hypercall, hc)\n",
+            "mshyperv.c",
+        );
+
+        assert!(
+            found.iter().all(|r| r.target != "hc"),
+            "a macro parameter was recorded as a function: {found:?}"
+        );
+    }
+
+    #[test]
+    fn a_static_call_key_holds_the_function_installed_in_it() {
+        let found = registration_rows(
+            "int vmx_vcpu_run(struct kvm_vcpu *vcpu);\n\
+             DEFINE_STATIC_CALL(kvm_x86_run, vmx_vcpu_run);\n",
+            "x86.c",
+        );
+
+        let row = found
+            .iter()
+            .find(|r| r.target == "vmx_vcpu_run")
+            .unwrap_or_else(|| panic!("not recorded: {found:?}"));
+        assert_eq!(row.container_type, "kvm_x86_run");
+        assert_eq!(row.member, "()");
+    }
+
+    #[test]
+    fn a_call_through_a_static_call_key_is_a_dispatch_site() {
+        let (_functions, sites) = analyze(
+            "int kvm_arch_vcpu_ioctl_run(struct kvm_vcpu *vcpu)\n\
+             {\n\
+             \tint r = 0;\n\
+             \tr = static_call(kvm_x86_run)(vcpu);\n\
+             \treturn r;\n\
+             }\n",
+            "x86.c",
+        );
+
+        let site = sites
+            .iter()
+            .find(|s| s.kind == DispatchKind::StaticCall)
+            .unwrap_or_else(|| panic!("no static call site: {sites:?}"));
+        assert_eq!(site.member, "()");
+        assert_eq!(site.receiver_type.as_deref(), Some("kvm_x86_run"));
+    }
+
+    #[test]
+    fn a_pasted_static_call_key_is_not_guessed() {
+        // `kvm_x86_call(op)` expands to `static_call(kvm_x86_##op)`; the name
+        // does not exist until the preprocessor makes it.
+        let (_functions, sites) = analyze(
+            "int f(struct kvm_vcpu *vcpu)\n\
+             {\n\
+             \tint r = 0;\n\
+             \tr = static_call(kvm_x86_##op)(vcpu);\n\
+             \treturn r;\n\
+             }\n",
+            "x86.c",
+        );
+
+        assert!(
+            sites.iter().all(|s| s.kind != DispatchKind::StaticCall),
+            "{sites:?}"
         );
     }
 

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -1279,6 +1279,11 @@ impl TreeSitterAnalyzer {
                 stack.push(child);
             }
 
+            if let Some(registration) = Self::initcall(node, source) {
+                found.push(registration);
+                continue;
+            }
+
             if node.kind() != "initializer_list" {
                 continue;
             }
@@ -1531,6 +1536,99 @@ impl TreeSitterAnalyzer {
         }
 
         members
+    }
+
+    /// A function the kernel runs at boot, named by the macro that files it.
+    ///
+    /// ```text
+    /// device_initcall(foo_init);
+    /// ```
+    ///
+    /// The macro puts a pointer to `foo_init` in a section that
+    /// `do_initcalls()` walks, so nothing in the source calls it and nothing
+    /// assigns it anywhere: the function reads as dead. What the file does say
+    /// is which level it is filed under, and that is what this records.
+    ///
+    /// No dispatch site is claimed. The call is a walk over a linker section
+    /// in another file, and pretending to know that from here would be a
+    /// guess. `registrations foo_init` answers; `callers foo_init` still says
+    /// nothing calls it, which remains true of the source.
+    fn initcall(node: tree_sitter::Node, source: &str) -> Option<RawRegistration> {
+        // File scope: an initcall inside a function is something else.
+        if node.kind() != "expression_statement" || node.parent()?.kind() != "translation_unit" {
+            return None;
+        }
+
+        let call = node
+            .named_child(0)
+            .filter(|c| c.kind() == "call_expression")?;
+        let level = call.child_by_field_name("function")?;
+        if level.kind() != "identifier" {
+            return None;
+        }
+        let level = &source[level.byte_range()];
+        if !Self::is_initcall_macro(level) {
+            return None;
+        }
+
+        let arguments = call.child_by_field_name("arguments")?;
+        let mut cursor = arguments.walk();
+        let named: Vec<tree_sitter::Node> = arguments.named_children(&mut cursor).collect();
+        let [target] = named[..] else {
+            return None;
+        };
+        if target.kind() != "identifier" {
+            return None;
+        }
+
+        let name = source[target.byte_range()].to_string();
+        if name.is_empty() {
+            return None;
+        }
+
+        Some(RawRegistration {
+            container_type: level.to_string(),
+            container_base_type: None,
+            container_field: None,
+            member: ARRAY_ELEMENT_MEMBER.to_string(),
+            target: name,
+            byte_start: target.start_byte(),
+            line: target.start_position().row as u32 + 1,
+            kind: RegistrationKind::DesignatedInit,
+        })
+    }
+
+    /// Whether a name files a function into an init or exit section.
+    ///
+    /// A closed family, spelled out rather than pattern-matched: `module_init`
+    /// is one and `mutex_init` is not, and a suffix rule cannot tell them
+    /// apart.
+    fn is_initcall_macro(name: &str) -> bool {
+        const LEVELS: &[&str] = &[
+            "early_initcall",
+            "pure_initcall",
+            "core_initcall",
+            "core_initcall_sync",
+            "postcore_initcall",
+            "postcore_initcall_sync",
+            "arch_initcall",
+            "arch_initcall_sync",
+            "subsys_initcall",
+            "subsys_initcall_sync",
+            "fs_initcall",
+            "fs_initcall_sync",
+            "rootfs_initcall",
+            "device_initcall",
+            "device_initcall_sync",
+            "late_initcall",
+            "late_initcall_sync",
+            "console_initcall",
+            "security_initcall",
+            "module_init",
+            "module_exit",
+            "subsys_initcall_entry",
+        ];
+        LEVELS.contains(&name)
     }
 
     /// The name of the array of function pointers this list initialises.
@@ -5073,6 +5171,50 @@ mod tests {
             pointer.definition.contains("(*)"),
             "a reader cannot tell it is a function pointer: {:?}",
             pointer.definition
+        );
+    }
+
+    #[test]
+    fn an_initcall_records_the_level_it_is_filed_under() {
+        // Nothing calls `foo_init` and nothing assigns it: the macro puts a
+        // pointer to it in a section, so without this it reads as dead code.
+        let found = registration_rows(
+            "static int foo_init(void)\n\
+             {\n\
+             \tint rc = 0;\n\
+             \treturn rc;\n\
+             }\n\
+             device_initcall(foo_init);\n",
+            "foo.c",
+        );
+
+        let row = found
+            .iter()
+            .find(|r| r.target == "foo_init")
+            .unwrap_or_else(|| panic!("initcall not recorded: {found:?}"));
+        assert_eq!(row.container_type, "device_initcall");
+        assert_eq!(row.member, "[]");
+    }
+
+    #[test]
+    fn a_call_that_merely_ends_in_init_is_not_an_initcall() {
+        // `module_init` is one of these and `mutex_init` is not; a suffix
+        // rule cannot tell them apart, which is why the family is spelled out.
+        let found = registration_rows(
+            "struct mutex { int x; };\n\
+             static struct mutex lock;\n\
+             int helper(void)\n\
+             {\n\
+             \tint value = 7;\n\
+             \treturn value;\n\
+             }\n\
+             mutex_init(lock);\n",
+            "foo.c",
+        );
+
+        assert!(
+            found.iter().all(|r| r.container_type != "mutex_init"),
+            "{found:?}"
         );
     }
 

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -215,6 +215,15 @@ pub struct TreeSitterAnalyzer {
     python_queries: &'static LanguageQueries,
 }
 
+/// A table of function pointers, and the typedef that hid that fact when the
+/// declaration did not spell it out.
+struct Table {
+    name: String,
+    /// The element type, when it is a name defined elsewhere. `None` means
+    /// the declarator itself said the elements are functions.
+    element_type: Option<String>,
+}
+
 impl TreeSitterAnalyzer {
     pub fn new() -> Result<Self> {
         // Initialize C parser and queries
@@ -1524,23 +1533,6 @@ impl TreeSitterAnalyzer {
         members
     }
 
-    /// The type an initializer list fills in, and the path of fields to reach
-    /// it from the type the file states.
-    ///
-    /// A list directly under a declaration or a compound literal names its
-    /// own type and the path is empty. A nested one does not:
-    ///
-    /// ```text
-    /// static struct nft_set_type nft_set_rbtree_type = {
-    ///         .ops = {
-    ///                 .activate = nft_rbtree_activate,
-    /// ```
-    ///
-    /// `activate` belongs to whatever `ops` is declared as within
-    /// `nft_set_type`, which lives with that struct rather than here. The
-    /// outer type and the path `ops` are what this file proves; resolution
-    /// turns them into the container, exactly as it does for a receiver that
-    /// reads through a field.
     /// The name of the array of function pointers this list initialises.
     ///
     /// ```text
@@ -1556,7 +1548,7 @@ impl TreeSitterAnalyzer {
     /// Recognised by shape: a declarator that is a function returning through
     /// a parenthesised pointer to an array, which is how C spells an array of
     /// function pointers and is not how it spells anything else.
-    fn function_pointer_table(list: tree_sitter::Node, source: &str) -> Option<String> {
+    fn function_pointer_table(list: tree_sitter::Node, source: &str) -> Option<Table> {
         let parent = list.parent()?;
         if parent.kind() != "init_declarator" {
             return None;
@@ -1577,12 +1569,34 @@ impl TreeSitterAnalyzer {
                 .or_else(|| node.named_child(0))?;
         }
 
-        if !(saw_function && saw_pointer && saw_array) {
+        let name = source[node.byte_range()].to_string();
+        if name.is_empty() {
             return None;
         }
 
-        let name = source[node.byte_range()].to_string();
-        (!name.is_empty()).then_some(name)
+        // Written out: `int (*handlers[])(struct kvm_vcpu *)`. The declarator
+        // says outright that the elements are functions.
+        if saw_function && saw_pointer && saw_array {
+            return Some(Table {
+                name,
+                element_type: None,
+            });
+        }
+
+        // Hidden behind a typedef: `static bfa_isr_func_t bfa_isrs[N]`. All
+        // the declarator says is that this is an array of something named
+        // elsewhere, so record which name and let the reader ask the typedef
+        // whether it is a function pointer. Guessing here would make a table
+        // out of every array of enum constants.
+        let declared = list.parent()?.parent()?.child_by_field_name("type")?;
+        if saw_array && !saw_function && declared.kind() == "type_identifier" {
+            return Some(Table {
+                name,
+                element_type: Some(source[declared.byte_range()].to_string()),
+            });
+        }
+
+        None
     }
 
     /// The functions a table of function pointers holds.
@@ -1592,7 +1606,11 @@ impl TreeSitterAnalyzer {
     /// through the table computes it at run time, so every element is a
     /// candidate and recording which one would suggest a precision the join
     /// does not have.
-    fn table_elements(list: tree_sitter::Node, source: &str, table: &str) -> Vec<RawRegistration> {
+    fn table_elements(
+        list: tree_sitter::Node,
+        source: &str,
+        table: &Table,
+    ) -> Vec<RawRegistration> {
         let mut found = Vec::new();
         let mut cursor = list.walk();
 
@@ -1623,8 +1641,12 @@ impl TreeSitterAnalyzer {
             }
 
             found.push(RawRegistration {
-                container_type: table.to_string(),
-                container_base_type: None,
+                container_type: table.name.clone(),
+                // Set only when a typedef stands between the declaration and
+                // the fact that these are functions: the row is a claim that
+                // holds if that name is a function-pointer typedef, and the
+                // reader checks it.
+                container_base_type: table.element_type.clone(),
                 container_field: None,
                 member: ARRAY_ELEMENT_MEMBER.to_string(),
                 target,
@@ -1637,6 +1659,23 @@ impl TreeSitterAnalyzer {
         found
     }
 
+    /// The type an initializer list fills in, and the path of fields to reach
+    /// it from the type the file states.
+    ///
+    /// A list directly under a declaration or a compound literal names its
+    /// own type and the path is empty. A nested one does not:
+    ///
+    /// ```text
+    /// static struct nft_set_type nft_set_rbtree_type = {
+    ///         .ops = {
+    ///                 .activate = nft_rbtree_activate,
+    /// ```
+    ///
+    /// `activate` belongs to whatever `ops` is declared as within
+    /// `nft_set_type`, which lives with that struct rather than here. The
+    /// outer type and the path `ops` are what this file proves; resolution
+    /// turns them into the container, exactly as it does for a receiver that
+    /// reads through a field.
     fn initializer_container(
         list: tree_sitter::Node,
         source: &str,
@@ -5035,6 +5074,49 @@ mod tests {
             "a reader cannot tell it is a function pointer: {:?}",
             pointer.definition
         );
+    }
+
+    #[test]
+    fn a_table_declared_through_a_typedef_is_a_claim_to_check() {
+        // `static bfa_isr_func_t bfa_isrs[N] = { ... }` says only that this
+        // is an array of something named elsewhere. Record the elements and
+        // the name, so the reader can ask the typedef whether they are
+        // functions; deciding here would need a file this one does not have.
+        let found = registration_rows(
+            "int bfa_isr_unhandled(void);\n\
+             int bfa_fcdiag_intr(void);\n\
+             static bfa_isr_func_t bfa_isrs[BFI_MC_MAX] = {\n\
+             \tbfa_isr_unhandled,\n\
+             \tbfa_fcdiag_intr,\n\
+             };\n",
+            "bfa_core.c",
+        );
+
+        assert_eq!(found.len(), 2, "{found:?}");
+        for row in &found {
+            assert_eq!(row.container_type, "bfa_isrs");
+            assert_eq!(row.member, "[]");
+            assert_eq!(
+                row.container_base_type.as_deref(),
+                Some("bfa_isr_func_t"),
+                "the claim to check is missing: {row:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_table_that_spells_out_its_functions_makes_no_claim() {
+        let found = registration_rows(
+            "int handle_cpuid(struct kvm_vcpu *vcpu);\n\
+             static int (*handlers[])(struct kvm_vcpu *vcpu) = {\n\
+             \t[EXIT_REASON_CPUID] = handle_cpuid,\n\
+             };\n",
+            "vmx.c",
+        );
+
+        let row = found.first().expect("dropped");
+        assert_eq!(row.container_type, "handlers");
+        assert_eq!(row.container_base_type, None);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -154,6 +154,14 @@ pub struct ResolvedDispatch {
     pub targets: Vec<String>,
 }
 
+/// The member recorded for a call through, or an installation into, an
+/// element of an array of function pointers.
+///
+/// A table has no members to name, so both sides of the join use this in
+/// place of one and the container is the array itself. No struct declares a
+/// member of this name, so a table cannot collide with a type.
+pub const ARRAY_ELEMENT_MEMBER: &str = "[]";
+
 /// How a dispatch site was written. Stored, so values are append-only.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DispatchKind {
@@ -170,6 +178,10 @@ pub enum DispatchKind {
     /// A candidate the source itself names, as the kernel's INDIRECT_CALL_n
     /// macros do to help the branch predictor.
     MacroDeclared,
+    /// `table[i](...)`: a call through an element of an array of function
+    /// pointers. The table is the container; a runtime index leaves every
+    /// element it holds a candidate.
+    ArrayElement,
 }
 
 impl DispatchKind {
@@ -181,6 +193,7 @@ impl DispatchKind {
             DispatchKind::PointerLocal => "pointer_local",
             DispatchKind::PointerParam => "pointer_param",
             DispatchKind::MacroDeclared => "macro_declared",
+            DispatchKind::ArrayElement => "array_element",
         }
     }
 
@@ -195,6 +208,7 @@ impl DispatchKind {
             "pointer_local" => Some(DispatchKind::PointerLocal),
             "pointer_param" => Some(DispatchKind::PointerParam),
             "macro_declared" => Some(DispatchKind::MacroDeclared),
+            "array_element" => Some(DispatchKind::ArrayElement),
             _ => None,
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -162,6 +162,14 @@ pub struct ResolvedDispatch {
 /// member of this name, so a table cannot collide with a type.
 pub const ARRAY_ELEMENT_MEMBER: &str = "[]";
 
+/// The member recorded for a call through, or an installation into, a
+/// static-call key.
+///
+/// A key holds one function, patched into the call site at run time, so there
+/// is no member and no index — the key is the whole slot. As with a table,
+/// both sides of the join use this in place of a member name.
+pub const STATIC_CALL_MEMBER: &str = "()";
+
 /// How a dispatch site was written. Stored, so values are append-only.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DispatchKind {
@@ -182,6 +190,9 @@ pub enum DispatchKind {
     /// pointers. The table is the container; a runtime index leaves every
     /// element it holds a candidate.
     ArrayElement,
+    /// `static_call(key)(...)`: a direct call patched at run time to whatever
+    /// was installed in the key.
+    StaticCall,
 }
 
 impl DispatchKind {
@@ -194,6 +205,7 @@ impl DispatchKind {
             DispatchKind::PointerParam => "pointer_param",
             DispatchKind::MacroDeclared => "macro_declared",
             DispatchKind::ArrayElement => "array_element",
+            DispatchKind::StaticCall => "static_call",
         }
     }
 
@@ -209,6 +221,7 @@ impl DispatchKind {
             "pointer_param" => Some(DispatchKind::PointerParam),
             "macro_declared" => Some(DispatchKind::MacroDeclared),
             "array_element" => Some(DispatchKind::ArrayElement),
+            "static_call" => Some(DispatchKind::StaticCall),
             _ => None,
         }
     }


### PR DESCRIPTION
1. bcd020d -- a table of function pointers becomes a container: [EXIT_REASON_X] = handler installs, table<args|i> dispatches, and the existing join connects them.
2. ed909d4 -- index function-pointer typedefs, which were never recorded at all because the name sits inside a function declarator.
3. 2c66ba8 -- tables whose element type hides behind a typedef (static bfa_isr_func_t bfa_isrs[]): the extractor records a claim, the reader verifies it against the typedef.
4. d54c8d0 -- record which level an initcall is filed under; no dispatch site is claimed, since the call is a walk over a linker section.
5. 0ffaca1 -- DEFINE_STATIC_CALL / static_call_update install into a key, static_call(key)(args) dispatches through it.
6. dadc779 -- stop recording a macro's own parameter as an installed function (TNUM(_v, _m) claimed a function called _v).

Net effect on a Linux tree: 115 dispatch tables holding 1,148 functions now resolve (was 0), plus 7,899 initcalls and 140 static-call installs; 1,989 false registrations removed. callers handle_vmx_instruction and callers kvm_handle_invalid_op -- your original two -- both answer.