### PR TITLE
Resolve 21,881 Rust callsites in the Linux kernel.

### DIFF
--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -156,6 +156,7 @@ pub struct DatabaseManager {
     dispatch_site_store: crate::database::dispatch_sites::DispatchSiteStore,
     registration_store: crate::database::registrations::RegistrationStore,
     argument_function_store: crate::database::argument_functions::ArgumentFunctionStore,
+    global_store: crate::database::globals::GlobalStore,
     object_macro_store: crate::database::object_macros::ObjectMacroStore,
     symbol_filename_store: SymbolFilenameStore,
     branch_store: IndexedBranchStore,
@@ -217,6 +218,7 @@ impl DatabaseManager {
             ),
             argument_function_store:
                 crate::database::argument_functions::ArgumentFunctionStore::new(connection.clone()),
+            global_store: crate::database::globals::GlobalStore::new(connection.clone()),
             symbol_filename_store: SymbolFilenameStore::new(connection.clone()),
             object_macro_store: crate::database::object_macros::ObjectMacroStore::new(
                 connection.clone(),
@@ -995,6 +997,11 @@ impl DatabaseManager {
         self.registration_store.insert_batch(registrations).await
     }
 
+    /// Record file-scope variables of aggregate type.
+    pub async fn insert_globals(&self, globals: Vec<crate::types::GlobalVariable>) -> Result<()> {
+        self.global_store.insert_batch(globals).await
+    }
+
     /// Record functions named as call arguments.
     pub async fn insert_argument_functions(
         &self,
@@ -1041,6 +1048,7 @@ impl DatabaseManager {
                 continue;
             }
             self.type_chained_receivers(&mut sites, &manifest).await?;
+            self.type_global_receivers(&mut sites, &manifest).await?;
 
             let mut dispatches = Vec::new();
             for site in sites {
@@ -1515,6 +1523,7 @@ impl DatabaseManager {
         }
 
         self.type_chained_receivers(&mut sites, &manifest).await?;
+        self.type_global_receivers(&mut sites, &manifest).await?;
 
         Ok(indirect_callers(
             &registrations,
@@ -1529,6 +1538,67 @@ impl DatabaseManager {
     /// field `f_op`. What `f_op` is declared as lives with struct file, in a
     /// header the analyzer was not looking at, so the last hop happens here,
     /// where the whole tree's types are available.
+    /// Type a receiver that names a file-scope variable declared elsewhere.
+    ///
+    /// `ppc_md.memory_block_size()` is written in a file that includes
+    /// machdep.h rather than containing it, so the analyzer sees a plain name
+    /// it cannot type. The declaration is in the index; the join happens here.
+    ///
+    /// A name declared with two different aggregates at one revision is left
+    /// alone: filing a site under the wrong type joins it with the wrong
+    /// registrations, which is worse than admitting the type is unknown.
+    async fn type_global_receivers(
+        &self,
+        sites: &mut [crate::types::DispatchSite],
+        manifest: &crate::database::resolution::RevisionPaths,
+    ) -> Result<()> {
+        let mut resolved: std::collections::HashMap<String, Option<String>> =
+            std::collections::HashMap::new();
+
+        for site in sites.iter_mut() {
+            if site.receiver_type.is_some() || site.receiver_base_type.is_some() {
+                continue;
+            }
+            let Some(receiver) = site.receiver_expr.as_deref() else {
+                continue;
+            };
+            let receiver = receiver.trim();
+            if receiver.is_empty()
+                || !receiver.chars().all(|c| c.is_alphanumeric() || c == '_')
+                || receiver.chars().next().is_some_and(|c| c.is_numeric())
+            {
+                continue;
+            }
+
+            let type_name = match resolved.get(receiver) {
+                Some(known) => known.clone(),
+                None => {
+                    let declarations = crate::database::resolution::at_revision(
+                        self.global_store.find_by_name(receiver).await?,
+                        manifest,
+                        |global| (global.file_path.as_str(), global.git_file_hash.as_str()),
+                    );
+                    let mut types: Vec<String> = declarations
+                        .into_iter()
+                        .map(|global| global.type_name)
+                        .collect();
+                    types.sort();
+                    types.dedup();
+                    let answer = match types.len() {
+                        1 => types.pop(),
+                        _ => None,
+                    };
+                    resolved.insert(receiver.to_string(), answer.clone());
+                    answer
+                }
+            };
+
+            site.receiver_type = type_name;
+        }
+
+        Ok(())
+    }
+
     async fn type_chained_receivers(
         &self,
         sites: &mut [crate::types::DispatchSite],

--- a/src/database/globals.rs
+++ b/src/database/globals.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Storage for file-scope variables of aggregate type: the ops tables a call
+// dispatches through without the calling file declaring them.
+use anyhow::Result;
+use arrow::array::{ArrayRef, Int64Builder, RecordBatch, RecordBatchIterator, StringArray};
+use arrow::array::{Int64Array, StringBuilder};
+use futures::TryStreamExt;
+use lancedb::connection::Connection;
+use lancedb::query::{ExecutableQuery, QueryBase};
+use std::sync::Arc;
+
+use crate::database::get_column;
+use crate::types::GlobalVariable;
+
+pub struct GlobalStore {
+    connection: Connection,
+}
+
+impl GlobalStore {
+    pub fn new(connection: Connection) -> Self {
+        Self { connection }
+    }
+
+    pub async fn insert_batch(&self, globals: Vec<GlobalVariable>) -> Result<()> {
+        if globals.is_empty() {
+            return Ok(());
+        }
+        let table = self.connection.open_table("globals").execute().await?;
+
+        let mut name = StringBuilder::new();
+        let mut type_name = StringBuilder::new();
+        let mut file_path = StringBuilder::new();
+        let mut git_file_hash = StringBuilder::new();
+        let mut line = Int64Builder::new();
+        for global in &globals {
+            name.append_value(&global.name);
+            type_name.append_value(&global.type_name);
+            file_path.append_value(&global.file_path);
+            git_file_hash.append_value(&global.git_file_hash);
+            line.append_value(global.line as i64);
+        }
+
+        let batch = RecordBatch::try_from_iter(vec![
+            ("name", Arc::new(name.finish()) as ArrayRef),
+            ("type_name", Arc::new(type_name.finish()) as ArrayRef),
+            ("file_path", Arc::new(file_path.finish()) as ArrayRef),
+            (
+                "git_file_hash",
+                Arc::new(git_file_hash.finish()) as ArrayRef,
+            ),
+            ("line", Arc::new(line.finish()) as ArrayRef),
+        ])?;
+
+        let mut merge_insert = table.merge_insert(&["file_path", "git_file_hash", "name"]);
+        merge_insert
+            .when_matched_update_all(None)
+            .when_not_matched_insert_all();
+        let schema = batch.schema();
+        merge_insert
+            .execute(Box::new(RecordBatchIterator::new(vec![Ok(batch)], schema)))
+            .await?;
+        Ok(())
+    }
+
+    /// Every declaration of this name, at any revision.
+    pub async fn find_by_name(&self, name: &str) -> Result<Vec<GlobalVariable>> {
+        let table = self.connection.open_table("globals").execute().await?;
+        let escaped = name.replace('\'', "''");
+        let batches = table
+            .query()
+            .only_if(format!("name = '{escaped}'"))
+            .execute()
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let mut out = Vec::new();
+        for batch in &batches {
+            let name = get_column::<StringArray>(batch, "name")?;
+            let type_name = get_column::<StringArray>(batch, "type_name")?;
+            let file_path = get_column::<StringArray>(batch, "file_path")?;
+            let git_file_hash = get_column::<StringArray>(batch, "git_file_hash")?;
+            let line = get_column::<Int64Array>(batch, "line")?;
+            for row in 0..batch.num_rows() {
+                out.push(GlobalVariable {
+                    name: name.value(row).to_string(),
+                    type_name: type_name.value(row).to_string(),
+                    file_path: file_path.value(row).to_string(),
+                    git_file_hash: git_file_hash.value(row).to_string(),
+                    line: line.value(row) as u32,
+                });
+            }
+        }
+        Ok(out)
+    }
+}

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -6,6 +6,7 @@ mod connection;
 pub mod content;
 pub mod dispatch_sites;
 mod functions;
+pub mod globals;
 pub mod object_macros;
 pub mod processed_files;
 pub mod registrations;

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -33,7 +33,7 @@ pub enum OptimizeOutcome {
 /// 4: a registration can be recorded before its container type is known,
 ///    carrying the base and field path instead. A version 3 index has no
 ///    such rows at all: it dropped those registrations.
-pub const SCHEMA_VERSION: u32 = 7;
+pub const SCHEMA_VERSION: u32 = 8;
 
 pub struct SchemaManager {
     connection: Connection,
@@ -87,6 +87,10 @@ impl SchemaManager {
                 &["container_base_type", "container_field"],
             )
             .await?;
+        }
+
+        if !table_names.iter().any(|n| n == "globals") {
+            self.create_globals_table().await?;
         }
 
         if !table_names.iter().any(|n| n == "argument_functions") {
@@ -238,6 +242,31 @@ impl SchemaManager {
             .create_table("object_macros", vec![RecordBatch::new_empty(schema)])
             .execute()
             .await?;
+
+        Ok(())
+    }
+
+    pub async fn create_globals_table(&self) -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("type_name", DataType::Utf8, false),
+            Field::new("file_path", DataType::Utf8, false),
+            Field::new("git_file_hash", DataType::Utf8, false),
+            Field::new("line", DataType::Int64, false),
+        ]));
+
+        let table = self
+            .connection
+            .create_table("globals", vec![RecordBatch::new_empty(schema)])
+            .execute()
+            .await?;
+
+        // Typing a receiver asks for one name.
+        table
+            .create_index(&["name"], lancedb::index::Index::Auto)
+            .execute()
+            .await
+            .ok();
 
         Ok(())
     }
@@ -633,6 +662,7 @@ impl SchemaManager {
         match name {
             "processed_files" => self.create_processed_files_table().await,
             "argument_functions" => self.create_argument_functions_table().await,
+            "globals" => self.create_globals_table().await,
             "registrations" => self.create_registrations_table().await,
             "dispatch_sites" => self.create_dispatch_sites_table().await,
             other => Err(anyhow::anyhow!("no way to recreate {other}")),

--- a/src/git_range.rs
+++ b/src/git_range.rs
@@ -2,7 +2,7 @@
 
 use crate::git::walk_tree_at_commit_with_repo;
 use crate::indexer::{list_shas_in_range, process_commits_pipeline};
-use crate::types::ArgumentFunction;
+use crate::types::{ArgumentFunction, GlobalVariable};
 use crate::{
     DatabaseManager, DispatchSite, FunctionInfo, GitFileEntry, GitFileManifestEntry,
     ProcessedFileRecord, Registration, TreeSitterAnalyzer, TypeInfo,
@@ -37,6 +37,7 @@ struct GitTupleResults {
     dispatch_sites: Vec<DispatchSite>,
     registrations: Vec<Registration>,
     argument_functions: Vec<ArgumentFunction>,
+    globals: Vec<GlobalVariable>,
     processed_files: Vec<ProcessedFileRecord>,
     files_processed: usize,
 }
@@ -48,6 +49,7 @@ impl GitTupleResults {
         self.dispatch_sites.extend(other.dispatch_sites);
         self.registrations.extend(other.registrations);
         self.argument_functions.extend(other.argument_functions);
+        self.globals.extend(other.globals);
         self.processed_files.extend(other.processed_files);
         self.files_processed += other.files_processed;
     }
@@ -258,12 +260,13 @@ fn process_git_file_tuple_with_repo(
 
     // Check analysis results
     let analysis = analysis_result?;
-    let (mut functions, types, dispatch_sites, registrations, argument_functions) = (
+    let (mut functions, types, dispatch_sites, registrations, argument_functions, globals) = (
         analysis.functions,
         analysis.types,
         analysis.dispatch_sites,
         analysis.registrations,
         analysis.argument_functions,
+        analysis.globals,
     );
     let macros = analysis.macros;
 
@@ -289,6 +292,7 @@ fn process_git_file_tuple_with_repo(
         dispatch_sites,
         registrations,
         argument_functions,
+        globals,
         processed_files: vec![processed_file_record],
         files_processed: 1,
     };
@@ -626,6 +630,7 @@ async fn process_git_tuples_streaming(config: StreamingConfig) -> Result<GitTupl
                             dispatch_result,
                             registration_result,
                             argument_function_result,
+                            global_result,
                             processed_files_result,
                         ) = tokio::join!(
                             async {
@@ -665,6 +670,13 @@ async fn process_git_tuples_streaming(config: StreamingConfig) -> Result<GitTupl
                                     db_manager_clone
                                         .insert_argument_functions(batch.argument_functions)
                                         .await
+                                } else {
+                                    Ok(())
+                                }
+                            },
+                            async {
+                                if !batch.globals.is_empty() {
+                                    db_manager_clone.insert_globals(batch.globals).await
                                 } else {
                                     Ok(())
                                 }
@@ -713,6 +725,10 @@ async fn process_git_tuples_streaming(config: StreamingConfig) -> Result<GitTupl
                                 "Inserter {} failed to insert argument functions: {}",
                                 inserter_id, e
                             );
+                            insertion_successful = false;
+                        }
+                        if let Err(e) = global_result {
+                            error!("Inserter {} failed to insert globals: {}", inserter_id, e);
                             insertion_successful = false;
                         }
                         if let Err(e) = processed_files_result {
@@ -990,6 +1006,7 @@ async fn process_git_tree_streaming(config: TreeStreamingConfig) -> Result<GitTu
                             dispatch_result,
                             registration_result,
                             argument_function_result,
+                            global_result,
                             processed_files_result,
                         ) = tokio::join!(
                             async {
@@ -1029,6 +1046,13 @@ async fn process_git_tree_streaming(config: TreeStreamingConfig) -> Result<GitTu
                                     db_manager_clone
                                         .insert_argument_functions(batch.argument_functions)
                                         .await
+                                } else {
+                                    Ok(())
+                                }
+                            },
+                            async {
+                                if !batch.globals.is_empty() {
+                                    db_manager_clone.insert_globals(batch.globals).await
                                 } else {
                                     Ok(())
                                 }
@@ -1076,6 +1100,10 @@ async fn process_git_tree_streaming(config: TreeStreamingConfig) -> Result<GitTu
                                 "Inserter {} failed to insert argument functions: {}",
                                 inserter_id, e
                             );
+                            insertion_successful = false;
+                        }
+                        if let Err(e) = global_result {
+                            error!("Inserter {} failed to insert globals: {}", inserter_id, e);
                             insertion_successful = false;
                         }
                         if let Err(e) = processed_files_result {

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -1043,8 +1043,12 @@ impl TreeSitterAnalyzer {
         language: Language,
     ) -> Result<FileAnalysis> {
         // Single pass: extract all calls once and map them to functions by byte ranges
-        let extraction =
-            Self::extract_all_calls_optimized(self.get_queries(language), tree, source_code)?;
+        let extraction = Self::extract_all_calls_optimized(
+            self.get_queries(language),
+            tree,
+            source_code,
+            language,
+        )?;
 
         // Create extraction context
         let ctx = ExtractionContext {
@@ -1101,6 +1105,7 @@ impl TreeSitterAnalyzer {
         queries: &LanguageQueries,
         tree: &Tree,
         source_code: &str,
+        language: Language,
     ) -> Result<CallExtraction> {
         let mut extraction = CallExtraction::default();
         let mut cursor = QueryCursor::new();
@@ -1281,7 +1286,16 @@ impl TreeSitterAnalyzer {
             .registrations
             .extend(Self::collect_assignments(tree.root_node(), source_code));
 
-        Self::type_receivers(tree.root_node(), source_code, &mut extraction.member_sites);
+        // The shapes a declaration takes differ per language, so each gets
+        // the pass that can read it.
+        match language {
+            Language::Rust => Self::type_rust_receivers(
+                tree.root_node(),
+                source_code,
+                &mut extraction.member_sites,
+            ),
+            _ => Self::type_receivers(tree.root_node(), source_code, &mut extraction.member_sites),
+        }
 
         // A keyword is not a member, so anything named after one came from a
         // misread, not from the code. Neither is a member reached from
@@ -1302,6 +1316,132 @@ impl TreeSitterAnalyzer {
             .retain(|registration| !Self::is_c_keyword(&registration.member));
 
         Ok(extraction)
+    }
+
+    /// Give each Rust dispatch site the type of its receiver.
+    ///
+    /// Rust states the type of every parameter and of every annotated
+    /// binding, and `self` is whatever the enclosing `impl` names, so a
+    /// receiver that is a plain name can be typed without leaving the file.
+    /// C needs its own pass because the shapes differ; this one reads
+    /// `function_item`, `parameter` and `let_declaration`.
+    fn type_rust_receivers(root: tree_sitter::Node, source: &str, sites: &mut [RawDispatchSite]) {
+        if sites.is_empty() {
+            return;
+        }
+
+        let mut scopes: Vec<(usize, usize, HashMap<String, String>)> = Vec::new();
+        let mut stack = vec![(root, None::<String>)];
+        while let Some((node, self_type)) = stack.pop() {
+            // `impl Foo { ... }` is what `self` means inside.
+            let self_type = if node.kind() == "impl_item" {
+                node.child_by_field_name("type")
+                    .and_then(|t| Self::rust_type_name(t, source))
+                    .or(self_type)
+            } else {
+                self_type
+            };
+
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                stack.push((child, self_type.clone()));
+            }
+
+            if node.kind() != "function_item" {
+                continue;
+            }
+
+            let mut declared = HashMap::new();
+            if let Some(self_type) = &self_type {
+                declared.insert("self".to_string(), self_type.clone());
+            }
+            Self::rust_declared_types_in(node, source, &mut declared);
+            scopes.push((node.start_byte(), node.end_byte(), declared));
+        }
+
+        for site in sites.iter_mut() {
+            if site.receiver_type.is_some() {
+                continue;
+            }
+            let Some(receiver) = site.receiver_expr.as_deref() else {
+                continue;
+            };
+            if !is_plain_name(receiver) {
+                continue;
+            }
+            let Some((_, _, declared)) = scopes
+                .iter()
+                .find(|(start, end, _)| site.byte_start >= *start && site.byte_start < *end)
+            else {
+                continue;
+            };
+            if let Some(type_name) = declared.get(receiver) {
+                site.receiver_type = Some(type_name.clone());
+            }
+        }
+    }
+
+    /// Names a Rust body binds to a stated type: parameters, and bindings
+    /// annotated at the `let`. An inferred binding states nothing here, and
+    /// guessing from the initialiser would need the callee's return type.
+    fn rust_declared_types_in(
+        node: tree_sitter::Node,
+        source: &str,
+        out: &mut HashMap<String, String>,
+    ) {
+        let mut stack = vec![node];
+        while let Some(current) = stack.pop() {
+            let mut cursor = current.walk();
+            for child in current.children(&mut cursor) {
+                // A nested closure or item has its own bindings; the outer
+                // ones still apply, so keep walking.
+                stack.push(child);
+            }
+            if !matches!(current.kind(), "parameter" | "let_declaration") {
+                continue;
+            }
+            let (Some(pattern), Some(type_node)) = (
+                current.child_by_field_name("pattern"),
+                current.child_by_field_name("type"),
+            ) else {
+                continue;
+            };
+            if pattern.kind() != "identifier" {
+                continue;
+            }
+            let Some(type_name) = Self::rust_type_name(type_node, source) else {
+                continue;
+            };
+            out.insert(source[pattern.byte_range()].to_string(), type_name);
+        }
+    }
+
+    /// The name a Rust type node denotes, with references, lifetimes and
+    /// generic arguments removed: `&mut fmt::Formatter<'_>` is a Formatter.
+    ///
+    /// A raw pointer is not stripped. `&T` reaches T's methods by
+    /// autoderef, so a call on it dispatches on T, but `(*mut T).cast()` is
+    /// a method of the pointer, and typing the receiver as T would claim a
+    /// member T does not have.
+    fn rust_type_name(node: tree_sitter::Node, source: &str) -> Option<String> {
+        let mut node = node;
+        loop {
+            match node.kind() {
+                "reference_type" => {
+                    node = node.child_by_field_name("type")?;
+                }
+                "generic_type" => {
+                    node = node.child_by_field_name("type")?;
+                }
+                "scoped_type_identifier" => {
+                    node = node.child_by_field_name("name")?;
+                }
+                "type_identifier" | "primitive_type" | "identifier" => {
+                    return Some(source[node.byte_range()].to_string());
+                }
+                _ => return None,
+            }
+        }
     }
 
     /// Give each member dispatch the type of its receiver, where the file
@@ -2991,7 +3131,7 @@ impl TreeSitterAnalyzer {
     ) -> Result<Vec<FunctionInfo>> {
         // Use the optimized approach but without pre-computed calls (for compatibility)
         let extraction =
-            Self::extract_all_calls_optimized(self.get_queries(language), tree, source)?;
+            Self::extract_all_calls_optimized(self.get_queries(language), tree, source, language)?;
         let ctx = ExtractionContext {
             tree,
             source,
@@ -4562,10 +4702,11 @@ impl TreeSitterAnalyzer {
         // A macro body dispatches like any other code: `((o)->run())` is a
         // call through a member wherever it is written. Positions are in the
         // wrapped text, and the caller maps them back to the file.
-        let mut sites = match Self::extract_all_calls_optimized(queries, &tree, &wrapped) {
-            Ok(extraction) => extraction.member_sites,
-            Err(_) => Vec::new(),
-        };
+        let mut sites =
+            match Self::extract_all_calls_optimized(queries, &tree, &wrapped, Language::C) {
+                Ok(extraction) => extraction.member_sites,
+                Err(_) => Vec::new(),
+            };
 
         // A macro body can install a function as well as call one, when it
         // declares the thing it initialises:
@@ -6828,6 +6969,64 @@ mod parameter_fate_tests {
     fn a_parameter_only_read_has_no_fate() {
         let body = "static int add(int a, int b) { return a + b; }\n";
         assert!(TreeSitterAnalyzer::parameter_fate(body, "a").is_empty());
+    }
+}
+
+#[cfg(test)]
+mod rust_receiver_tests {
+    use super::*;
+
+    fn sites_of(source: &str) -> Vec<RawDispatchSite> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        let queries = TreeSitterAnalyzer::rust_queries().unwrap();
+        let mut extraction =
+            TreeSitterAnalyzer::extract_all_calls_optimized(queries, &tree, source, Language::Rust)
+                .unwrap();
+        std::mem::take(&mut extraction.member_sites)
+    }
+
+    fn receiver_type_of(sites: &[RawDispatchSite], member: &str) -> Option<String> {
+        sites
+            .iter()
+            .find(|site| site.member == member)
+            .and_then(|site| site.receiver_type.clone())
+    }
+
+    #[test]
+    fn self_is_the_type_the_impl_names() {
+        let sites = sites_of(
+            "struct VmallocPageIter;\n\
+             impl<'a> Iterator for VmallocPageIter<'a> {\n\
+             \tfn next(&mut self) -> Option<u32> { self.size() }\n\
+             }\n",
+        );
+        assert_eq!(
+            receiver_type_of(&sites, "size").as_deref(),
+            Some("VmallocPageIter"),
+            "{sites:?}"
+        );
+    }
+
+    #[test]
+    fn a_parameter_is_typed_from_its_declaration() {
+        let sites = sites_of("fn show(fmt: &mut fmt::Formatter<'_>) { fmt.write_str(\"x\"); }\n");
+        assert_eq!(
+            receiver_type_of(&sites, "write_str").as_deref(),
+            Some("Formatter"),
+            "{sites:?}"
+        );
+    }
+
+    #[test]
+    fn a_raw_pointer_is_not_its_pointee() {
+        // `.cast()` belongs to the pointer. Typing the receiver as `request`
+        // would claim a member that struct does not have.
+        let sites = sites_of("fn f(ptr: *mut request) { ptr.cast(); }\n");
+        assert_eq!(receiver_type_of(&sites, "cast"), None, "{sites:?}");
     }
 }
 

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -1431,7 +1431,32 @@ impl TreeSitterAnalyzer {
                     node = node.child_by_field_name("type")?;
                 }
                 "generic_type" => {
-                    node = node.child_by_field_name("type")?;
+                    // A call through a smart pointer dispatches on what it
+                    // holds: `Arc<TagSet>::raw_tag_set` is a method of
+                    // TagSet, reached by Deref. Only pointers that deref to
+                    // their argument are seen through; `Vec<T>` has methods
+                    // of its own and is not one.
+                    let base = node.child_by_field_name("type")?;
+                    let base_name = Self::rust_type_name(base, source)?;
+                    if !matches!(
+                        base_name.as_str(),
+                        "Arc" | "Rc" | "Box" | "Pin" | "ARef" | "KBox" | "UniqueArc" | "Owned"
+                    ) {
+                        return Some(base_name);
+                    }
+                    let held = node
+                        .child_by_field_name("type_arguments")
+                        .and_then(|arguments| {
+                            let mut cursor = arguments.walk();
+                            let found = arguments
+                                .named_children(&mut cursor)
+                                .find(|child| child.kind() != "lifetime");
+                            found
+                        });
+                    match held {
+                        Some(held) => node = held,
+                        None => return Some(base_name),
+                    }
                 }
                 "scoped_type_identifier" => {
                     node = node.child_by_field_name("name")?;
@@ -7017,6 +7042,27 @@ mod rust_receiver_tests {
         assert_eq!(
             receiver_type_of(&sites, "write_str").as_deref(),
             Some("Formatter"),
+            "{sites:?}"
+        );
+    }
+
+    #[test]
+    fn a_smart_pointer_is_the_type_it_holds() {
+        let sites = sites_of("fn f(tagset: Arc<TagSet<T>>) { tagset.raw_tag_set(); }\n");
+        assert_eq!(
+            receiver_type_of(&sites, "raw_tag_set").as_deref(),
+            Some("TagSet"),
+            "{sites:?}"
+        );
+    }
+
+    #[test]
+    fn a_container_is_not_the_type_it_holds() {
+        // Vec has methods of its own; `.len()` is one of them.
+        let sites = sites_of("fn f(items: Vec<Request>) { items.len(); }\n");
+        assert_eq!(
+            receiver_type_of(&sites, "len").as_deref(),
+            Some("Vec"),
             "{sites:?}"
         );
     }

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -3352,7 +3352,7 @@ impl TreeSitterAnalyzer {
                         line_start = node.start_position().row as u32 + 1;
                     }
                     "body" => {
-                        members = self.parse_struct_members_from_node(node, source);
+                        members = self.parse_struct_members_from_node(node, source, language);
                     }
                     "struct" => {
                         kind = "struct".to_string();
@@ -4042,6 +4042,35 @@ impl TreeSitterAnalyzer {
         members
     }
 
+    /// Fields of a Rust struct.
+    ///
+    /// The type is reduced to the aggregate it names, so that a chain like
+    /// `self.inner.write()` can be walked: what a member is declared as has
+    /// to match what a receiver is typed as, and receivers are recorded
+    /// without their references or generic arguments.
+    fn parse_rust_container_fields(body_node: tree_sitter::Node, source: &str) -> Vec<FieldInfo> {
+        let mut members = Vec::new();
+        let mut cursor = body_node.walk();
+        for child in body_node.children(&mut cursor) {
+            if child.kind() != "field_declaration" {
+                continue;
+            }
+            let (Some(name), Some(type_node)) = (
+                child.child_by_field_name("name"),
+                child.child_by_field_name("type"),
+            ) else {
+                continue;
+            };
+            members.push(FieldInfo {
+                name: source[name.byte_range()].to_string(),
+                type_name: Self::rust_type_name(type_node, source)
+                    .unwrap_or_else(|| collapse_whitespace(&source[type_node.byte_range()])),
+                offset: None,
+            });
+        }
+        members
+    }
+
     fn parse_zig_error_members(body_node: tree_sitter::Node, source: &str) -> Vec<FieldInfo> {
         let mut members = Vec::new();
         let mut cursor = body_node.walk();
@@ -4066,12 +4095,18 @@ impl TreeSitterAnalyzer {
         &self,
         body_node: tree_sitter::Node,
         source: &str,
+        language: Language,
     ) -> Vec<FieldInfo> {
         match body_node.kind() {
             "error_set_declaration" => return Self::parse_zig_error_members(body_node, source),
             "struct_declaration" | "enum_declaration" | "union_declaration"
             | "opaque_declaration" => {
                 return Self::parse_zig_container_fields(body_node, source);
+            }
+            // C names its struct body the same thing, and its fields carry a
+            // declarator rather than a name.
+            "field_declaration_list" if matches!(language, Language::Rust) => {
+                return Self::parse_rust_container_fields(body_node, source);
             }
             _ => {}
         }
@@ -7108,6 +7143,35 @@ mod rust_receiver_tests {
             .iter()
             .find(|site| site.member == member)
             .and_then(|site| site.receiver_type.clone())
+    }
+
+    #[test]
+    fn a_rust_struct_records_its_fields() {
+        let mut analyzer = TreeSitterAnalyzer::new().unwrap();
+        let analysis = analyzer
+            .analyze_source_with_metadata(
+                "struct GenDisk {\n\
+                 \ttagset: Arc<TagSet>,\n\
+                 \tcount: u32,\n\
+                 }\n",
+                std::path::Path::new("x.rs"),
+                "hash",
+                None,
+            )
+            .unwrap();
+        let disk = analysis
+            .types
+            .iter()
+            .find(|t| t.name == "GenDisk")
+            .unwrap_or_else(|| panic!("{:?}", analysis.types));
+        let members: Vec<(&str, &str)> = disk
+            .members
+            .iter()
+            .map(|m| (m.name.as_str(), m.type_name.as_str()))
+            .collect();
+        // The member's type is reduced the same way a receiver's is, so the
+        // two can be compared when walking a chain.
+        assert_eq!(members, vec![("tagset", "TagSet"), ("count", "u32")]);
     }
 
     #[test]

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -1455,17 +1455,29 @@ impl TreeSitterAnalyzer {
             let Some(receiver) = site.receiver_expr.as_deref() else {
                 continue;
             };
-            if !is_plain_name(receiver) {
-                continue;
-            }
             let Some((_, _, declared)) = scopes
                 .iter()
                 .find(|(start, end, _)| site.byte_start >= *start && site.byte_start < *end)
             else {
                 continue;
             };
-            if let Some(type_name) = declared.get(receiver) {
-                site.receiver_type = Some(type_name.clone());
+
+            if is_plain_name(receiver) {
+                if let Some(type_name) = declared.get(receiver) {
+                    site.receiver_type = Some(type_name.clone());
+                }
+                continue;
+            }
+
+            // `self.inner.write()`: this file states what `self` is, and the
+            // fields say what is read from it. What `inner` is declared as
+            // belongs to whichever file defines that struct, so the path is
+            // recorded and resolution walks it against the types table.
+            if let Some((base, fields)) = field_path(receiver) {
+                if let Some(base_type) = declared.get(base) {
+                    site.receiver_base_type = Some(base_type.clone());
+                    site.receiver_field = Some(fields);
+                }
             }
         }
     }
@@ -7197,6 +7209,22 @@ mod rust_receiver_tests {
             Some("Formatter"),
             "{sites:?}"
         );
+    }
+
+    #[test]
+    fn a_field_chain_records_the_base_and_the_path() {
+        let sites = sites_of(
+            "impl GenDisk {\n\
+             \tfn go(&self) { self.inner.write(); }\n\
+             }\n",
+        );
+        let site = sites.iter().find(|s| s.member == "write").unwrap();
+        assert_eq!(
+            site.receiver_base_type.as_deref(),
+            Some("GenDisk"),
+            "{site:?}"
+        );
+        assert_eq!(site.receiver_field.as_deref(), Some("inner"), "{site:?}");
     }
 
     #[test]

--- a/src/treesitter_analyzer.rs
+++ b/src/treesitter_analyzer.rs
@@ -8,8 +8,8 @@ use tree_sitter::{Parser, Query, QueryCursor, Tree};
 
 use crate::types::{
     ArgumentFunction, DispatchKind, DispatchSite, FieldInfo, FunctionInfo, GlobalTypeRegistry,
-    MacroParams, ParameterInfo, Registration, RegistrationKind, TypeInfo, ARRAY_ELEMENT_MEMBER,
-    STATIC_CALL_MEMBER,
+    GlobalVariable, MacroParams, ParameterInfo, Registration, RegistrationKind, TypeInfo,
+    ARRAY_ELEMENT_MEMBER, STATIC_CALL_MEMBER,
 };
 // TemporaryCallRelationship import removed - call relationships are now embedded in function JSON columns
 use crate::hash::compute_file_hash;
@@ -70,6 +70,8 @@ pub struct FileAnalysis {
     pub registrations: Vec<Registration>,
     /// Functions named as call arguments: what a callee was handed.
     pub argument_functions: Vec<ArgumentFunction>,
+    /// File-scope variables of aggregate type.
+    pub globals: Vec<GlobalVariable>,
 }
 
 /// Calls found in one file: resolved edges, and dispatch sites whose targets
@@ -151,6 +153,14 @@ struct ExtractedFunctions {
     dispatch_sites: Vec<DispatchSite>,
     registrations: Vec<Registration>,
     argument_functions: Vec<ArgumentFunction>,
+}
+
+/// A file-scope variable, before its file is known.
+#[derive(Debug, Clone)]
+struct RawGlobal {
+    name: String,
+    type_name: String,
+    line: u32,
 }
 
 /// A call argument naming an identifier, before it is attributed to the
@@ -994,6 +1004,7 @@ impl TreeSitterAnalyzer {
             dispatch_sites,
             registrations,
             argument_functions,
+            globals,
         } = self.extract_all_with_embedded_data(
             &tree,
             source_code,
@@ -1028,6 +1039,7 @@ impl TreeSitterAnalyzer {
             dispatch_sites,
             registrations,
             argument_functions,
+            globals,
         })
     }
 
@@ -1090,6 +1102,23 @@ impl TreeSitterAnalyzer {
         dispatch_sites.extend(macro_sites);
         registrations.extend(macro_registrations);
 
+        // Only C states a variable's aggregate this way; other languages get
+        // their receivers typed by their own pass.
+        let globals = if matches!(language, Language::C) {
+            Self::collect_file_scope_globals(tree.root_node(), source_code)
+                .into_iter()
+                .map(|raw| GlobalVariable {
+                    name: raw.name,
+                    type_name: raw.type_name,
+                    file_path: self.make_relative_path(file_path, source_root),
+                    git_file_hash: git_hash.to_string(),
+                    line: raw.line,
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         Ok(FileAnalysis {
             functions,
             types,
@@ -1097,6 +1126,7 @@ impl TreeSitterAnalyzer {
             dispatch_sites,
             registrations,
             argument_functions,
+            globals,
         })
     }
 
@@ -1316,6 +1346,65 @@ impl TreeSitterAnalyzer {
             .retain(|registration| !Self::is_c_keyword(&registration.member));
 
         Ok(extraction)
+    }
+
+    /// File-scope variables of aggregate type, declaration or definition.
+    ///
+    /// `extern struct machdep_calls ppc_md;` is what lets a call written as
+    /// `ppc_md.memory_block_size()` be typed, in a file that includes the
+    /// header rather than containing it.
+    fn collect_file_scope_globals(root: tree_sitter::Node, source: &str) -> Vec<RawGlobal> {
+        let mut out = Vec::new();
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            // A declaration inside a function is a local, and locals are
+            // typed by the pass that can see the scope.
+            if node.kind() == "function_definition" {
+                continue;
+            }
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                stack.push(child);
+            }
+            if node.kind() != "declaration" {
+                continue;
+            }
+            let Some(type_node) = node.child_by_field_name("type") else {
+                continue;
+            };
+            let Some(type_name) = Self::aggregate_type_name(type_node, source) else {
+                continue;
+            };
+            let mut cursor = node.walk();
+            for declarator in node.children_by_field_name("declarator", &mut cursor) {
+                let mut current = declarator;
+                let mut is_function = false;
+                loop {
+                    if current.kind() == "function_declarator" {
+                        is_function = true;
+                    }
+                    if current.kind() == "identifier" {
+                        // A prototype names a function, not a variable.
+                        if !is_function {
+                            out.push(RawGlobal {
+                                name: source[current.byte_range()].to_string(),
+                                type_name: type_name.clone(),
+                                line: current.start_position().row as u32 + 1,
+                            });
+                        }
+                        break;
+                    }
+                    match current
+                        .child_by_field_name("declarator")
+                        .or_else(|| current.named_child(0))
+                    {
+                        Some(next) => current = next,
+                        None => break,
+                    }
+                }
+            }
+        }
+        out
     }
 
     /// Give each Rust dispatch site the type of its receiver.

--- a/src/types.rs
+++ b/src/types.rs
@@ -259,6 +259,21 @@ pub struct Registration {
     pub container_field: Option<String>,
 }
 
+/// A file-scope variable of aggregate type.
+///
+/// `extern struct machdep_calls ppc_md;` sits in a header, so a file calling
+/// `ppc_md.memory_block_size()` never declares it and cannot type the
+/// receiver. Recorded here, the type is available where the answer is given.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GlobalVariable {
+    pub name: String,
+    /// Aggregate the declaration names, without `struct` or qualifiers.
+    pub type_name: String,
+    pub file_path: String,
+    pub git_file_hash: String,
+    pub line: u32,
+}
+
 /// What the call a function was handed to does with it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Handover {

--- a/tests/indirect_calls.rs
+++ b/tests/indirect_calls.rs
@@ -215,6 +215,30 @@ fn write_argument_fixture(repo: &Path) {
          }\n",
     )
     .unwrap();
+    // An ops table declared in a header and dispatched from a file that
+    // includes it: the calling file cannot type the receiver.
+    std::fs::write(
+        repo.join("delay.h"),
+        "struct arm_delay_ops { void (*delay)(unsigned long); };\n\
+         extern struct arm_delay_ops arm_delay_ops;\n",
+    )
+    .unwrap();
+    std::fs::write(
+        repo.join("delay.c"),
+        "#include \"delay.h\"\n\
+         static void loop_delay(unsigned long n) { }\n\
+         struct arm_delay_ops arm_delay_ops = { .delay = loop_delay };\n",
+    )
+    .unwrap();
+    std::fs::write(
+        repo.join("use_delay.c"),
+        "#include \"delay.h\"\n\
+         void spin(unsigned long n)\n\
+         {\n\
+         \tarm_delay_ops.delay(n);\n\
+         }\n",
+    )
+    .unwrap();
     std::fs::write(
         repo.join("rcu.c"),
         "struct rcu_head { void (*func)(struct rcu_head *head); };\n\
@@ -275,26 +299,24 @@ async fn index_fixture(repo: &Path) -> (Arc<DatabaseManager>, String) {
     (db, git_sha)
 }
 
-#[tokio::test]
-async fn a_function_handed_to_a_call_is_recorded() {
-    let dir = tempfile::tempdir().unwrap();
-    git_run(dir.path(), &["init", "-q"]);
-    write_argument_fixture(dir.path());
-    git_run(dir.path(), &["add", "."]);
-    git_run(dir.path(), &["commit", "-q", "-m", "fixture"]);
+async fn index_argument_fixture(repo: &Path) -> (Arc<DatabaseManager>, String) {
+    git_run(repo, &["init", "-q"]);
+    write_argument_fixture(repo);
+    git_run(repo, &["add", "."]);
+    git_run(repo, &["commit", "-q", "-m", "fixture"]);
 
-    let git_sha = git::get_git_sha(dir.path()).unwrap().unwrap();
+    let git_sha = git::get_git_sha(repo).unwrap().unwrap();
     let db = Arc::new(
         DatabaseManager::new(
-            dir.path().join(".semcode.db").to_str().unwrap(),
-            dir.path().to_string_lossy().into_owned(),
+            repo.join(".semcode.db").to_str().unwrap(),
+            repo.to_string_lossy().into_owned(),
         )
         .await
         .unwrap(),
     );
     db.create_tables().await.unwrap();
     semcode::git_range::process_git_tree(
-        dir.path(),
+        repo,
         &git_sha,
         &["c".to_string(), "h".to_string()],
         db.clone(),
@@ -303,6 +325,13 @@ async fn a_function_handed_to_a_call_is_recorded() {
     )
     .await
     .unwrap();
+    (db, git_sha)
+}
+
+#[tokio::test]
+async fn a_function_handed_to_a_call_is_recorded() {
+    let dir = tempfile::tempdir().unwrap();
+    let (db, git_sha) = index_argument_fixture(dir.path()).await;
 
     let handed = db.find_argument_functions_of("nic_intr").await.unwrap();
     assert_eq!(
@@ -391,6 +420,28 @@ async fn a_function_handed_to_a_call_is_recorded() {
     assert!(
         output.contains("attached to inode::i_rcu"),
         "the rcu_head's owner was not reported:\n{output}"
+    );
+}
+
+#[tokio::test]
+async fn a_receiver_declared_in_a_header_is_typed() {
+    let dir = tempfile::tempdir().unwrap();
+    let (db, git_sha) = index_argument_fixture(dir.path()).await;
+
+    // `arm_delay_ops.delay(n)` is written where only the header declares the
+    // variable, so the type comes from the index rather than the file.
+    let callers = db
+        .find_indirect_callers("loop_delay", &git_sha)
+        .await
+        .unwrap();
+    let matched: Vec<_> = callers
+        .iter()
+        .filter(|c| c.evidence.is_type_matched())
+        .collect();
+    assert_eq!(
+        matched.len(),
+        1,
+        "expected the header-declared receiver to match: {callers:?}"
     );
 }
 


### PR DESCRIPTION
Resolve 21,881 Rust callsites in the Linux kernel.

f851438 record the base and the field path of a Rust receiver
ba5a825 index the fields of a Rust struct
7a6a829 type a receiver that names a variable declared elsewhere
7998c56 see through a smart pointer to the type it holds
ac3b79e type a Rust dispatch receiver from its declaration