### PR TITLE
name an object as the subject only when it holds what was stored

### DIFF
--- a/src/callchain.rs
+++ b/src/callchain.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::types::Handover;
 use crate::{DatabaseManager, FunctionInfo};
 use anstream::stdout;
 use anyhow::Result;
@@ -578,22 +579,37 @@ pub async fn show_registrations_to_writer(
 
             // Where that call puts it, and by what route: the slot is a
             // claim about the registrar, not about this call site.
-            if let (Some(subject_type), Some(subject_member)) =
-                (&argument.subject_type, &argument.subject_member)
+            let handover = db
+                .follow_handed_parameter(&argument.callee, argument.argument_index, git_sha)
+                .await?;
+
+            // The object is only the one this function was attached to if it
+            // holds the thing the callee stored into. `call_rcu(&inode->i_rcu,
+            // cb)` passes an rcu_head and the callback lands in
+            // rcu_head::func, so the inode is the subject. `request_irq(...,
+            // handler, ..., netdev->name, ...)` also passes a member, and the
+            // handler has nothing to do with it.
+            if let (
+                Some(subject_type),
+                Some(subject_member),
+                Some(Handover::StoredIn { container_type, .. }),
+            ) = (&argument.subject_type, &argument.subject_member, &handover)
             {
-                writeln!(
-                    writer,
-                    "     attached to {}::{}",
-                    subject_type.cyan(),
-                    subject_member.cyan(),
-                )?;
+                let holds = db
+                    .member_aggregate_git_aware(subject_type, subject_member, git_sha)
+                    .await?;
+                if holds.as_deref() == Some(container_type.as_str()) {
+                    writeln!(
+                        writer,
+                        "     attached to {}::{}",
+                        subject_type.cyan(),
+                        subject_member.cyan(),
+                    )?;
+                }
             }
 
-            match db
-                .follow_handed_parameter(&argument.callee, argument.argument_index, git_sha)
-                .await?
-            {
-                Some(crate::types::Handover::StoredIn {
+            match handover {
+                Some(Handover::StoredIn {
                     path,
                     container_type,
                     member,
@@ -605,7 +621,7 @@ pub async fn show_registrations_to_writer(
                     "called later".yellow(),
                     path.join(" -> ").bright_black(),
                 )?,
-                Some(crate::types::Handover::Invoked { path }) => writeln!(
+                Some(Handover::Invoked { path }) => writeln!(
                     writer,
                     "     calls it {} through {}",
                     "before returning".yellow(),

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -1334,6 +1334,21 @@ impl DatabaseManager {
         })
     }
 
+    /// The aggregate a member of a type is declared as, at a revision.
+    ///
+    /// `inode::i_rcu` is an `rcu_head`, which is what says the head a
+    /// callback was queued on belongs to that inode.
+    pub async fn member_aggregate_git_aware(
+        &self,
+        container_type: &str,
+        member: &str,
+        git_sha: &str,
+    ) -> Result<Option<String>> {
+        let manifest = self.git_manifest_cached(git_sha).await?;
+        self.field_aggregate(container_type, member, &manifest)
+            .await
+    }
+
     /// Where a call puts the function it is handed.
     ///
     /// `request_irq(irq, nic_intr, ...)` installs nothing by itself: the

--- a/tests/indirect_calls.rs
+++ b/tests/indirect_calls.rs
@@ -217,8 +217,13 @@ fn write_argument_fixture(repo: &Path) {
     .unwrap();
     std::fs::write(
         repo.join("rcu.c"),
-        "struct inode { int i_state; struct rcu_head i_rcu; };\n\
+        "struct rcu_head { void (*func)(struct rcu_head *head); };\n\
+         struct inode { int i_state; struct rcu_head i_rcu; };\n\
          static void i_callback(struct rcu_head *head) { }\n\
+         void call_rcu(struct rcu_head *head, void (*func)(struct rcu_head *))\n\
+         {\n\
+         \thead->func = func;\n\
+         }\n\
          static void destroy_inode(struct inode *inode)\n\
          {\n\
          \tcall_rcu(&inode->i_rcu, i_callback);\n\
@@ -369,6 +374,23 @@ async fn a_function_handed_to_a_call_is_recorded() {
     assert!(
         output.contains("called later"),
         "the timing was not reported:\n{output}"
+    );
+
+    // The call passes `netdev->name` too, and the handler has nothing to do
+    // with it: only an object holding what the callee stored is the subject.
+    assert!(
+        !output.contains("attached to"),
+        "an unrelated argument was reported as the subject:\n{output}"
+    );
+
+    let mut output = Vec::new();
+    semcode::callchain::show_registrations_to_writer(&db, "i_callback", &mut output, &git_sha)
+        .await
+        .unwrap();
+    let output = plain(&String::from_utf8(output).unwrap());
+    assert!(
+        output.contains("attached to inode::i_rcu"),
+        "the rcu_head's owner was not reported:\n{output}"
     );
 }
 


### PR DESCRIPTION
`request_irq(adapter->pdev->irq, e1000_intr, IRQF_SHARED, netdev->name, netdev)` was reported as attaching the handler to net_device::name. It passes a member of an object, which is the shape an attachment takes, but that member is the string the interrupt is named after and the handler never goes near it.

An object is the subject when it holds the thing the callee stored into: `call_rcu(&inode->i_rcu, cb)` passes an rcu_head, the callback lands in rcu_head::func, and inode::i_rcu is declared as an rcu_head. Check that, and the wrong claim goes away while the RCU ones stay.

Assisted-by: claw:claude-opus-5